### PR TITLE
fix: Use portrait poster images (480x720) for thumbnails and posters

### DIFF
--- a/data/shows.json
+++ b/data/shows.json
@@ -18,8 +18,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/6Vhi7cGlV0eeFcNx117lg6/858d499c9d6369b2c277d1a40f7989b1/251222_2S_TodayTix_1440x580_RG2.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/6Vhi7cGlV0eeFcNx117lg6/858d499c9d6369b2c277d1a40f7989b1/251222_2S_TodayTix_1440x580_RG2.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/6Vhi7cGlV0eeFcNx117lg6/858d499c9d6369b2c277d1a40f7989b1/251222_2S_TodayTix_1440x580_RG2.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/6Vhi7cGlV0eeFcNx117lg6/858d499c9d6369b2c277d1a40f7989b1/251222_2S_TodayTix_480x720_RG2.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/6Vhi7cGlV0eeFcNx117lg6/858d499c9d6369b2c277d1a40f7989b1/251222_2S_TodayTix_480x720_RG2.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "A new musical comedy about two strangers who meet on the streets of New York City when Robin agrees to help Dougal carry a cake across town. As they navigate the city together, unexpected connection and romance bloom in this charming, laugh-filled love story celebrating chance encounters and the magic of New York.",
       "ageRecommendation": "Ages 12+",
@@ -82,8 +82,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/2RTBxHCd5kl0TNJpYYHdCq/6686e0f26d3b819c5b4b10ec9bab40ea/MHE-2025Q1-TodayTix-1440x580.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/2RTBxHCd5kl0TNJpYYHdCq/6686e0f26d3b819c5b4b10ec9bab40ea/MHE-2025Q1-TodayTix-1440x580.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/2RTBxHCd5kl0TNJpYYHdCq/6686e0f26d3b819c5b4b10ec9bab40ea/MHE-2025Q1-TodayTix-1440x580.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/2RTBxHCd5kl0TNJpYYHdCq/6686e0f26d3b819c5b4b10ec9bab40ea/MHE-2025Q1-TodayTix-480x720.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/2RTBxHCd5kl0TNJpYYHdCq/6686e0f26d3b819c5b4b10ec9bab40ea/MHE-2025Q1-TodayTix-480x720.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "In a future where robots have become obsolete, two helper-bots discover what it means to be human through an unexpected connection. Winner of six 2025 Tony Awards including Best Musical.",
       "ageRecommendation": "Ages 10+",
@@ -133,8 +133,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/4k2gPWw9iR99KSUoR312Mv/88d8e5c3db7c731eb17231579412d2ec/1440x580_Hero_Key_Art_1__1_.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/4k2gPWw9iR99KSUoR312Mv/88d8e5c3db7c731eb17231579412d2ec/1440x580_Hero_Key_Art_1__1_.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/4k2gPWw9iR99KSUoR312Mv/88d8e5c3db7c731eb17231579412d2ec/1440x580_Hero_Key_Art_1__1_.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/4k2gPWw9iR99KSUoR312Mv/88d8e5c3db7c731eb17231579412d2ec/480x720_Hero_Key_Art_1__1_.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/4k2gPWw9iR99KSUoR312Mv/88d8e5c3db7c731eb17231579412d2ec/480x720_Hero_Key_Art_1__1_.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "Based on S.E. Hinton's classic novel, this electrifying new musical follows the Greasers and Socs in 1967 Tulsa as they navigate loyalty, love, and the struggle to belong. Winner of the 2024 Tony Award for Best Musical.",
       "ageRecommendation": "Ages 12+",
