### PR TITLE
fix: Change image aspect ratio handling from fit=fill to fit=pad

### DIFF
--- a/data/shows.json
+++ b/data/shows.json
@@ -17,9 +17,9 @@
       "runtime": "2h 15m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/6Vhi7cGlV0eeFcNx117lg6/858d499c9d6369b2c277d1a40f7989b1/251222_2S_TodayTix_1440x580_RG2.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/6Vhi7cGlV0eeFcNx117lg6/858d499c9d6369b2c277d1a40f7989b1/251222_2S_TodayTix_1440x580_RG2.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/6Vhi7cGlV0eeFcNx117lg6/858d499c9d6369b2c277d1a40f7989b1/251222_2S_TodayTix_1440x580_RG2.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/6Vhi7cGlV0eeFcNx117lg6/858d499c9d6369b2c277d1a40f7989b1/251222_2S_TodayTix_1440x580_RG2.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/6Vhi7cGlV0eeFcNx117lg6/858d499c9d6369b2c277d1a40f7989b1/251222_2S_TodayTix_1440x580_RG2.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/6Vhi7cGlV0eeFcNx117lg6/858d499c9d6369b2c277d1a40f7989b1/251222_2S_TodayTix_1440x580_RG2.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "A new musical comedy about two strangers who meet on the streets of New York City when Robin agrees to help Dougal carry a cake across town. As they navigate the city together, unexpected connection and romance bloom in this charming, laugh-filled love story celebrating chance encounters and the magic of New York.",
       "ageRecommendation": "Ages 12+",
@@ -81,9 +81,9 @@
       "runtime": "2h 15m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/2RTBxHCd5kl0TNJpYYHdCq/6686e0f26d3b819c5b4b10ec9bab40ea/MHE-2025Q1-TodayTix-1440x580.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/2RTBxHCd5kl0TNJpYYHdCq/6686e0f26d3b819c5b4b10ec9bab40ea/MHE-2025Q1-TodayTix-1440x580.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/2RTBxHCd5kl0TNJpYYHdCq/6686e0f26d3b819c5b4b10ec9bab40ea/MHE-2025Q1-TodayTix-1440x580.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/2RTBxHCd5kl0TNJpYYHdCq/6686e0f26d3b819c5b4b10ec9bab40ea/MHE-2025Q1-TodayTix-1440x580.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/2RTBxHCd5kl0TNJpYYHdCq/6686e0f26d3b819c5b4b10ec9bab40ea/MHE-2025Q1-TodayTix-1440x580.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/2RTBxHCd5kl0TNJpYYHdCq/6686e0f26d3b819c5b4b10ec9bab40ea/MHE-2025Q1-TodayTix-1440x580.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "In a future where robots have become obsolete, two helper-bots discover what it means to be human through an unexpected connection. Winner of six 2025 Tony Awards including Best Musical.",
       "ageRecommendation": "Ages 10+",
@@ -132,9 +132,9 @@
       "runtime": "2h 25m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/4k2gPWw9iR99KSUoR312Mv/88d8e5c3db7c731eb17231579412d2ec/1440x580_Hero_Key_Art_1__1_.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/4k2gPWw9iR99KSUoR312Mv/88d8e5c3db7c731eb17231579412d2ec/1440x580_Hero_Key_Art_1__1_.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/4k2gPWw9iR99KSUoR312Mv/88d8e5c3db7c731eb17231579412d2ec/1440x580_Hero_Key_Art_1__1_.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/4k2gPWw9iR99KSUoR312Mv/88d8e5c3db7c731eb17231579412d2ec/1440x580_Hero_Key_Art_1__1_.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/4k2gPWw9iR99KSUoR312Mv/88d8e5c3db7c731eb17231579412d2ec/1440x580_Hero_Key_Art_1__1_.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/4k2gPWw9iR99KSUoR312Mv/88d8e5c3db7c731eb17231579412d2ec/1440x580_Hero_Key_Art_1__1_.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "Based on S.E. Hinton's classic novel, this electrifying new musical follows the Greasers and Socs in 1967 Tulsa as they navigate loyalty, love, and the struggle to belong. Winner of the 2024 Tony Award for Best Musical.",
       "ageRecommendation": "Ages 12+",
