### PR TITLE
fix: Update .mcp.json to use HTTP format for web app compatibility

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,12 +1,8 @@
 {
   "mcpServers": {
     "scrapingbee": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://mcp.scrapingbee.com/mcp?api_key=TM5B2FK5G0BNFS2IL2T1OUGYJR7KP49UEYZ33KUUYWJ3NZC8ZJG6BMAXI83IQRD3017UTTNX5JISNDMW"
-      ]
+      "type": "http",
+      "url": "https://mcp.scrapingbee.com/mcp?api_key=TM5B2FK5G0BNFS2IL2T1OUGYJR7KP49UEYZ33KUUYWJ3NZC8ZJG6BMAXI83IQRD3017UTTNX5JISNDMW"
     }
   }
 }


### PR DESCRIPTION
Changed ScrapingBee MCP configuration from command-based (npx) to HTTP format to enable usage in Claude Code web app. The command format only works in CLI, while HTTP format works in both CLI and web environments.

https://claude.ai/code/session_017rYj9GodHvQaz8SzgF3LyN