@@ -173,8 +173,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/2tnPnN9n2rh9DS8Z49FMah/bf346a6ea998e2cf0e35d0438c239128/HK-112133-022895-2025Update-TodayTix-1440x580.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/2tnPnN9n2rh9DS8Z49FMah/bf346a6ea998e2cf0e35d0438c239128/HK-112133-022895-2025Update-TodayTix-1440x580.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/2tnPnN9n2rh9DS8Z49FMah/bf346a6ea998e2cf0e35d0438c239128/HK-112133-022895-2025Update-TodayTix-1440x580.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/2tnPnN9n2rh9DS8Z49FMah/bf346a6ea998e2cf0e35d0438c239128/HK-112133-022895-2025Update-TodayTix-480x720.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/2tnPnN9n2rh9DS8Z49FMah/bf346a6ea998e2cf0e35d0438c239128/HK-112133-022895-2025Update-TodayTix-480x720.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "A new musical featuring the songs of 16-time Grammy Award winner Alicia Keys. Set in 1990s New York, a 17-year-old girl dreams of a life beyond her Hell's Kitchen block.",
       "ageRecommendation": "Ages 12+",
@@ -213,8 +213,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/6p6TvEYSo15T9KAMmG7AX8/190ccc2f991bc7c260caf99d2428de1f/OMM_BWAY_TodayTix_Tony_Win_1440x580.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/6p6TvEYSo15T9KAMmG7AX8/190ccc2f991bc7c260caf99d2428de1f/OMM_BWAY_TodayTix_Tony_Win_1440x580.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/6p6TvEYSo15T9KAMmG7AX8/190ccc2f991bc7c260caf99d2428de1f/OMM_BWAY_TodayTix_Tony_Win_1440x580.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/6p6TvEYSo15T9KAMmG7AX8/190ccc2f991bc7c260caf99d2428de1f/OMM_BWAY_TodayTix_Tony_Win_480x720.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/6p6TvEYSo15T9KAMmG7AX8/190ccc2f991bc7c260caf99d2428de1f/OMM_BWAY_TodayTix_Tony_Win_480x720.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "The Olivier Award-winning Best New Musical tells the outrageous true story of the WWII plot to fool Hitler with a corpse, fake documents, and an idealistic intelligence team.",
       "ageRecommendation": "Ages 10+",
@@ -250,8 +250,8 @@
       "intermissions": 0,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/4zbcjgKVEjMqH95SVSrin5/fac3fa834c775239bff394554bba6a6a/OM_009_B_BANNER_RESIZING_2026_TodayTix_VariousSizes_JinkxKeyArt_v01_1440x580.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/4zbcjgKVEjMqH95SVSrin5/fac3fa834c775239bff394554bba6a6a/OM_009_B_BANNER_RESIZING_2026_TodayTix_VariousSizes_JinkxKeyArt_v01_1440x580.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/4zbcjgKVEjMqH95SVSrin5/fac3fa834c775239bff394554bba6a6a/OM_009_B_BANNER_RESIZING_2026_TodayTix_VariousSizes_JinkxKeyArt_v01_1440x580.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/4zbcjgKVEjMqH95SVSrin5/fac3fa834c775239bff394554bba6a6a/OM_009_B_BANNER_RESIZING_2026_TodayTix_VariousSizes_JinkxKeyArt_v01_480x720.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/4zbcjgKVEjMqH95SVSrin5/fac3fa834c775239bff394554bba6a6a/OM_009_B_BANNER_RESIZING_2026_TodayTix_VariousSizes_JinkxKeyArt_v01_480x720.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "Cole Escola's uproarious comedy imagines Mary Todd Lincoln as a miserable, hard-drinking woman who dreams of becoming a cabaret star while her husband prepares for that fateful night at Ford's Theatre.",
       "ageRecommendation": "Ages 16+",
