### PR TITLE
fix: Fix invalid JSON syntax in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "-y",
         "mcp-remote",
-        "https://mcp.scrapingbee.com/mcp?api_key=TM5B2FK5G0BNFS2IL2T1OUGYJR7KP49UEYZ33KUUYWJ3NZC8ZJG6BMAXI83IQRD3017UTTNX5JISNDMW
+        "https://mcp.scrapingbee.com/mcp?api_key=TM5B2FK5G0BNFS2IL2T1OUGYJR7KP49UEYZ33KUUYWJ3NZC8ZJG6BMAXI83IQRD3017UTTNX5JISNDMW"
       ]
     }
   }


### PR DESCRIPTION
Add missing closing quote after the ScrapingBee API URL.