@@ -172,9 +172,9 @@
       "runtime": "2h 30m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/2tnPnN9n2rh9DS8Z49FMah/bf346a6ea998e2cf0e35d0438c239128/HK-112133-022895-2025Update-TodayTix-1440x580.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/2tnPnN9n2rh9DS8Z49FMah/bf346a6ea998e2cf0e35d0438c239128/HK-112133-022895-2025Update-TodayTix-1440x580.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/2tnPnN9n2rh9DS8Z49FMah/bf346a6ea998e2cf0e35d0438c239128/HK-112133-022895-2025Update-TodayTix-1440x580.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/2tnPnN9n2rh9DS8Z49FMah/bf346a6ea998e2cf0e35d0438c239128/HK-112133-022895-2025Update-TodayTix-1440x580.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/2tnPnN9n2rh9DS8Z49FMah/bf346a6ea998e2cf0e35d0438c239128/HK-112133-022895-2025Update-TodayTix-1440x580.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/2tnPnN9n2rh9DS8Z49FMah/bf346a6ea998e2cf0e35d0438c239128/HK-112133-022895-2025Update-TodayTix-1440x580.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "A new musical featuring the songs of 16-time Grammy Award winner Alicia Keys. Set in 1990s New York, a 17-year-old girl dreams of a life beyond her Hell's Kitchen block.",
       "ageRecommendation": "Ages 12+",
@@ -212,9 +212,9 @@
       "runtime": "2h 40m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/6p6TvEYSo15T9KAMmG7AX8/190ccc2f991bc7c260caf99d2428de1f/OMM_BWAY_TodayTix_Tony_Win_1440x580.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/6p6TvEYSo15T9KAMmG7AX8/190ccc2f991bc7c260caf99d2428de1f/OMM_BWAY_TodayTix_Tony_Win_1440x580.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/6p6TvEYSo15T9KAMmG7AX8/190ccc2f991bc7c260caf99d2428de1f/OMM_BWAY_TodayTix_Tony_Win_1440x580.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/6p6TvEYSo15T9KAMmG7AX8/190ccc2f991bc7c260caf99d2428de1f/OMM_BWAY_TodayTix_Tony_Win_1440x580.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/6p6TvEYSo15T9KAMmG7AX8/190ccc2f991bc7c260caf99d2428de1f/OMM_BWAY_TodayTix_Tony_Win_1440x580.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/6p6TvEYSo15T9KAMmG7AX8/190ccc2f991bc7c260caf99d2428de1f/OMM_BWAY_TodayTix_Tony_Win_1440x580.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "The Olivier Award-winning Best New Musical tells the outrageous true story of the WWII plot to fool Hitler with a corpse, fake documents, and an idealistic intelligence team.",
       "ageRecommendation": "Ages 10+",
@@ -249,9 +249,9 @@
       "runtime": "1h 20m",
       "intermissions": 0,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/4zbcjgKVEjMqH95SVSrin5/fac3fa834c775239bff394554bba6a6a/OM_009_B_BANNER_RESIZING_2026_TodayTix_VariousSizes_JinkxKeyArt_v01_1440x580.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/4zbcjgKVEjMqH95SVSrin5/fac3fa834c775239bff394554bba6a6a/OM_009_B_BANNER_RESIZING_2026_TodayTix_VariousSizes_JinkxKeyArt_v01_1440x580.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/4zbcjgKVEjMqH95SVSrin5/fac3fa834c775239bff394554bba6a6a/OM_009_B_BANNER_RESIZING_2026_TodayTix_VariousSizes_JinkxKeyArt_v01_1440x580.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/4zbcjgKVEjMqH95SVSrin5/fac3fa834c775239bff394554bba6a6a/OM_009_B_BANNER_RESIZING_2026_TodayTix_VariousSizes_JinkxKeyArt_v01_1440x580.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/4zbcjgKVEjMqH95SVSrin5/fac3fa834c775239bff394554bba6a6a/OM_009_B_BANNER_RESIZING_2026_TodayTix_VariousSizes_JinkxKeyArt_v01_1440x580.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/4zbcjgKVEjMqH95SVSrin5/fac3fa834c775239bff394554bba6a6a/OM_009_B_BANNER_RESIZING_2026_TodayTix_VariousSizes_JinkxKeyArt_v01_1440x580.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "Cole Escola's uproarious comedy imagines Mary Todd Lincoln as a miserable, hard-drinking woman who dreams of becoming a cabaret star while her husband prepares for that fateful night at Ford's Theatre.",
       "ageRecommendation": "Ages 16+",