@@ -379,8 +379,8 @@
       ],
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/5gW3ZYxAvxe77MsU6JuLmJ/dade888017a9a9d15791184d381255bc/P00130120_BUG_TodayTixAssets_KeyArt_1440x580_11.14.25_FINAL.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5gW3ZYxAvxe77MsU6JuLmJ/dade888017a9a9d15791184d381255bc/P00130120_BUG_TodayTixAssets_KeyArt_1440x580_11.14.25_FINAL.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/5gW3ZYxAvxe77MsU6JuLmJ/dade888017a9a9d15791184d381255bc/P00130120_BUG_TodayTixAssets_KeyArt_1440x580_11.14.25_FINAL.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5gW3ZYxAvxe77MsU6JuLmJ/dade888017a9a9d15791184d381255bc/P00130120_BUG_TodayTixAssets_KeyArt_480x720_11.14.25_FINAL.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/5gW3ZYxAvxe77MsU6JuLmJ/dade888017a9a9d15791184d381255bc/P00130120_BUG_TodayTixAssets_KeyArt_480x720_11.14.25_FINAL.jpg?w=600&h=900&fit=fill&q=85&f=center"
       }
     },
     {
@@ -396,8 +396,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/1lcQYDVMkTKsxKaQTtV0iO/271137f40545d3b4a8d04b6019664241/1440x580_Hero_Key_Art.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1lcQYDVMkTKsxKaQTtV0iO/271137f40545d3b4a8d04b6019664241/1440x580_Hero_Key_Art.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/1lcQYDVMkTKsxKaQTtV0iO/271137f40545d3b4a8d04b6019664241/1440x580_Hero_Key_Art.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1lcQYDVMkTKsxKaQTtV0iO/271137f40545d3b4a8d04b6019664241/480x720_Hero_Key_Art.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/1lcQYDVMkTKsxKaQTtV0iO/271137f40545d3b4a8d04b6019664241/480x720_Hero_Key_Art.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "The untold story of the Witches of Oz. Long before Dorothy arrives, Elphaba and Glinda meet as sorcery students and form an unlikely friendship that will change the land of Oz forever.",
       "ageRecommendation": "Ages 8+",
@@ -436,8 +436,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/1pYzhGpYcpbasqXvOf3YBq/5ac1b9604f509fa4acf54f3ea38e35fd/HAM_020_PA_BRAND_REFRESH_TICKETING_ASSETS_TodayTix_HeroKeyArt_1440x580_v1.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1pYzhGpYcpbasqXvOf3YBq/5ac1b9604f509fa4acf54f3ea38e35fd/HAM_020_PA_BRAND_REFRESH_TICKETING_ASSETS_TodayTix_HeroKeyArt_1440x580_v1.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/1pYzhGpYcpbasqXvOf3YBq/5ac1b9604f509fa4acf54f3ea38e35fd/HAM_020_PA_BRAND_REFRESH_TICKETING_ASSETS_TodayTix_HeroKeyArt_1440x580_v1.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1pYzhGpYcpbasqXvOf3YBq/5ac1b9604f509fa4acf54f3ea38e35fd/HAM_020_PA_BRAND_REFRESH_TICKETING_ASSETS_TodayTix_HeroKeyArt_480x720_v1.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/1pYzhGpYcpbasqXvOf3YBq/5ac1b9604f509fa4acf54f3ea38e35fd/HAM_020_PA_BRAND_REFRESH_TICKETING_ASSETS_TodayTix_HeroKeyArt_480x720_v1.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "The story of America's Founding Father Alexander Hamilton, an immigrant from the West Indies who became George Washington's right-hand man and the nation's first Treasury Secretary.",
       "ageRecommendation": "Ages 10+",
@@ -477,8 +477,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/20JbwcyfTKefeounu0bb7g/bb61c8a016dfae49f63172206b9fb4cc/TLK_TodayTix_1440x580__3_.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/20JbwcyfTKefeounu0bb7g/bb61c8a016dfae49f63172206b9fb4cc/TLK_TodayTix_1440x580__3_.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/20JbwcyfTKefeounu0bb7g/bb61c8a016dfae49f63172206b9fb4cc/TLK_TodayTix_1440x580__3_.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/20JbwcyfTKefeounu0bb7g/bb61c8a016dfae49f63172206b9fb4cc/TLK_TodayTix_480x720__3_.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/20JbwcyfTKefeounu0bb7g/bb61c8a016dfae49f63172206b9fb4cc/TLK_TodayTix_480x720__3_.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "Disney's award-winning musical brings the African savanna to Broadway with stunning puppetry and masks. Young Simba must embrace his destiny to become king after tragedy strikes the Pride Lands.",
       "ageRecommendation": "Ages 6+",
@@ -567,8 +567,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/5WOyzD6VmmtuvGFJoVg79d/e4ffa9fa40c01724450eb5f31b75c7be/MR_086_PA_LOGO_RESIZING_ASSETS_2025_1440x580_v01.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5WOyzD6VmmtuvGFJoVg79d/e4ffa9fa40c01724450eb5f31b75c7be/MR_086_PA_LOGO_RESIZING_ASSETS_2025_1440x580_v01.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/5WOyzD6VmmtuvGFJoVg79d/e4ffa9fa40c01724450eb5f31b75c7be/MR_086_PA_LOGO_RESIZING_ASSETS_2025_1440x580_v01.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5WOyzD6VmmtuvGFJoVg79d/e4ffa9fa40c01724450eb5f31b75c7be/MR_086_PA_LOGO_RESIZING_ASSETS_2025_480x720_v01.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/5WOyzD6VmmtuvGFJoVg79d/e4ffa9fa40c01724450eb5f31b75c7be/MR_086_PA_LOGO_RESIZING_ASSETS_2025_480x720_v01.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "Enter a world of splendor and romance, of eye-popping excess, of glitz, grandeur and glory! A world where Bohemians and aristocrats rub elbows and revel in electrifying enchantment.",
       "ageRecommendation": "Ages 12+",
@@ -608,8 +608,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/1XmnTVfLKO0DYjasW0wYG0/1527ae1efb51cffaded96cd4b4c9baeb/ALD_TodayTix_Hero_1440x580.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1XmnTVfLKO0DYjasW0wYG0/1527ae1efb51cffaded96cd4b4c9baeb/ALD_TodayTix_Hero_1440x580.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/1XmnTVfLKO0DYjasW0wYG0/1527ae1efb51cffaded96cd4b4c9baeb/ALD_TodayTix_Hero_1440x580.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1XmnTVfLKO0DYjasW0wYG0/1527ae1efb51cffaded96cd4b4c9baeb/ALD_TodayTix_Hero_480x720.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/1XmnTVfLKO0DYjasW0wYG0/1527ae1efb51cffaded96cd4b4c9baeb/ALD_TodayTix_Hero_480x720.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "Disney's thrilling adaptation of the animated classic. From the producer of The Lion King comes the story of a street-smart young man who discovers a magic lamp and genie.",
       "ageRecommendation": "Ages 6+",
@@ -652,8 +652,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/t09ycMZvQ674f7dJ12lpu/1c74af76123f48799204fe96f76a7257/HTD-2174W-MiscDec-TodayTix-Updates-Hero-1440x580-v1.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/t09ycMZvQ674f7dJ12lpu/1c74af76123f48799204fe96f76a7257/HTD-2174W-MiscDec-TodayTix-Updates-Hero-1440x580-v1.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/t09ycMZvQ674f7dJ12lpu/1c74af76123f48799204fe96f76a7257/HTD-2174W-MiscDec-TodayTix-Updates-Hero-1440x580-v1.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/t09ycMZvQ674f7dJ12lpu/1c74af76123f48799204fe96f76a7257/HTD-2174W-MiscDec-TodayTix-Updates-Hero-480x720-v1.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/t09ycMZvQ674f7dJ12lpu/1c74af76123f48799204fe96f76a7257/HTD-2174W-MiscDec-TodayTix-Updates-Hero-480x720-v1.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "Welcome to Hadestown, where a song can change your fate. This acclaimed new musical by Anaïs Mitchell intertwines two mythic tales — that of Orpheus and Eurydice, and King Hades and his wife Persephone.",
       "ageRecommendation": "Ages 10+",
@@ -692,8 +692,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/m7Pq32ZM887jDNbPXwb2i/eb048aa40d3a46d288eb8963538419a9/TodayTix_Hero_1440x580_14601_MJ_Updated_Partner_assets_FR.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/m7Pq32ZM887jDNbPXwb2i/eb048aa40d3a46d288eb8963538419a9/TodayTix_Hero_1440x580_14601_MJ_Updated_Partner_assets_FR.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/m7Pq32ZM887jDNbPXwb2i/eb048aa40d3a46d288eb8963538419a9/TodayTix_Hero_1440x580_14601_MJ_Updated_Partner_assets_FR.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/m7Pq32ZM887jDNbPXwb2i/eb048aa40d3a46d288eb8963538419a9/TodayTix_Hero_480x720_14601_MJ_Updated_Partner_assets_FR.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/m7Pq32ZM887jDNbPXwb2i/eb048aa40d3a46d288eb8963538419a9/TodayTix_Hero_480x720_14601_MJ_Updated_Partner_assets_FR.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "The story of Michael Jackson, centering around the making of his 1992 Dangerous World Tour, revealing the creative mind and collaborative spirit that catapulted him into legendary status.",
       "ageRecommendation": "Ages 8+",
@@ -728,8 +728,8 @@
       "intermissions": 0,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/5GitG8n9EJB8EKEqU9B6Lq/263afbf4f3039bdfd38bd74def4ef6a5/250501_SIX_ConcertBanners_1440x580_RG.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5GitG8n9EJB8EKEqU9B6Lq/263afbf4f3039bdfd38bd74def4ef6a5/250501_SIX_ConcertBanners_1440x580_RG.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/5GitG8n9EJB8EKEqU9B6Lq/263afbf4f3039bdfd38bd74def4ef6a5/250501_SIX_ConcertBanners_1440x580_RG.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/5GitG8n9EJB8EKEqU9B6Lq/263afbf4f3039bdfd38bd74def4ef6a5/250501_SIX_ConcertBanners_480x720_RG.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/5GitG8n9EJB8EKEqU9B6Lq/263afbf4f3039bdfd38bd74def4ef6a5/250501_SIX_ConcertBanners_480x720_RG.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "The six wives of Henry VIII take the mic to tell their own stories and reclaim their identities in this electrifying pop concert musical.",
       "ageRecommendation": "Ages 10+",
@@ -765,8 +765,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/3dnKgNoU6R8vKgpXgyAoUo/f68ed6881da773baca3084c1ec22a8a0/BOM_2025_TTPA_15Ann_1440x580_1848_RGB-SLF.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/3dnKgNoU6R8vKgpXgyAoUo/f68ed6881da773baca3084c1ec22a8a0/BOM_2025_TTPA_15Ann_1440x580_1848_RGB-SLF.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/3dnKgNoU6R8vKgpXgyAoUo/f68ed6881da773baca3084c1ec22a8a0/BOM_2025_TTPA_15Ann_1440x580_1848_RGB-SLF.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/3dnKgNoU6R8vKgpXgyAoUo/f68ed6881da773baca3084c1ec22a8a0/BOM_2025_TTPA_15Ann_480x720_1848_RGB-SLF.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/3dnKgNoU6R8vKgpXgyAoUo/f68ed6881da773baca3084c1ec22a8a0/BOM_2025_TTPA_15Ann_480x720_1848_RGB-SLF.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "From the creators of South Park comes this hilarious musical about two mismatched Mormon missionaries sent to spread the word in a remote Ugandan village.",
       "ageRecommendation": "Ages 17+",
@@ -801,8 +801,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/1pePhHDlaO3Ll7GWC0YkL1/80b1aac734fa1a7ca7c950883f84cc24/_J-Nov2025Update-TodayTix-1440x580-ALT.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1pePhHDlaO3Ll7GWC0YkL1/80b1aac734fa1a7ca7c950883f84cc24/_J-Nov2025Update-TodayTix-1440x580-ALT.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/1pePhHDlaO3Ll7GWC0YkL1/80b1aac734fa1a7ca7c950883f84cc24/_J-Nov2025Update-TodayTix-1440x580-ALT.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/1pePhHDlaO3Ll7GWC0YkL1/80b1aac734fa1a7ca7c950883f84cc24/_J-Nov2025Update-TodayTix-480x720-ALT.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/1pePhHDlaO3Ll7GWC0YkL1/80b1aac734fa1a7ca7c950883f84cc24/_J-Nov2025Update-TodayTix-480x720-ALT.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "What if Juliet's story didn't end in tragedy? This joyful jukebox musical featuring Max Martin's iconic pop hits reimagines Shakespeare's heroine as she writes her own destiny.",
       "ageRecommendation": "Ages 10+",
@@ -853,8 +853,8 @@
       "intermissions": 1,
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/4aMYNDxN6buTaCrcMKIvuN/6bdda041a5e5d9856105cb583334478b/TT-109547-017703-TodayTix-1440x580.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/4aMYNDxN6buTaCrcMKIvuN/6bdda041a5e5d9856105cb583334478b/TT-109547-017703-TodayTix-1440x580.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/4aMYNDxN6buTaCrcMKIvuN/6bdda041a5e5d9856105cb583334478b/TT-109547-017703-TodayTix-1440x580.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/4aMYNDxN6buTaCrcMKIvuN/6bdda041a5e5d9856105cb583334478b/TT-109547-017703-TodayTix-480x720.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/4aMYNDxN6buTaCrcMKIvuN/6bdda041a5e5d9856105cb583334478b/TT-109547-017703-TodayTix-480x720.jpg?w=600&h=900&fit=fill&q=85&f=center"
       },
       "synopsis": "Nineteen years after Harry's original adventure, he's now a Ministry of Magic employee while his son Albus struggles with the family legacy at Hogwarts.",
       "ageRecommendation": "Ages 10+",
@@ -912,8 +912,8 @@
       ],
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/3vH6kVRmlcOnzVfYGFxOJb/6098bba8b5336ed355c5d6b9de90e420/Hero_1440x580.png?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/3vH6kVRmlcOnzVfYGFxOJb/6098bba8b5336ed355c5d6b9de90e420/Hero_1440x580.png?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/3vH6kVRmlcOnzVfYGFxOJb/6098bba8b5336ed355c5d6b9de90e420/Hero_1440x580.png?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/3vH6kVRmlcOnzVfYGFxOJb/6098bba8b5336ed355c5d6b9de90e420/Hero_480x720.png?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/3vH6kVRmlcOnzVfYGFxOJb/6098bba8b5336ed355c5d6b9de90e420/Hero_480x720.png?w=600&h=900&fit=fill&q=85&f=center"
       }
     },
     {
@@ -948,8 +948,8 @@
       ],
       "images": {
         "hero": "https://images.ctfassets.net/6pezt69ih962/79kOvZoGMIvolshDhfWms4/b4b3fa7cdd0728e35a9832da9e0a5ec2/STTFS-NewKeyArt-ThirdPartyAssets_TodayTix-1440x580.jpg?w=1920&h=1080&fit=pad&q=90&bg=rgb:1a1a1a",
-        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/79kOvZoGMIvolshDhfWms4/b4b3fa7cdd0728e35a9832da9e0a5ec2/STTFS-NewKeyArt-ThirdPartyAssets_TodayTix-1440x580.jpg?w=400&h=400&fit=fill&q=80&f=center",
-        "poster": "https://images.ctfassets.net/6pezt69ih962/79kOvZoGMIvolshDhfWms4/b4b3fa7cdd0728e35a9832da9e0a5ec2/STTFS-NewKeyArt-ThirdPartyAssets_TodayTix-1440x580.jpg?w=600&h=900&fit=fill&q=85&f=center"
+        "thumbnail": "https://images.ctfassets.net/6pezt69ih962/79kOvZoGMIvolshDhfWms4/b4b3fa7cdd0728e35a9832da9e0a5ec2/STTFS-NewKeyArt-ThirdPartyAssets_TodayTix-480x720.jpg?w=400&h=400&fit=fill&q=80&f=center",
+        "poster": "https://images.ctfassets.net/6pezt69ih962/79kOvZoGMIvolshDhfWms4/b4b3fa7cdd0728e35a9832da9e0a5ec2/STTFS-NewKeyArt-ThirdPartyAssets_TodayTix-480x720.jpg?w=600&h=900&fit=fill&q=85&f=center"
       }
     },
     {


### PR DESCRIPTION
Problem: Was using 1440x580 landscape banners for all image types. Cropping wide landscape to square/portrait looked terrible.

Solution:
1. Updated formatImageUrls() to construct 480x720 poster URLs from 1440x580 hero URLs by replacing dimensions in filename
2. Updated all shows to use 480x720 portrait sources for thumbnails and posters

This gives much better crops since 480x720 (2:3 portrait) crops naturally to square and portrait formats.

https://claude.ai/code/session_01TYrqrB4gG3Z9ajMwCxbKhF