@@ -291,9 +291,9 @@
       "runtime": "2h 30m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/CC1GEZL2J69RvNjOiaO8f/a2e9bc8f475c1073839a0dfd67b6cd29/TodayTix_-_1440_x_580.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/CC1GEZL2J69RvNjOiaO8f/a2e9bc8f475c1073839a0dfd67b6cd29/TodayTix_-_1440_x_580.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/CC1GEZL2J69RvNjOiaO8f/a2e9bc8f475c1073839a0dfd67b6cd29/TodayTix_-_1440_x_580.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/CC1GEZL2J69RvNjOiaO8f/a2e9bc8f475c1073839a0dfd67b6cd29/TodayTix_-_1440_x_580.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/CC1GEZL2J69RvNjOiaO8f/a2e9bc8f475c1073839a0dfd67b6cd29/TodayTix_-_1440_x_580.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/CC1GEZL2J69RvNjOiaO8f/a2e9bc8f475c1073839a0dfd67b6cd29/TodayTix_-_1440_x_580.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "F. Scott Fitzgerald's iconic novel roars to life in this dazzling new musical. Jay Gatsby throws lavish parties in pursuit of his lost love, Daisy Buchanan, in the glittering Jazz Age.",
       "ageRecommendation": "Ages 12+",
@@ -378,9 +378,9 @@
         }
       ],
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/5gW3ZYxAvxe77MsU6JuLmJ/dade888017a9a9d15791184d381255bc/P00130120_BUG_TodayTixAssets_KeyArt_1440x580_11.14.25_FINAL.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5gW3ZYxAvxe77MsU6JuLmJ/dade888017a9a9d15791184d381255bc/P00130120_BUG_TodayTixAssets_KeyArt_1440x580_11.14.25_FINAL.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/5gW3ZYxAvxe77MsU6JuLmJ/dade888017a9a9d15791184d381255bc/P00130120_BUG_TodayTixAssets_KeyArt_1440x580_11.14.25_FINAL.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/5gW3ZYxAvxe77MsU6JuLmJ/dade888017a9a9d15791184d381255bc/P00130120_BUG_TodayTixAssets_KeyArt_1440x580_11.14.25_FINAL.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5gW3ZYxAvxe77MsU6JuLmJ/dade888017a9a9d15791184d381255bc/P00130120_BUG_TodayTixAssets_KeyArt_1440x580_11.14.25_FINAL.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/5gW3ZYxAvxe77MsU6JuLmJ/dade888017a9a9d15791184d381255bc/P00130120_BUG_TodayTixAssets_KeyArt_1440x580_11.14.25_FINAL.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       }
     },
     {
@@ -395,9 +395,9 @@
       "runtime": "2h 45m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/1lcQYDVMkTKsxKaQTtV0iO/271137f40545d3b4a8d04b6019664241/1440x580_Hero_Key_Art.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1lcQYDVMkTKsxKaQTtV0iO/271137f40545d3b4a8d04b6019664241/1440x580_Hero_Key_Art.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/1lcQYDVMkTKsxKaQTtV0iO/271137f40545d3b4a8d04b6019664241/1440x580_Hero_Key_Art.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/1lcQYDVMkTKsxKaQTtV0iO/271137f40545d3b4a8d04b6019664241/1440x580_Hero_Key_Art.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1lcQYDVMkTKsxKaQTtV0iO/271137f40545d3b4a8d04b6019664241/1440x580_Hero_Key_Art.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/1lcQYDVMkTKsxKaQTtV0iO/271137f40545d3b4a8d04b6019664241/1440x580_Hero_Key_Art.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "The untold story of the Witches of Oz. Long before Dorothy arrives, Elphaba and Glinda meet as sorcery students and form an unlikely friendship that will change the land of Oz forever.",
       "ageRecommendation": "Ages 8+",
@@ -435,9 +435,9 @@
       "runtime": "2h 55m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/1pYzhGpYcpbasqXvOf3YBq/5ac1b9604f509fa4acf54f3ea38e35fd/HAM_020_PA_BRAND_REFRESH_TICKETING_ASSETS_TodayTix_HeroKeyArt_1440x580_v1.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1pYzhGpYcpbasqXvOf3YBq/5ac1b9604f509fa4acf54f3ea38e35fd/HAM_020_PA_BRAND_REFRESH_TICKETING_ASSETS_TodayTix_HeroKeyArt_1440x580_v1.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/1pYzhGpYcpbasqXvOf3YBq/5ac1b9604f509fa4acf54f3ea38e35fd/HAM_020_PA_BRAND_REFRESH_TICKETING_ASSETS_TodayTix_HeroKeyArt_1440x580_v1.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/1pYzhGpYcpbasqXvOf3YBq/5ac1b9604f509fa4acf54f3ea38e35fd/HAM_020_PA_BRAND_REFRESH_TICKETING_ASSETS_TodayTix_HeroKeyArt_1440x580_v1.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1pYzhGpYcpbasqXvOf3YBq/5ac1b9604f509fa4acf54f3ea38e35fd/HAM_020_PA_BRAND_REFRESH_TICKETING_ASSETS_TodayTix_HeroKeyArt_1440x580_v1.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/1pYzhGpYcpbasqXvOf3YBq/5ac1b9604f509fa4acf54f3ea38e35fd/HAM_020_PA_BRAND_REFRESH_TICKETING_ASSETS_TodayTix_HeroKeyArt_1440x580_v1.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "The story of America's Founding Father Alexander Hamilton, an immigrant from the West Indies who became George Washington's right-hand man and the nation's first Treasury Secretary.",
       "ageRecommendation": "Ages 10+",
@@ -476,9 +476,9 @@
       "runtime": "2h 30m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/20JbwcyfTKefeounu0bb7g/bb61c8a016dfae49f63172206b9fb4cc/TLK_TodayTix_1440x580__3_.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/20JbwcyfTKefeounu0bb7g/bb61c8a016dfae49f63172206b9fb4cc/TLK_TodayTix_1440x580__3_.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/20JbwcyfTKefeounu0bb7g/bb61c8a016dfae49f63172206b9fb4cc/TLK_TodayTix_1440x580__3_.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/20JbwcyfTKefeounu0bb7g/bb61c8a016dfae49f63172206b9fb4cc/TLK_TodayTix_1440x580__3_.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/20JbwcyfTKefeounu0bb7g/bb61c8a016dfae49f63172206b9fb4cc/TLK_TodayTix_1440x580__3_.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/20JbwcyfTKefeounu0bb7g/bb61c8a016dfae49f63172206b9fb4cc/TLK_TodayTix_1440x580__3_.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "Disney's award-winning musical brings the African savanna to Broadway with stunning puppetry and masks. Young Simba must embrace his destiny to become king after tragedy strikes the Pride Lands.",
       "ageRecommendation": "Ages 6+",
@@ -521,9 +521,9 @@
       "runtime": "2h 30m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/5tavViEkwtgCwYVOhRJVlB/661fe574f436bbd7af8d8d966d6924df/hero.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5tavViEkwtgCwYVOhRJVlB/661fe574f436bbd7af8d8d966d6924df/hero.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/5tavViEkwtgCwYVOhRJVlB/661fe574f436bbd7af8d8d966d6924df/hero.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/5tavViEkwtgCwYVOhRJVlB/661fe574f436bbd7af8d8d966d6924df/hero.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5tavViEkwtgCwYVOhRJVlB/661fe574f436bbd7af8d8d966d6924df/hero.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/5tavViEkwtgCwYVOhRJVlB/661fe574f436bbd7af8d8d966d6924df/hero.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "Set in the legendary city during the roaring twenties, Chicago tells the story of Roxie Hart, a housewife who murders her lover and convinces her husband to take the fall. The longest-running American musical in Broadway history.",
       "ageRecommendation": "Ages 13+",
@@ -566,9 +566,9 @@
       "runtime": "2h 35m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/5WOyzD6VmmtuvGFJoVg79d/e4ffa9fa40c01724450eb5f31b75c7be/MR_086_PA_LOGO_RESIZING_ASSETS_2025_1440x580_v01.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5WOyzD6VmmtuvGFJoVg79d/e4ffa9fa40c01724450eb5f31b75c7be/MR_086_PA_LOGO_RESIZING_ASSETS_2025_1440x580_v01.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/5WOyzD6VmmtuvGFJoVg79d/e4ffa9fa40c01724450eb5f31b75c7be/MR_086_PA_LOGO_RESIZING_ASSETS_2025_1440x580_v01.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/5WOyzD6VmmtuvGFJoVg79d/e4ffa9fa40c01724450eb5f31b75c7be/MR_086_PA_LOGO_RESIZING_ASSETS_2025_1440x580_v01.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5WOyzD6VmmtuvGFJoVg79d/e4ffa9fa40c01724450eb5f31b75c7be/MR_086_PA_LOGO_RESIZING_ASSETS_2025_1440x580_v01.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/5WOyzD6VmmtuvGFJoVg79d/e4ffa9fa40c01724450eb5f31b75c7be/MR_086_PA_LOGO_RESIZING_ASSETS_2025_1440x580_v01.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "Enter a world of splendor and romance, of eye-popping excess, of glitz, grandeur and glory! A world where Bohemians and aristocrats rub elbows and revel in electrifying enchantment.",
       "ageRecommendation": "Ages 12+",
@@ -607,9 +607,9 @@
       "runtime": "2h 30m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/1XmnTVfLKO0DYjasW0wYG0/1527ae1efb51cffaded96cd4b4c9baeb/ALD_TodayTix_Hero_1440x580.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1XmnTVfLKO0DYjasW0wYG0/1527ae1efb51cffaded96cd4b4c9baeb/ALD_TodayTix_Hero_1440x580.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/1XmnTVfLKO0DYjasW0wYG0/1527ae1efb51cffaded96cd4b4c9baeb/ALD_TodayTix_Hero_1440x580.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/1XmnTVfLKO0DYjasW0wYG0/1527ae1efb51cffaded96cd4b4c9baeb/ALD_TodayTix_Hero_1440x580.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1XmnTVfLKO0DYjasW0wYG0/1527ae1efb51cffaded96cd4b4c9baeb/ALD_TodayTix_Hero_1440x580.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/1XmnTVfLKO0DYjasW0wYG0/1527ae1efb51cffaded96cd4b4c9baeb/ALD_TodayTix_Hero_1440x580.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "Disney's thrilling adaptation of the animated classic. From the producer of The Lion King comes the story of a street-smart young man who discovers a magic lamp and genie.",
       "ageRecommendation": "Ages 6+",
@@ -651,9 +651,9 @@
       "runtime": "2h 30m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/t09ycMZvQ674f7dJ12lpu/1c74af76123f48799204fe96f76a7257/HTD-2174W-MiscDec-TodayTix-Updates-Hero-1440x580-v1.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/t09ycMZvQ674f7dJ12lpu/1c74af76123f48799204fe96f76a7257/HTD-2174W-MiscDec-TodayTix-Updates-Hero-1440x580-v1.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/t09ycMZvQ674f7dJ12lpu/1c74af76123f48799204fe96f76a7257/HTD-2174W-MiscDec-TodayTix-Updates-Hero-1440x580-v1.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/t09ycMZvQ674f7dJ12lpu/1c74af76123f48799204fe96f76a7257/HTD-2174W-MiscDec-TodayTix-Updates-Hero-1440x580-v1.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/t09ycMZvQ674f7dJ12lpu/1c74af76123f48799204fe96f76a7257/HTD-2174W-MiscDec-TodayTix-Updates-Hero-1440x580-v1.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/t09ycMZvQ674f7dJ12lpu/1c74af76123f48799204fe96f76a7257/HTD-2174W-MiscDec-TodayTix-Updates-Hero-1440x580-v1.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "Welcome to Hadestown, where a song can change your fate. This acclaimed new musical by Anaïs Mitchell intertwines two mythic tales — that of Orpheus and Eurydice, and King Hades and his wife Persephone.",
       "ageRecommendation": "Ages 10+",
@@ -691,9 +691,9 @@
       "runtime": "2h 30m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/m7Pq32ZM887jDNbPXwb2i/eb048aa40d3a46d288eb8963538419a9/TodayTix_Hero_1440x580_14601_MJ_Updated_Partner_assets_FR.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/m7Pq32ZM887jDNbPXwb2i/eb048aa40d3a46d288eb8963538419a9/TodayTix_Hero_1440x580_14601_MJ_Updated_Partner_assets_FR.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/m7Pq32ZM887jDNbPXwb2i/eb048aa40d3a46d288eb8963538419a9/TodayTix_Hero_1440x580_14601_MJ_Updated_Partner_assets_FR.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/m7Pq32ZM887jDNbPXwb2i/eb048aa40d3a46d288eb8963538419a9/TodayTix_Hero_1440x580_14601_MJ_Updated_Partner_assets_FR.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/m7Pq32ZM887jDNbPXwb2i/eb048aa40d3a46d288eb8963538419a9/TodayTix_Hero_1440x580_14601_MJ_Updated_Partner_assets_FR.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/m7Pq32ZM887jDNbPXwb2i/eb048aa40d3a46d288eb8963538419a9/TodayTix_Hero_1440x580_14601_MJ_Updated_Partner_assets_FR.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "The story of Michael Jackson, centering around the making of his 1992 Dangerous World Tour, revealing the creative mind and collaborative spirit that catapulted him into legendary status.",
       "ageRecommendation": "Ages 8+",
@@ -727,9 +727,9 @@
       "runtime": "1h 20m",
       "intermissions": 0,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/5GitG8n9EJB8EKEqU9B6Lq/263afbf4f3039bdfd38bd74def4ef6a5/250501_SIX_ConcertBanners_1440x580_RG.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5GitG8n9EJB8EKEqU9B6Lq/263afbf4f3039bdfd38bd74def4ef6a5/250501_SIX_ConcertBanners_1440x580_RG.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/5GitG8n9EJB8EKEqU9B6Lq/263afbf4f3039bdfd38bd74def4ef6a5/250501_SIX_ConcertBanners_1440x580_RG.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/5GitG8n9EJB8EKEqU9B6Lq/263afbf4f3039bdfd38bd74def4ef6a5/250501_SIX_ConcertBanners_1440x580_RG.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5GitG8n9EJB8EKEqU9B6Lq/263afbf4f3039bdfd38bd74def4ef6a5/250501_SIX_ConcertBanners_1440x580_RG.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/5GitG8n9EJB8EKEqU9B6Lq/263afbf4f3039bdfd38bd74def4ef6a5/250501_SIX_ConcertBanners_1440x580_RG.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "The six wives of Henry VIII take the mic to tell their own stories and reclaim their identities in this electrifying pop concert musical.",
       "ageRecommendation": "Ages 10+",
@@ -764,9 +764,9 @@
       "runtime": "2h 30m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/3dnKgNoU6R8vKgpXgyAoUo/f68ed6881da773baca3084c1ec22a8a0/BOM_2025_TTPA_15Ann_1440x580_1848_RGB-SLF.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/3dnKgNoU6R8vKgpXgyAoUo/f68ed6881da773baca3084c1ec22a8a0/BOM_2025_TTPA_15Ann_1440x580_1848_RGB-SLF.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/3dnKgNoU6R8vKgpXgyAoUo/f68ed6881da773baca3084c1ec22a8a0/BOM_2025_TTPA_15Ann_1440x580_1848_RGB-SLF.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/3dnKgNoU6R8vKgpXgyAoUo/f68ed6881da773baca3084c1ec22a8a0/BOM_2025_TTPA_15Ann_1440x580_1848_RGB-SLF.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/3dnKgNoU6R8vKgpXgyAoUo/f68ed6881da773baca3084c1ec22a8a0/BOM_2025_TTPA_15Ann_1440x580_1848_RGB-SLF.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/3dnKgNoU6R8vKgpXgyAoUo/f68ed6881da773baca3084c1ec22a8a0/BOM_2025_TTPA_15Ann_1440x580_1848_RGB-SLF.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "From the creators of South Park comes this hilarious musical about two mismatched Mormon missionaries sent to spread the word in a remote Ugandan village.",
       "ageRecommendation": "Ages 17+",
@@ -800,9 +800,9 @@
       "runtime": "2h 30m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/1pePhHDlaO3Ll7GWC0YkL1/80b1aac734fa1a7ca7c950883f84cc24/_J-Nov2025Update-TodayTix-1440x580-ALT.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1pePhHDlaO3Ll7GWC0YkL1/80b1aac734fa1a7ca7c950883f84cc24/_J-Nov2025Update-TodayTix-1440x580-ALT.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/1pePhHDlaO3Ll7GWC0YkL1/80b1aac734fa1a7ca7c950883f84cc24/_J-Nov2025Update-TodayTix-1440x580-ALT.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/1pePhHDlaO3Ll7GWC0YkL1/80b1aac734fa1a7ca7c950883f84cc24/_J-Nov2025Update-TodayTix-1440x580-ALT.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1pePhHDlaO3Ll7GWC0YkL1/80b1aac734fa1a7ca7c950883f84cc24/_J-Nov2025Update-TodayTix-1440x580-ALT.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/1pePhHDlaO3Ll7GWC0YkL1/80b1aac734fa1a7ca7c950883f84cc24/_J-Nov2025Update-TodayTix-1440x580-ALT.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "What if Juliet's story didn't end in tragedy? This joyful jukebox musical featuring Max Martin's iconic pop hits reimagines Shakespeare's heroine as she writes her own destiny.",
       "ageRecommendation": "Ages 10+",
@@ -852,9 +852,9 @@
       "runtime": "2h 50m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/4aMYNDxN6buTaCrcMKIvuN/6bdda041a5e5d9856105cb583334478b/TT-109547-017703-TodayTix-1440x580.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/4aMYNDxN6buTaCrcMKIvuN/6bdda041a5e5d9856105cb583334478b/TT-109547-017703-TodayTix-1440x580.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/4aMYNDxN6buTaCrcMKIvuN/6bdda041a5e5d9856105cb583334478b/TT-109547-017703-TodayTix-1440x580.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/4aMYNDxN6buTaCrcMKIvuN/6bdda041a5e5d9856105cb583334478b/TT-109547-017703-TodayTix-1440x580.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/4aMYNDxN6buTaCrcMKIvuN/6bdda041a5e5d9856105cb583334478b/TT-109547-017703-TodayTix-1440x580.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/4aMYNDxN6buTaCrcMKIvuN/6bdda041a5e5d9856105cb583334478b/TT-109547-017703-TodayTix-1440x580.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       },
       "synopsis": "Nineteen years after Harry's original adventure, he's now a Ministry of Magic employee while his son Albus struggles with the family legacy at Hogwarts.",
       "ageRecommendation": "Ages 10+",
@@ -911,9 +911,9 @@
         }
       ],
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/3vH6kVRmlcOnzVfYGFxOJb/6098bba8b5336ed355c5d6b9de90e420/Hero_1440x580.png?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/3vH6kVRmlcOnzVfYGFxOJb/6098bba8b5336ed355c5d6b9de90e420/Hero_1440x580.png?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/3vH6kVRmlcOnzVfYGFxOJb/6098bba8b5336ed355c5d6b9de90e420/Hero_1440x580.png?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/3vH6kVRmlcOnzVfYGFxOJb/6098bba8b5336ed355c5d6b9de90e420/Hero_1440x580.png?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/3vH6kVRmlcOnzVfYGFxOJb/6098bba8b5336ed355c5d6b9de90e420/Hero_1440x580.png?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/3vH6kVRmlcOnzVfYGFxOJb/6098bba8b5336ed355c5d6b9de90e420/Hero_1440x580.png?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       }
     },
     {
@@ -947,9 +947,9 @@
         }
       ],
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/79kOvZoGMIvolshDhfWms4/b4b3fa7cdd0728e35a9832da9e0a5ec2/STTFS-NewKeyArt-ThirdPartyAssets_TodayTix-1440x580.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/79kOvZoGMIvolshDhfWms4/b4b3fa7cdd0728e35a9832da9e0a5ec2/STTFS-NewKeyArt-ThirdPartyAssets_TodayTix-1440x580.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/79kOvZoGMIvolshDhfWms4/b4b3fa7cdd0728e35a9832da9e0a5ec2/STTFS-NewKeyArt-ThirdPartyAssets_TodayTix-1440x580.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/79kOvZoGMIvolshDhfWms4/b4b3fa7cdd0728e35a9832da9e0a5ec2/STTFS-NewKeyArt-ThirdPartyAssets_TodayTix-1440x580.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/79kOvZoGMIvolshDhfWms4/b4b3fa7cdd0728e35a9832da9e0a5ec2/STTFS-NewKeyArt-ThirdPartyAssets_TodayTix-1440x580.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/79kOvZoGMIvolshDhfWms4/b4b3fa7cdd0728e35a9832da9e0a5ec2/STTFS-NewKeyArt-ThirdPartyAssets_TodayTix-1440x580.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       }
     },
     {
@@ -964,9 +964,9 @@
       "runtime": "2h 30m",
       "intermissions": 0,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/5wlzdAiaIPpQufxOLrhUpy/2b7d391c1d9a997ac27d545195e66976/CAB-ThirdPartyAssets-Sept2025Update-TodayTix-480x720.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5wlzdAiaIPpQufxOLrhUpy/2b7d391c1d9a997ac27d545195e66976/CAB-ThirdPartyAssets-Sept2025Update-TodayTix-480x720.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/5wlzdAiaIPpQufxOLrhUpy/2b7d391c1d9a997ac27d545195e66976/CAB-ThirdPartyAssets-Sept2025Update-TodayTix-480x720.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/5wlzdAiaIPpQufxOLrhUpy/2b7d391c1d9a997ac27d545195e66976/CAB-ThirdPartyAssets-Sept2025Update-TodayTix-480x720.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5wlzdAiaIPpQufxOLrhUpy/2b7d391c1d9a997ac27d545195e66976/CAB-ThirdPartyAssets-Sept2025Update-TodayTix-480x720.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/5wlzdAiaIPpQufxOLrhUpy/2b7d391c1d9a997ac27d545195e66976/CAB-ThirdPartyAssets-Sept2025Update-TodayTix-480x720.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       }
     },
     {
@@ -981,9 +981,9 @@
       "runtime": "3h 10m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/3dGAJQDhSwUokR9btkZoHk/2838c7aa5629cb03f4288499e3d171c8/Poster.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/3dGAJQDhSwUokR9btkZoHk/2838c7aa5629cb03f4288499e3d171c8/Poster.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/3dGAJQDhSwUokR9btkZoHk/2838c7aa5629cb03f4288499e3d171c8/Poster.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/3dGAJQDhSwUokR9btkZoHk/2838c7aa5629cb03f4288499e3d171c8/Poster.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/3dGAJQDhSwUokR9btkZoHk/2838c7aa5629cb03f4288499e3d171c8/Poster.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/3dGAJQDhSwUokR9btkZoHk/2838c7aa5629cb03f4288499e3d171c8/Poster.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       }
     },
     {
@@ -998,9 +998,9 @@
       "runtime": "2h 30m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/vOabhFsW8llOXiXMB5EDb/25b285a06a7da5dced0b3c3dd149741a/WFE_today_tix_480x720__1_.png?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/vOabhFsW8llOXiXMB5EDb/25b285a06a7da5dced0b3c3dd149741a/WFE_today_tix_480x720__1_.png?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/vOabhFsW8llOXiXMB5EDb/25b285a06a7da5dced0b3c3dd149741a/WFE_today_tix_480x720__1_.png?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/vOabhFsW8llOXiXMB5EDb/25b285a06a7da5dced0b3c3dd149741a/WFE_today_tix_480x720__1_.png?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/vOabhFsW8llOXiXMB5EDb/25b285a06a7da5dced0b3c3dd149741a/WFE_today_tix_480x720__1_.png?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/vOabhFsW8llOXiXMB5EDb/25b285a06a7da5dced0b3c3dd149741a/WFE_today_tix_480x720__1_.png?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       }
     },
     {
@@ -1015,9 +1015,9 @@
       "runtime": "2h 45m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/7hlurmIvsEgajvThGordJO/1718c5445a06ecac8485f55eac9af2a8/Tonys_Original_Suffs_Show_Poster.jpeg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/7hlurmIvsEgajvThGordJO/1718c5445a06ecac8485f55eac9af2a8/Tonys_Original_Suffs_Show_Poster.jpeg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/7hlurmIvsEgajvThGordJO/1718c5445a06ecac8485f55eac9af2a8/Tonys_Original_Suffs_Show_Poster.jpeg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/7hlurmIvsEgajvThGordJO/1718c5445a06ecac8485f55eac9af2a8/Tonys_Original_Suffs_Show_Poster.jpeg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/7hlurmIvsEgajvThGordJO/1718c5445a06ecac8485f55eac9af2a8/Tonys_Original_Suffs_Show_Poster.jpeg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/7hlurmIvsEgajvThGordJO/1718c5445a06ecac8485f55eac9af2a8/Tonys_Original_Suffs_Show_Poster.jpeg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       }
     },
     {
@@ -1032,9 +1032,9 @@
       "runtime": "2h 20m",
       "intermissions": 1,
       "images": {
-        "hero": "https://images.ctfassets.net/6pezt69ih962/2sy9oNkIkLAN9mK1cVNuzc/5cf87da0d49971c55432d3279b327239/notebook_480x720_CLOSING.jpg?w=1920&h=1080&fit=fill&q=90",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/2sy9oNkIkLAN9mK1cVNuzc/5cf87da0d49971c55432d3279b327239/notebook_480x720_CLOSING.jpg?w=400&h=400&fit=fill&q=80",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/2sy9oNkIkLAN9mK1cVNuzc/5cf87da0d49971c55432d3279b327239/notebook_480x720_CLOSING.jpg?w=600&h=900&fit=fill&q=85"
+        "hero": "https://images.ctfassets.net/6pezt69ih962/2sy9oNkIkLAN9mK1cVNuzc/5cf87da0d49971c55432d3279b327239/notebook_480x720_CLOSING.jpg?w=1920&h=1080&fit=pad&bg=rgb:1a1a1a&q=90",
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/2sy9oNkIkLAN9mK1cVNuzc/5cf87da0d49971c55432d3279b327239/notebook_480x720_CLOSING.jpg?w=400&h=400&fit=pad&bg=rgb:1a1a1a&q=80",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/2sy9oNkIkLAN9mK1cVNuzc/5cf87da0d49971c55432d3279b327239/notebook_480x720_CLOSING.jpg?w=600&h=900&fit=pad&bg=rgb:1a1a1a&q=85"
       }
     }
   ]


### PR DESCRIPTION
Problem:
- All show images were landscape banners (1440x580) from TodayTix
- Using fit=fill to force into square (400x400) and portrait (600x900) caused heavy cropping
- Images were displaying with important content cut off

Changes:
1. Updated all 81 image URLs in shows.json to use fit=pad instead of fit=fill
   - Adds dark letterboxing (bg=rgb:1a1a1a) instead of cropping
   - Shows full image without cutting off content

2. Enhanced fetch-images.js script for future improvements:
   - Now fetches separate POSTER, HERO, and THUMBNAIL types from TodayTix API
   - formatImageUrls() updated to handle multiple image types
   - Uses fit=pad by default to prevent cropping
   - When run via GitHub Actions, will fetch proper square posters for better display

Next steps:
- Run fetch-images GitHub Action to fetch proper square poster images from TodayTix
- This will replace letterboxed images with native square posters

https://claude.ai/code/session_01TYrqrB4gG3Z9ajMwCxbKhF