### PR TITLE
Schmigadoon 2026 postmortem: automation fixes (8 bug classes)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -612,6 +612,7 @@ jobs:
             tests/unit/tb-direct-url.test.mjs \
             tests/unit/trade-press-scraper.test.mjs \
             tests/unit/tryout-url-filter.test.mjs \
+            tests/unit/url-content-sanity.test.mjs \
             tests/unit/url-date-wrongproduction.test.mjs \
             tests/unit/data-quality-pipeline.test.js \
             tests/unit/integrity-report.test.js \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -604,6 +604,7 @@ jobs:
             tests/unit/deep-research-guardian.test.mjs \
             tests/unit/outlet-id-mapper.test.mjs \
             tests/unit/parse-grosses-analysis.test.mjs \
+            tests/unit/rebuild-pause.test.mjs \
             tests/unit/review-write-guard.test.mjs \
             tests/unit/sample.test.mjs \
             tests/unit/sanity.test.mjs \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -595,6 +595,7 @@ jobs:
           # Run all unit tests with tsx (provides TypeScript import support)
           # Exclude ensemble.test.mjs (pre-existing ts-node compilation issue with scripts/tsconfig.json)
           npx tsx --test \
+            tests/unit/anticipatory-preview-gate.test.mjs \
             tests/unit/biz-data-functions.test.mjs \
             tests/unit/bww-roundup-extractor.test.mjs \
             tests/unit/commercial-changes.test.mjs \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -598,10 +598,12 @@ jobs:
             tests/unit/biz-data-functions.test.mjs \
             tests/unit/bww-roundup-extractor.test.mjs \
             tests/unit/commercial-changes.test.mjs \
+            tests/unit/content-verifier.test.mjs \
             tests/unit/cote-notices-registry.test.mjs \
             tests/unit/deep-research-guardian.test.mjs \
             tests/unit/outlet-id-mapper.test.mjs \
             tests/unit/parse-grosses-analysis.test.mjs \
+            tests/unit/review-write-guard.test.mjs \
             tests/unit/sample.test.mjs \
             tests/unit/sanity.test.mjs \
             tests/unit/score-conversion-rules.test.mjs \
@@ -609,6 +611,7 @@ jobs:
             tests/unit/source-validator.test.mjs \
             tests/unit/tb-direct-url.test.mjs \
             tests/unit/trade-press-scraper.test.mjs \
+            tests/unit/tryout-url-filter.test.mjs \
             tests/unit/url-date-wrongproduction.test.mjs \
             tests/unit/data-quality-pipeline.test.js \
             tests/unit/integrity-report.test.js \

--- a/scripts/collect-review-texts.js
+++ b/scripts/collect-review-texts.js
@@ -90,7 +90,7 @@ const { cleanText, stripTrailingJunk, TRAILING_JUNK_PATTERNS } = require('./lib/
 const { verifyContent, quickValidityCheck } = require('./lib/content-verifier');
 
 // Content quality detection (garbage/invalid content filter)
-const { assessTextQuality, isGarbageContent, validateShowMentioned, extractByline, matchesCritic, computeContentFingerprint, classifyContentTier, verifyFullTextContent, extractAuthorFromHtml, extractHighConfidenceAuthor } = require('./lib/content-quality');
+const { assessTextQuality, isGarbageContent, validateShowMentioned, validateContentMentionsShow, extractByline, matchesCritic, computeContentFingerprint, classifyContentTier, verifyFullTextContent, extractAuthorFromHtml, extractHighConfidenceAuthor } = require('./lib/content-quality');
 const { resolveOutletFromUrl, getOutletDisplayName, generateReviewFilename, normalizeOutlet } = require('./lib/review-normalization');
 const { setExtractedScore } = require('./lib/score-routing');
 const { classifyIncompleteReason } = require('./lib/incomplete-reason');
@@ -5962,6 +5962,40 @@ async function processReview(review) {
     // Archive HTML
     const archivePath = result.html ? archiveHtml(result.html, review, result.method) : null;
 
+    // Post-fetch URL→content sanity check (Schmigadoon 2026 Bug #2).
+    // BrightData/ScrapingBee occasionally returns a completely different article
+    // under our target URL (CDN misroute, stale cache, slug redirect). The LLM
+    // verifier catches SOME of these but is expensive and can be defeated by
+    // adversarial text. A cheap deterministic mention-count + HTML-<title>
+    // guard catches the class before we persist fullText or burn CV tokens.
+    {
+      const canonicalTitle = _showsJsonCache
+        ? (_showsJsonCache.shows.find(s => s.id === review.showId)?.title || showTitle)
+        : showTitle;
+      const sanity = validateContentMentionsShow(
+        result.text,
+        result.html || null,
+        canonicalTitle,
+        review.showId
+      );
+      if (!sanity.valid) {
+        console.log(`  ✗ URL→CONTENT MISMATCH: ${sanity.reason}`);
+        if (sanity.htmlTitle) console.log(`    HTML <title>: "${sanity.htmlTitle}"`);
+        recordFailedFetch(review, 'url_content_mismatch', {
+          method: result.method,
+          mismatchReason: sanity.reason,
+          mentionCount: sanity.mentionCount,
+          threshold: sanity.threshold,
+          htmlTitle: sanity.htmlTitle,
+          htmlTitleMatch: sanity.htmlTitleMatch,
+          textLength: result.text.length,
+          archivePath,
+        });
+        stats.totalFailed++;
+        return { success: false, error: 'url_content_mismatch', reason: sanity.reason };
+      }
+    }
+
     // Validate
     const validation = validateReviewText(result.text, review);
     console.log(`  Validation: ${validation.valid ? 'PASS' : 'ISSUES'} (${validation.wordCount} words)`);
@@ -6156,6 +6190,33 @@ async function processReview(review) {
           }
 
           const archivePath = retryResult.html ? archiveHtml(retryResult.html, review, retryResult.method) : null;
+
+          // Post-fetch URL→content sanity check (Bug #2) — also on retry path
+          const retryCanonicalTitle = _showsJsonCache
+            ? (_showsJsonCache.shows.find(s => s.id === review.showId)?.title || showTitle)
+            : showTitle;
+          const retrySanity = validateContentMentionsShow(
+            retryResult.text,
+            retryResult.html || null,
+            retryCanonicalTitle,
+            review.showId
+          );
+          if (!retrySanity.valid) {
+            console.log(`  ✗ URL→CONTENT MISMATCH (retry): ${retrySanity.reason}`);
+            recordFailedFetch(review, 'url_content_mismatch', {
+              method: retryResult.method,
+              mismatchReason: retrySanity.reason,
+              mentionCount: retrySanity.mentionCount,
+              threshold: retrySanity.threshold,
+              htmlTitle: retrySanity.htmlTitle,
+              textLength: retryResult.text.length,
+              archivePath,
+              retry: true,
+            });
+            stats.totalFailed++;
+            return { success: false, error: 'url_content_mismatch_retry', reason: retrySanity.reason };
+          }
+
           const validation = validateReviewText(retryResult.text, review);
           await updateReviewJson(review, retryResult.text, validation, archivePath, retryResult.method, retryResult.attempts, retryResult.archiveData || {}, retryResult.html || '', null);
 

--- a/scripts/collect-review-texts.js
+++ b/scripts/collect-review-texts.js
@@ -95,6 +95,7 @@ const { resolveOutletFromUrl, getOutletDisplayName, generateReviewFilename, norm
 const { setExtractedScore } = require('./lib/score-routing');
 const { classifyIncompleteReason } = require('./lib/incomplete-reason');
 const { isTourReviewExcerpt, isFilmTvReview } = require('./lib/excerpt-validation');
+const { isAnticipatoryPreviewPost } = require('./lib/content-filters');
 
 // NYT Critics' Pick lookup — lazy-loaded once per run from authoritative URL list.
 // Do NOT check raw HTML (10% FP from NYT page chrome). URL match only.
@@ -4237,6 +4238,43 @@ async function updateReviewJson(review, text, validation, archivePath, method, a
       data.publishDate = extractedDate;
       data.dateSource = 'text-regex';
       console.log(`    → Extracted publishDate from text: ${extractedDate}`);
+    }
+  }
+
+  // Schmigadoon 2026 postmortem Bug #5: anticipatory pre-opening-night posts.
+  // For preview-heavy outlets (frontmezzjunkies, broadwaydirect, ...) require
+  // publishDate >= openingDate. For all other outlets allow a 2-day grace (matches
+  // the post-broadcast audit check at publish-date-pre-opening.check.js).
+  // Rejected reviews have their fetched text stripped and are flagged so the
+  // rebuild excludes them. Clearable via humanReviewedEarlyPublish=true.
+  {
+    let showOpeningDate = null;
+    try {
+      if (!_showsJsonCache) _showsJsonCache = JSON.parse(fs.readFileSync('data/shows.json', 'utf8'));
+      const showMeta = _showsJsonCache.shows.find(s => s.id === (data.showId || review.showId));
+      showOpeningDate = showMeta?.openingDate || null;
+    } catch (e) { /* shows.json unavailable — skip gate (fail-open) */ }
+
+    const anticip = isAnticipatoryPreviewPost(
+      data.publishDate,
+      showOpeningDate,
+      data.outletId || review.outletId,
+      { humanReviewedEarlyPublish: data.humanReviewedEarlyPublish === true }
+    );
+    if (anticip.rejected) {
+      console.log(`  ✗ ANTICIPATORY PRE-OPENING POST: ${anticip.reason}`);
+      data.fullText = null;
+      data.wrongProduction = true;
+      data.wrongProductionReason = 'anticipatory_pre_opening_post';
+      data.wrongProductionDetail = anticip.reason;
+      data.wrongProductionDetectedAt = new Date().toISOString();
+      data.wrongProductionDetectedBy = 'ingest-anticipatory-gate';
+      data.anticipatoryGateOutletCategory = anticip.outletCategory;
+      data.anticipatoryGateDaysBeforeOpening = anticip.daysBeforeOpening;
+      // Preserve archivePath so curators can still audit the HTML.
+      // Skip score routing and content verification — the rest of this
+      // function still runs but the flagged fullText=null causes downstream
+      // rebuild to exclude this review.
     }
   }
 

--- a/scripts/lib/bww-roundup-validator.js
+++ b/scripts/lib/bww-roundup-validator.js
@@ -6,6 +6,8 @@
  * and scrape-bww-reviews.js.
  */
 
+const { TRYOUT_URL_MARKERS } = require('./content-filters');
+
 /**
  * Check if "Review Roundup" appears in the <title> tag (not just anywhere on the page).
  * The BWW homepage contains "Review Roundup" in teaser links but NOT in its title.
@@ -48,18 +50,9 @@ function isBWWRoundupContent(html) {
 // Stop words stripped before title matching — must be lowercase
 const TITLE_STOP_WORDS = new Set(['the', 'and', 'for', 'from', 'with', 'that', 'this', 'its', 'a', 'an', 'of', 'in', 'on', 'at', 'by']);
 
-// Tryout / pre-Broadway / regional markers — BWW publishes Review Roundups for these
-// non-Broadway productions with identical title slugs. SERP returns them ahead of the
-// actual Broadway roundup on opening night when Google hasn't indexed the Broadway URL yet.
-// Confirmed incident: 2026-04-20 Schmigadoon opening night, SERP returned Kennedy Center
-// world-premiere roundup (2025) instead of the Broadway one.
-const TRYOUT_URL_MARKERS = [
-  'world-premiere',
-  'kennedy-center',
-  'pre-broadway',
-  'out-of-town',
-  'tryout',
-];
+// TRYOUT_URL_MARKERS lives in content-filters.js as a single source of truth.
+// Re-imported above so the BWW slug validator stays aligned with the general
+// SERP prefilter applied in url-discovery.js (Schmigadoon 2026 Bug #8).
 
 /**
  * Normalize a show title into matchable words: lowercase, strip punctuation, remove stop words.

--- a/scripts/lib/content-filters.js
+++ b/scripts/lib/content-filters.js
@@ -92,4 +92,77 @@ function isUrlYearOutsideWindow(url, openingYear, closingYear) {
   return urlYear < openingYear - 3 || urlYear > upper;
 }
 
-module.exports = { isNotBroadway, isUrlYearOutsideWindow };
+/**
+ * URL path markers indicating non-Broadway productions that share a show title.
+ * These are safe hard-rejects at SERP discovery time — if ANY of these strings
+ * appear in the URL (case-insensitive), the result is almost certainly a different
+ * production (tryout, TV, film, world premiere).
+ *
+ * Confirmed incidents:
+ *  - 2026-04-20 Schmigadoon opening: SERP returned Kennedy Center world-premiere
+ *    roundup (2025) instead of Broadway; 9 T1/T2 URLs scraped for Kennedy Center
+ *    tryout, 2021 Apple TV+ series, and an Off-Broadway Transfer.
+ *
+ * Used by:
+ *  - scripts/lib/url-discovery.js (general SERP prefilter, all outlets)
+ *  - scripts/lib/bww-roundup-validator.js (BWW RR slug validation)
+ *  - scripts/collect-review-texts.js (via url-discovery)
+ *
+ * Do NOT add generic words like "review" — this list is strictly for URL
+ * patterns that identify a DIFFERENT production of the same title.
+ */
+const TRYOUT_URL_MARKERS = [
+  'world-premiere',
+  'world_premiere',
+  'kennedy-center',
+  'kennedycenter',
+  'pre-broadway',
+  'prebroadway',
+  'out-of-town',
+  'tryout',
+  'try-out',
+  'tv-review',
+  'tv_review',
+  'television-review',
+  'film-review',
+  'film_review',
+  'movie-review',
+  'streaming-review',
+  'netflix-review',
+  'apple-tv',
+  'appletv',
+  'disney-plus',
+  'la-jolla',
+  'old-globe',
+  'old_globe',
+  'ahmanson',
+  'geffen-playhouse',
+  'national-tour',
+  'tour-review',
+  'on-tour',
+];
+
+/**
+ * Returns true if the URL contains any tryout/TV/film/pre-Broadway marker.
+ * Used as a SERP prefilter and BWW slug validator.
+ *
+ * @param {string} url - Full URL or URL slug
+ * @returns {{ rejected: boolean, marker?: string }}
+ */
+function hasTryoutUrlMarker(url) {
+  if (!url || typeof url !== 'string') return { rejected: false };
+  const lower = url.toLowerCase();
+  for (const marker of TRYOUT_URL_MARKERS) {
+    if (lower.includes(marker)) {
+      return { rejected: true, marker };
+    }
+  }
+  return { rejected: false };
+}
+
+module.exports = {
+  isNotBroadway,
+  isUrlYearOutsideWindow,
+  TRYOUT_URL_MARKERS,
+  hasTryoutUrlMarker,
+};

--- a/scripts/lib/content-filters.js
+++ b/scripts/lib/content-filters.js
@@ -160,9 +160,105 @@ function hasTryoutUrlMarker(url) {
   return { rejected: false };
 }
 
+/**
+ * Outlets known to publish "anticipation" / preview / feature pieces well
+ * before opening night. For these outlets an ingest-time gate is tighter:
+ * anything published before openingDate is rejected unless manually cleared
+ * (humanReviewedEarlyPublish: true in the source review file).
+ *
+ * Confirmed incident:
+ *  - 2026-04-20 Schmigadoon opening: frontmezzjunkies post published 2026-04-04
+ *    (16 days pre-opening) got scored 76 and reached the review pool. Bug #5
+ *    in the Schmigadoon 2026 postmortem.
+ *
+ * Do NOT add T1 news outlets here (NYT, Variety, etc.) — their embargo-lift
+ * coverage is legitimately 48–72h pre-opening and the default 2-day grace
+ * already accommodates it.
+ */
+const PREVIEW_HEAVY_OUTLETS = new Set([
+  'frontmezzjunkies',
+  'broadwaydirect',
+  'broadway-direct',
+]);
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Default: allow publishDate up to 2 days before openingDate (matches the
+ * post-broadcast audit check at scripts/lib/opening-night-checks/
+ * publish-date-pre-opening.check.js). Press embargoes routinely lift 24–48h
+ * early, so this grace is load-bearing for T1 outlets.
+ */
+const DEFAULT_GRACE_DAYS_BEFORE_OPENING = 2;
+
+/**
+ * Preview-heavy outlets publish pre-opening feature pieces that read like
+ * reviews but aren't. For these outlets, require publishDate >= openingDate
+ * (grace = 0). Override via opts.gracePreviewHeavyOutlet in tests.
+ */
+const PREVIEW_HEAVY_GRACE_DAYS = 0;
+
+/**
+ * Returns whether a review is an anticipatory pre-opening-night post that
+ * should be rejected at ingest. Matches the semantics of the existing
+ * post-broadcast audit check (publish-date-pre-opening.check.js) but fires
+ * BEFORE the review reaches reviews.json / scoring.
+ *
+ * Bypass: opt-in via humanReviewedEarlyPublish=true on the source file.
+ * Curators may intentionally clear anticipatory posts they've verified as
+ * legitimate reviews (rare — typically only for T1 embargo-lift coverage).
+ *
+ * @param {string|null} publishDate - Review publish date (YYYY-MM-DD)
+ * @param {string|null} openingDate - Show opening date (YYYY-MM-DD)
+ * @param {string|null} outletId - Review outlet ID (normalized)
+ * @param {Object} [opts]
+ * @param {boolean} [opts.humanReviewedEarlyPublish] - Manual clear flag from source file
+ * @param {number} [opts.graceDays] - Override default 2-day grace (non-preview outlets)
+ * @param {number} [opts.gracePreviewHeavyOutlet] - Override 0-day grace for preview-heavy outlets
+ * @returns {{ rejected: boolean, reason?: string, daysBeforeOpening?: number, outletCategory?: 'preview-heavy'|'default' }}
+ */
+function isAnticipatoryPreviewPost(publishDate, openingDate, outletId, opts = {}) {
+  if (opts.humanReviewedEarlyPublish === true) {
+    return { rejected: false };
+  }
+  if (!publishDate || !openingDate) {
+    return { rejected: false };
+  }
+
+  const opening = new Date(openingDate);
+  const publish = new Date(publishDate);
+  if (Number.isNaN(opening.getTime()) || Number.isNaN(publish.getTime())) {
+    return { rejected: false };
+  }
+
+  const isPreviewHeavy = !!(outletId && PREVIEW_HEAVY_OUTLETS.has(String(outletId).toLowerCase()));
+  const graceDays = isPreviewHeavy
+    ? (opts.gracePreviewHeavyOutlet != null ? opts.gracePreviewHeavyOutlet : PREVIEW_HEAVY_GRACE_DAYS)
+    : (opts.graceDays != null ? opts.graceDays : DEFAULT_GRACE_DAYS_BEFORE_OPENING);
+
+  const cutoff = new Date(opening.getTime() - graceDays * MS_PER_DAY);
+  if (publish >= cutoff) {
+    return { rejected: false };
+  }
+
+  const daysBeforeOpening = Math.round((opening.getTime() - publish.getTime()) / MS_PER_DAY);
+  return {
+    rejected: true,
+    reason: isPreviewHeavy
+      ? `preview-heavy outlet "${outletId}" published ${daysBeforeOpening}d before openingDate (${openingDate}); require publish on/after opening unless cleared`
+      : `published ${daysBeforeOpening}d before openingDate (${openingDate}); exceeds ${graceDays}-day grace`,
+    daysBeforeOpening,
+    outletCategory: isPreviewHeavy ? 'preview-heavy' : 'default',
+  };
+}
+
 module.exports = {
   isNotBroadway,
   isUrlYearOutsideWindow,
   TRYOUT_URL_MARKERS,
   hasTryoutUrlMarker,
+  PREVIEW_HEAVY_OUTLETS,
+  DEFAULT_GRACE_DAYS_BEFORE_OPENING,
+  PREVIEW_HEAVY_GRACE_DAYS,
+  isAnticipatoryPreviewPost,
 };

--- a/scripts/lib/content-quality.js
+++ b/scripts/lib/content-quality.js
@@ -2120,6 +2120,133 @@ function extractHighConfidenceAuthor(html) {
   return null;
 }
 
+/**
+ * Post-fetch URL→content sanity check (Schmigadoon 2026 Bug #2).
+ *
+ * Before persisting fullText fetched from a URL we believe is a review of SHOW_X,
+ * verify the content actually mentions SHOW_X enough to trust it. This catches
+ * the class of failure where BrightData/ScrapingBee returns a completely
+ * different article (e.g., Everybody's Talking About Jamie content served on
+ * a Schmigadoon URL due to CDN misrouting, stale cache, or wrong-slug redirect).
+ *
+ * Two independent checks, BOTH must pass:
+ *   1. Body mention count: the show title (or significant show-ID word) appears
+ *      at least N times, where N scales with text length.
+ *   2. HTML <title> match (when html provided): the <title> contains a
+ *      significant title word or ID word — a completely unrelated title is a
+ *      strong signal we fetched the wrong page.
+ *
+ * Returns { valid, reason, mentionCount, threshold, htmlTitle, htmlTitleMatch }.
+ *
+ * @param {string} text - The fetched fullText (post-cleaning)
+ * @param {string} [html] - Raw HTML (for <title> check, optional)
+ * @param {string} showTitle - Human-readable show title (e.g., "Schmigadoon")
+ * @param {string} [showId] - Show ID slug (e.g., "schmigadoon-2026")
+ * @param {Object} [opts]
+ * @param {number} [opts.minMentionsLong=3] - Threshold for text ≥1500 chars
+ * @param {number} [opts.minMentionsShort=1] - Threshold for text <1500 chars
+ * @returns {{ valid: boolean, reason?: string, mentionCount: number, threshold: number, htmlTitle: string|null, htmlTitleMatch: boolean|null }}
+ */
+function validateContentMentionsShow(text, html, showTitle, showId, opts = {}) {
+  const minLong = opts.minMentionsLong != null ? opts.minMentionsLong : 3;
+  const minShort = opts.minMentionsShort != null ? opts.minMentionsShort : 1;
+
+  if (!text || typeof text !== 'string') {
+    return {
+      valid: false,
+      reason: 'empty text',
+      mentionCount: 0,
+      threshold: minShort,
+      htmlTitle: null,
+      htmlTitleMatch: null,
+    };
+  }
+
+  const lower = text.toLowerCase();
+  const threshold = text.length >= 1500 ? minLong : minShort;
+
+  // Build the set of title tokens to count — show title, title-without-"The",
+  // significant ID words. One occurrence of ANY token counts toward the total
+  // (we're asking "does this page really cover SHOW_X?", not "is the exact
+  // official title used 3 times"). De-duplicate tokens so "Schmigadoon" in
+  // both title and ID doesn't double-weight.
+  const tokens = new Set();
+  if (showTitle && showTitle.length > 2) {
+    tokens.add(showTitle.toLowerCase());
+    const noThe = showTitle.toLowerCase().replace(/^the\s+/, '');
+    if (noThe.length > 2) tokens.add(noThe);
+  }
+  if (showId) {
+    const idBase = showId.replace(/-\d{4}$/, '');
+    for (const w of idBase.split('-')) {
+      if (w.length > 4 && !['the', 'and', 'for', 'with', 'from'].includes(w)) {
+        tokens.add(w.toLowerCase());
+      }
+    }
+  }
+
+  let mentionCount = 0;
+  for (const token of tokens) {
+    if (!token) continue;
+    // Count non-overlapping occurrences, word-boundary when single word.
+    const isSingleWord = !/\s/.test(token);
+    const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = isSingleWord
+      ? new RegExp(`\\b${escaped}\\b`, 'gi')
+      : new RegExp(escaped, 'gi');
+    const matches = lower.match(re);
+    if (matches) mentionCount += matches.length;
+  }
+
+  // HTML <title> check (optional — only when html is provided)
+  let htmlTitle = null;
+  let htmlTitleMatch = null;
+  if (html && typeof html === 'string') {
+    const m = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+    if (m) {
+      htmlTitle = m[1].replace(/\s+/g, ' ').trim();
+      const titleLower = htmlTitle.toLowerCase();
+      htmlTitleMatch = false;
+      for (const token of tokens) {
+        if (token && titleLower.includes(token)) {
+          htmlTitleMatch = true;
+          break;
+        }
+      }
+    }
+  }
+
+  if (mentionCount < threshold) {
+    return {
+      valid: false,
+      reason: `show mentioned ${mentionCount}× (below ${threshold} threshold for ${text.length}-char text)`,
+      mentionCount,
+      threshold,
+      htmlTitle,
+      htmlTitleMatch,
+    };
+  }
+
+  if (htmlTitleMatch === false) {
+    return {
+      valid: false,
+      reason: `HTML <title> "${htmlTitle}" does not reference show "${showTitle || showId}"`,
+      mentionCount,
+      threshold,
+      htmlTitle,
+      htmlTitleMatch,
+    };
+  }
+
+  return {
+    valid: true,
+    mentionCount,
+    threshold,
+    htmlTitle,
+    htmlTitleMatch,
+  };
+}
+
 module.exports = {
   isGarbageContent,
   hasReviewContent,
@@ -2127,6 +2254,7 @@ module.exports = {
   detectGarbageFromReasoning,
   // New enhanced validation functions
   validateShowMentioned,
+  validateContentMentionsShow,
   detectMultiShowContent,
   detectConcatenatedArticles,
   // Content tier classification (5-tier taxonomy)

--- a/scripts/lib/content-verifier.js
+++ b/scripts/lib/content-verifier.js
@@ -417,7 +417,13 @@ Set isValid=true only if the content is a review of the ${mc.label} production a
       // Call site keeps logging and wpReasoning annotation so CI output remains informative.
       let filmTvFlag = parsed.isFilmTv || false;
       let filmTvConfidence = parsed.confidence || 'medium';
-      const temporalOverrides = applyTemporalOverrides(wpFlag, filmTvFlag, wpConfidence, openingDate, publishDate);
+      const temporalOverrides = applyTemporalOverrides(wpFlag, filmTvFlag, wpConfidence, openingDate, publishDate, {
+        issues: parsed.issues,
+        reasoning: parsed.reasoning,
+      });
+      if (temporalOverrides.bypassedForStrongSignal && wpFlag) {
+        console.log(`    ✓ LLM wrongProduction NOT overridden: CV issues contain explicit "different show" markers — keeping ${wpConfidence} confidence`);
+      }
       if (temporalOverrides.wpConfidence !== wpConfidence && wpFlag && openingDate && publishDate) {
         const daysDiff = Math.round(Math.abs((new Date(publishDate) - new Date(openingDate)) / 86400000));
         console.log(`    ⚠ LLM wrongProduction overridden: review published ${daysDiff}d from opening — downgrading to low confidence`);

--- a/scripts/lib/content-verifier.js
+++ b/scripts/lib/content-verifier.js
@@ -369,6 +369,13 @@ Analyze the content and respond with ONLY valid JSON (no markdown fences):
 ${wrongProdList}
    A review of the ${mc.label} production that merely *mentions* other productions is NOT a wrong production — it must be *reviewing* a non-${mc.label} staging.
 
+   **"Reviews OF" vs "mentions OF" — the critical distinction (Schmigadoon 2026 FP class):**
+   Before flagging wrongProduction=true, ask yourself: is this critic evaluating the ${mc.label} run that just opened, or is the critic evaluating a different run?
+     - **Evaluates the ${mc.label} run** (NOT wrongProduction, even if other productions are named): critic attended the ${mc.label} performance, the opinion-bearing sentences describe the ${mc.label} cast/staging, phrases like "the show at [${mc.label} theatre]", "this ${mc.label} outing", "on Broadway/West End now", "in its new ${mc.label} incarnation".
+     - **Evaluates a different run** (IS wrongProduction): the opinion-bearing sentences describe a Kennedy Center / Almeida / La Jolla / TV / film / prior-revival cast and venue — the review was WRITTEN about that run and merely refiled on a ${mc.label} show page.
+   Background paragraphs that contextualize ("this is a transfer from the Kennedy Center pre-Broadway tryout"), historical asides ("the show was famously a 2021 Apple TV+ series"), or comparative references ("like NBC's Smash…") are NOT evidence of wrongProduction. Do not flag on mention alone.
+   **Confidence calibration for this flag:** Only set wrongProduction=true with confidence="high" when the review's opinion-bearing content evaluates a non-${mc.label} production. If the evidence is only a passing mention, contextual aside, or comparative reference, set wrongProduction=false. If you're uncertain whether the review is OF the ${mc.label} run or OF a different run, set confidence="low" — the rebuild gate requires confidence>=medium for promotion.
+
    **YEAR / PRODUCTION MATCHING (most common failure mode):** The showTitle may contain a year suffix (e.g. "Cats 1982", "A Christmas Carol 2001", "Art 1998"). Many shows have multiple revivals — Cats had a 1982 original and a 2016 Broadway revival at different venues. DO NOT assume the review matches the showTitle year just because the show name matches. Cross-check:
    - What year/run does the review actually describe? Look for opening-year mentions, cast names, venue names, and the review's publishDate.
    - If the showTitle says "Cats 1982" but the review describes a production at Neil Simon Theatre (the 2016 revival was at Neil Simon; the 1982 original was at Winter Garden), that is wrongProduction=true.

--- a/scripts/lib/rebuild-pause.js
+++ b/scripts/lib/rebuild-pause.js
@@ -1,0 +1,53 @@
+/**
+ * Rebuild-pause tombstone — opening-night manual-edit race guard.
+ *
+ * Incident: Schmigadoon 2026-04-21 opening morning. An edit to
+ * broadway-scorecard-data/reviews.json (removing 2 wrong-production entries)
+ * raced a rebuild-reviews run that was auto-committing reviews.json from
+ * review-texts. Manual `gh run cancel` took ~60s to propagate, and the
+ * rebuild's push could have overwritten the manual fix before the broadcast.
+ *
+ * This module is the read-side of a tombstone file that tells rebuild-all-
+ * reviews.js (and any other rebuild entry point) to exit early without
+ * touching reviews.json. `scripts/pause-rebuild.js` is the write-side CLI.
+ *
+ * Fail-open: any read/parse error → not paused (do not let a corrupt
+ * tombstone accidentally disable rebuilds permanently).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const REBUILD_PAUSE_PATH = path.join(__dirname, '..', '..', 'data', 'audit', 'rebuild-pause.json');
+
+function readRebuildPause(pausePath = REBUILD_PAUSE_PATH) {
+  try {
+    if (!fs.existsSync(pausePath)) return null;
+    const raw = fs.readFileSync(pausePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (!parsed.until) return null;
+    const until = new Date(parsed.until);
+    if (Number.isNaN(until.getTime())) return null;
+    return {
+      until,
+      reason: typeof parsed.reason === 'string' ? parsed.reason : '',
+      pausedBy: typeof parsed.pausedBy === 'string' ? parsed.pausedBy : '',
+      pausedAt: typeof parsed.pausedAt === 'string' ? parsed.pausedAt : '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isRebuildPaused(nowMs = Date.now(), pausePath = REBUILD_PAUSE_PATH) {
+  const entry = readRebuildPause(pausePath);
+  if (!entry) return false;
+  return entry.until.getTime() > nowMs;
+}
+
+module.exports = {
+  REBUILD_PAUSE_PATH,
+  readRebuildPause,
+  isRebuildPaused,
+};

--- a/scripts/lib/review-guards.js
+++ b/scripts/lib/review-guards.js
@@ -69,18 +69,49 @@ function pickBestDtliSlug(showId, slugs) {
  * this close to opening, we downgrade wrongProduction confidence to 'low' and clear
  * isFilmTv entirely. Low confidence prevents fullText nulling.
  *
+ * BYPASS (Schmigadoon 2026-04-21 EBT incident): when CV issues/reasoning contain
+ * explicit "completely different show" markers, the override does NOT fire. This
+ * is not an LLM false positive near opening — it's definitive evidence of wrong
+ * content (e.g., a scraper fetched Every Brilliant Thing URL instead of Schmigadoon).
+ * Those signals should override the opening-week safety net, not be overridden by it.
+ *
  * @param {boolean} wpFlag - LLM's wrongProduction flag
  * @param {boolean} filmTvFlag - LLM's isFilmTv flag
  * @param {string} wpConfidence - LLM's confidence level ('high'|'medium'|'low')
  * @param {string|null} openingDate - Show's opening date (YYYY-MM-DD)
  * @param {string|null} publishDate - Review's publish date (YYYY-MM-DD)
- * @returns {{ wpConfidence: string, filmTvFlag: boolean }}
+ * @param {object} [cvContext] - Optional CV signals. {issues: string[], reasoning: string}
+ * @returns {{ wpConfidence: string, filmTvFlag: boolean, bypassedForStrongSignal: boolean }}
  */
-function applyTemporalOverrides(wpFlag, filmTvFlag, wpConfidence, openingDate, publishDate) {
+const STRONG_DIFFERENT_SHOW_MARKERS = [
+  /does not appear in/i,
+  /doesn'?t appear in/i,
+  /not appear(?: in| at all)/i,
+  /completely different show/i,
+  /different production entirely/i,
+  /wrong production entirely/i,
+  /reviews the wrong production/i,
+  /reviews? a different show/i,
+  /unrelated to the expected/i,
+  /not mentioned in/i,
+  /expected show[^.]*(?:does not|doesn'?t|not)[^.]*appear/i,
+];
+
+function hasStrongDifferentShowSignal(cvIssues, cvReasoning) {
+  const texts = [];
+  if (Array.isArray(cvIssues)) texts.push(...cvIssues.map(String));
+  if (cvReasoning) texts.push(String(cvReasoning));
+  if (texts.length === 0) return false;
+  return texts.some(t => STRONG_DIFFERENT_SHOW_MARKERS.some(re => re.test(t)));
+}
+
+function applyTemporalOverrides(wpFlag, filmTvFlag, wpConfidence, openingDate, publishDate, cvContext) {
   let resultWpConfidence = wpConfidence;
   let resultFilmTvFlag = filmTvFlag;
 
-  if (openingDate && publishDate) {
+  const strongDifferent = !!(cvContext && hasStrongDifferentShowSignal(cvContext.issues, cvContext.reasoning));
+
+  if (!strongDifferent && openingDate && publishDate) {
     const opening = new Date(openingDate);
     const publish = new Date(publishDate);
     if (!isNaN(opening.getTime()) && !isNaN(publish.getTime())) {
@@ -92,7 +123,11 @@ function applyTemporalOverrides(wpFlag, filmTvFlag, wpConfidence, openingDate, p
     }
   }
 
-  return { wpConfidence: resultWpConfidence, filmTvFlag: resultFilmTvFlag };
+  return {
+    wpConfidence: resultWpConfidence,
+    filmTvFlag: resultFilmTvFlag,
+    bypassedForStrongSignal: strongDifferent,
+  };
 }
 
 /**
@@ -1289,6 +1324,8 @@ module.exports = {
   shouldSkipScoredReview,
   pickBestDtliSlug,
   applyTemporalOverrides,
+  hasStrongDifferentShowSignal,
+  STRONG_DIFFERENT_SHOW_MARKERS,
   getWrongProductionReasonFromUrl,
   getWrongProductionReasonForUnknownCritic,
   urlLooksLikeReview,

--- a/scripts/lib/review-write-guard.js
+++ b/scripts/lib/review-write-guard.js
@@ -21,6 +21,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { parseRating } = require('./score-conversion-rules');
 
 // Fields that represent collected/scored data and must not be silently erased.
 // KEEP IN SYNC with .github/actions/push-review-texts/action.yml PROTECTED array.
@@ -172,6 +173,15 @@ function safeWriteReview(filePath, newData, options = {}) {
     console.warn(`[review-write-guard] originalScore is a number (${newData.originalScore}) in ${path.basename(filePath)} — should be a string. Caller: ${caller}`);
   }
 
+  // Schmigadoon 2026 bug #6 guard: assignedScore must be null or a finite number.
+  // Schema drift shipped "2/4 stars" (string) to reviews.json because some ingest
+  // path wrote the raw rating string into the numeric slot. Coerce known rating
+  // patterns via the shared parseRating() helper; null + log anything unparseable.
+  const coercion = coerceAssignedScore(newData, filePath);
+  if (coercion.changed) {
+    console.warn(`[review-write-guard] assignedScore coerced in ${path.basename(filePath)}: ${JSON.stringify(coercion.from)} → ${coercion.to} (${coercion.reason})`);
+  }
+
   // Pattern Card #4: URL collision detection — warn before writing a file whose URL
   // already exists in another file in the same show directory.
   if (!force && newData.url) {
@@ -279,4 +289,79 @@ function _normalizeUrlForCollision(url) {
   }
 }
 
-module.exports = { safeWriteReview, checkForDataLoss, getEffectiveProtectedFields, checkUrlCollision, PROTECTED_FIELDS };
+/**
+ * Coerce a non-numeric assignedScore into a number, or null it if unparseable.
+ *
+ * Schmigadoon 2026 shipped the NY Post review with assignedScore="2/4 stars"
+ * (string) because schema drift let a raw rating string land in the numeric
+ * slot. validate-data.js catches this post-rebuild, but the gate is too late —
+ * the bad value had already gone to subscribers. Block it at write time.
+ *
+ * Recognized patterns (via shared parseRating()): "N/N stars", "N stars",
+ * "B+" / letter grades, sentiment words, bare numeric strings. Anything else
+ * becomes null + flag, and the caller's stderr shows the coercion.
+ *
+ * @param {object} data The review-text JSON object (mutated in place).
+ * @param {string} [filePath] Optional, only used for log context.
+ * @returns {{ changed: boolean, from?: any, to: number|null, reason?: string }}
+ */
+function coerceAssignedScore(data, filePath) {
+  const val = data.assignedScore;
+  // Already the right shape (null, undefined, or finite number) — no-op.
+  if (val === null || val === undefined) return { changed: false, to: val ?? null };
+  if (typeof val === 'number' && Number.isFinite(val)) return { changed: false, to: val };
+
+  const original = val;
+
+  // First preference: originalScoreNormalized is the authoritative 0-100 form
+  // that setExtractedScore() already wrote from the extractor's normalizedScore.
+  // If it's present and sane, trust it.
+  if (
+    typeof data.originalScoreNormalized === 'number' &&
+    Number.isFinite(data.originalScoreNormalized) &&
+    data.originalScoreNormalized >= 0 &&
+    data.originalScoreNormalized <= 100
+  ) {
+    data.assignedScore = data.originalScoreNormalized;
+    data._assignedScoreCoercedFrom = original;
+    data._assignedScoreCoercedAt = new Date().toISOString();
+    return {
+      changed: true,
+      from: original,
+      to: data.originalScoreNormalized,
+      reason: 'from-originalScoreNormalized',
+    };
+  }
+
+  // Second preference: string form that parseRating() understands (stars, grades, etc.).
+  if (typeof val === 'string') {
+    const parsed = parseRating(val);
+    if (
+      parsed &&
+      !parsed.unparseable &&
+      typeof parsed.expected === 'number' &&
+      Number.isFinite(parsed.expected)
+    ) {
+      data.assignedScore = parsed.expected;
+      data._assignedScoreCoercedFrom = original;
+      data._assignedScoreCoercedAt = new Date().toISOString();
+      return {
+        changed: true,
+        from: original,
+        to: parsed.expected,
+        reason: `parsed-as-${parsed.type}`,
+      };
+    }
+  }
+
+  // Unrecoverable: null the score and flag for human review so the bad value
+  // can't propagate to reviews.json. Rebuild will skip this review.
+  data.assignedScore = null;
+  data._assignedScoreCoercionFailed = true;
+  data._assignedScoreCoercedFrom = original;
+  data._assignedScoreCoercedAt = new Date().toISOString();
+  data.needsReview = true;
+  return { changed: true, from: original, to: null, reason: 'unparseable' };
+}
+
+module.exports = { safeWriteReview, checkForDataLoss, getEffectiveProtectedFields, checkUrlCollision, coerceAssignedScore, PROTECTED_FIELDS };

--- a/scripts/lib/url-discovery.js
+++ b/scripts/lib/url-discovery.js
@@ -14,7 +14,7 @@ const fs = require('fs');
 const path = require('path');
 const scraper = require('./scraper');
 const { domainMatchesExpected, setRegistryDomainAliases } = scraper;
-const { isUrlYearOutsideWindow } = require('./content-filters');
+const { isUrlYearOutsideWindow, hasTryoutUrlMarker } = require('./content-filters');
 const { isLondonMarket } = require('./venue-classification');
 const { urlLooksLikeReview } = require('./review-guards');
 
@@ -61,6 +61,28 @@ const DOMAIN_REDIRECTS = {
 };
 
 let _showsJsonCache = null;
+
+// Per-show tryout/TV/film/world-premiere URL rejection counter.
+// Keyed by showId (or '__global__' when no showId available).
+// Exposed via getTryoutRejectionStats() for instrumentation / broadcast-time audit.
+const _tryoutRejections = new Map();
+function _recordTryoutRejection(showId, marker, url) {
+  const key = showId || '__global__';
+  if (!_tryoutRejections.has(key)) _tryoutRejections.set(key, []);
+  _tryoutRejections.get(key).push({ marker, url });
+}
+
+function getTryoutRejectionStats() {
+  const out = {};
+  for (const [showId, entries] of _tryoutRejections.entries()) {
+    out[showId] = { count: entries.length, entries };
+  }
+  return out;
+}
+
+function resetTryoutRejectionStats() {
+  _tryoutRejections.clear();
+}
 
 /**
  * Look up show title and year from shows.json
@@ -554,6 +576,21 @@ async function discoverCorrectUrl(review, scrapingBeeKey, options = {}) {
     // TheaterMania /shows/ pages are listing pages, not reviews
     if (urlLower.includes('theatermania.com/shows/')) continue;
 
+    // Tryout / TV / film / world-premiere URL prefilter (Schmigadoon 2026 Bug #8).
+    // Rejects SERP results whose URL slug names a non-Broadway production of the
+    // same title — Kennedy Center / Apple TV / pre-Broadway / Old Globe / etc.
+    // Category gate: only apply to broadway/west-end/off-broadway shows; for
+    // historical/touring lookups we may legitimately want those results.
+    const isBroadwayLike = ['broadway', 'west-end', 'off-broadway', 'off-west-end'].includes(showInfo.category);
+    if (isBroadwayLike) {
+      const tryoutCheck = hasTryoutUrlMarker(url);
+      if (tryoutCheck.rejected) {
+        _recordTryoutRejection(review.showId, tryoutCheck.marker, url);
+        log(`    [SKIP] Tryout/non-Broadway URL marker "${tryoutCheck.marker}": ${url.substring(0, 100)}`);
+        continue;
+      }
+    }
+
     // Skip URLs whose embedded year is outside the production window
     const openYear = showInfo.year ? parseInt(showInfo.year) : null;
     const closeYear = showInfo.closingDate ? new Date(showInfo.closingDate).getFullYear() : null;
@@ -728,4 +765,6 @@ module.exports = {
   calculateDateWindow,
   buildDateTbs,
   validateUrlDomain,
+  getTryoutRejectionStats,
+  resetTryoutRejectionStats,
 };

--- a/scripts/pause-rebuild.js
+++ b/scripts/pause-rebuild.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * Pause/resume rebuild-all-reviews.js (Schmigadoon 2026 Bug #12).
+ *
+ * On opening morning, a direct hand-edit to reviews.json races any rebuild
+ * that CI has queued or is running. This script writes a tombstone the
+ * rebuild script reads at startup — if the tombstone is fresh, rebuild
+ * exits cleanly (exit 0) without touching reviews.json.
+ *
+ * USAGE
+ *   node scripts/pause-rebuild.js --minutes=30 --reason="opening-night hotfix"
+ *   node scripts/pause-rebuild.js --minutes=30 --cancel-in-flight   # also cancel running rebuild-reviews runs
+ *   node scripts/pause-rebuild.js --clear
+ *   node scripts/pause-rebuild.js --status
+ *
+ * The tombstone lives at data/audit/rebuild-pause.json and must be COMMITTED
+ * + PUSHED to the public repo for CI rebuild runs to see it. This script
+ * writes the file; the caller is responsible for the commit/push (so the
+ * pause workflow lives alongside the manual edit workflow).
+ *
+ * --cancel-in-flight additionally invokes `gh run cancel` on any currently-
+ * running "Rebuild Reviews Data" or "Rebuild Reviews (Fast)" runs, because
+ * a tombstone only stops the NEXT run, not one already past its startup check.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const { REBUILD_PAUSE_PATH, readRebuildPause } = require('./lib/rebuild-pause');
+
+function parseArgs(argv) {
+  const args = { clear: false, status: false, cancel: false, minutes: null, reason: '', pausedBy: '' };
+  for (const a of argv.slice(2)) {
+    if (a === '--clear') args.clear = true;
+    else if (a === '--status') args.status = true;
+    else if (a === '--cancel-in-flight') args.cancel = true;
+    else if (a.startsWith('--minutes=')) args.minutes = parseInt(a.split('=')[1], 10);
+    else if (a.startsWith('--reason=')) args.reason = a.slice('--reason='.length);
+    else if (a.startsWith('--paused-by=')) args.pausedBy = a.slice('--paused-by='.length);
+  }
+  return args;
+}
+
+function printStatus() {
+  const entry = readRebuildPause();
+  if (!entry) {
+    console.log('No rebuild-pause tombstone. Rebuild runs normally.');
+    return 0;
+  }
+  const now = Date.now();
+  const active = entry.until.getTime() > now;
+  const minutesLeft = Math.round((entry.until.getTime() - now) / 60000);
+  console.log(`Rebuild pause tombstone: ${REBUILD_PAUSE_PATH}`);
+  console.log(`  Active:    ${active ? 'YES' : 'no (expired)'}`);
+  console.log(`  Reason:    ${entry.reason || '(none)'}`);
+  console.log(`  Paused by: ${entry.pausedBy || '(unknown)'}`);
+  console.log(`  Paused at: ${entry.pausedAt || '(unknown)'}`);
+  console.log(`  Until:     ${entry.until.toISOString()}${active ? ` (${minutesLeft}min left)` : ''}`);
+  return 0;
+}
+
+function clear() {
+  if (!fs.existsSync(REBUILD_PAUSE_PATH)) {
+    console.log('No tombstone to clear.');
+    return 0;
+  }
+  fs.unlinkSync(REBUILD_PAUSE_PATH);
+  console.log(`Cleared tombstone: ${REBUILD_PAUSE_PATH}`);
+  console.log('Remember to commit + push so CI rebuilds see the cleared state.');
+  return 0;
+}
+
+function cancelInFlightRebuilds() {
+  const workflows = ['Rebuild Reviews Data', 'Rebuild Reviews (Fast)'];
+  let cancelled = 0;
+  for (const wf of workflows) {
+    let runIds = [];
+    try {
+      const out = execSync(
+        `gh run list --workflow="${wf}" --status=in_progress --json=databaseId --jq=".[].databaseId"`,
+        { encoding: 'utf8' }
+      );
+      runIds = out.split('\n').map((s) => s.trim()).filter(Boolean);
+    } catch (e) {
+      console.log(`  (skip ${wf}: gh run list failed — ${e.message.split('\n')[0]})`);
+      continue;
+    }
+    if (runIds.length === 0) {
+      console.log(`  ${wf}: no in-flight runs`);
+      continue;
+    }
+    for (const id of runIds) {
+      try {
+        execSync(`gh run cancel ${id}`, { encoding: 'utf8' });
+        console.log(`  ${wf}: cancelled run ${id}`);
+        cancelled += 1;
+      } catch (e) {
+        console.log(`  ${wf}: failed to cancel ${id} — ${e.message.split('\n')[0]}`);
+      }
+    }
+  }
+  if (cancelled > 0) {
+    console.log(`Cancelled ${cancelled} in-flight run(s). Cancellation can take ~60s to propagate.`);
+  }
+  return cancelled;
+}
+
+function setPause({ minutes, reason, pausedBy }) {
+  const pausedAt = new Date();
+  const until = new Date(pausedAt.getTime() + minutes * 60000);
+  const dir = path.dirname(REBUILD_PAUSE_PATH);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const body = {
+    pausedAt: pausedAt.toISOString(),
+    until: until.toISOString(),
+    ttlMinutes: minutes,
+    reason: reason || '',
+    pausedBy: pausedBy || process.env.USER || 'unknown',
+  };
+  fs.writeFileSync(REBUILD_PAUSE_PATH, JSON.stringify(body, null, 2) + '\n');
+  console.log(`Paused rebuild for ${minutes} minute(s).`);
+  console.log(`  File:   ${REBUILD_PAUSE_PATH}`);
+  console.log(`  Until:  ${until.toISOString()}`);
+  console.log(`  Reason: ${body.reason || '(none)'}`);
+  console.log('');
+  console.log('NEXT STEPS:');
+  console.log('  1. Commit + push this file so CI rebuilds see the pause:');
+  console.log('       git add data/audit/rebuild-pause.json');
+  console.log('       git commit -m "chore: pause rebuild for opening-night hotfix"');
+  console.log('       git push');
+  console.log('  2. Apply your manual edit to reviews.json in broadway-scorecard-data.');
+  console.log('  3. Clear the tombstone once the edit is deployed:');
+  console.log('       node scripts/pause-rebuild.js --clear');
+  return 0;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  if (args.status) return printStatus();
+  if (args.clear) return clear();
+
+  if (!args.minutes || !Number.isFinite(args.minutes) || args.minutes < 1) {
+    console.error('ERROR: --minutes=<N> is required to set a pause (integer >= 1).');
+    console.error('       Use --status to inspect, --clear to remove an existing pause.');
+    process.exit(2);
+  }
+  if (args.minutes > 180) {
+    console.error('ERROR: --minutes capped at 180 (3h). Pauses longer than a single opening');
+    console.error('       broadcast window are almost always unintentional. If you genuinely');
+    console.error('       need this, re-run after 180 min or extend the cap deliberately.');
+    process.exit(2);
+  }
+
+  const rc = setPause(args);
+  if (args.cancel) {
+    console.log('');
+    console.log('Cancelling in-flight rebuild runs…');
+    cancelInFlightRebuilds();
+  }
+  return rc;
+}
+
+process.exit(main());

--- a/scripts/rebuild-all-reviews.js
+++ b/scripts/rebuild-all-reviews.js
@@ -47,6 +47,7 @@ const { shouldAutoClearWrongProduction, shouldAutoClearWrongShow } = require('./
 const { safeWriteReview } = require('./lib/review-write-guard');
 const { KNOWN_SYNDICATION_PAIRS } = require('./lib/syndication-pairs');
 const { logExclusion: _sharedLogExclusion } = require('./lib/exclusion-logger');
+const { isRebuildPaused, readRebuildPause, REBUILD_PAUSE_PATH } = require('./lib/rebuild-pause');
 
 // Authoritative NYT Critic's Pick set — union of two sources:
 //   1. data/nyt-critics-picks.json — scraped from nytimes.com/spotlight/theater-critics-picks
@@ -735,6 +736,28 @@ function getBestScore(data) {
 // Main execution
 console.log('=== REBUILDING ALL REVIEWS ===\n');
 console.log('NOTE: Reviews without valid scores are EXCLUDED (no default of 50)\n');
+
+// Rebuild-pause guard (Schmigadoon 2026 Bug #12).
+// If a manual opening-night edit has set a tombstone, exit cleanly BEFORE any
+// reads or writes. This prevents a concurrent rebuild from overwriting a
+// hand-edited reviews.json during the 10am broadcast window.
+// Bypass with --ignore-pause if the tombstone is stale and you know what
+// you're doing. Tombstone format + write-side CLI: scripts/pause-rebuild.js.
+if (!process.argv.includes('--ignore-pause') && isRebuildPaused()) {
+  const entry = readRebuildPause();
+  console.log('⏸  REBUILD PAUSED by opening-night manual-edit tombstone');
+  console.log(`   File:      ${REBUILD_PAUSE_PATH}`);
+  console.log(`   Reason:    ${entry.reason || '(none given)'}`);
+  console.log(`   Paused by: ${entry.pausedBy || '(unknown)'}`);
+  console.log(`   Paused at: ${entry.pausedAt || '(unknown)'}`);
+  console.log(`   Until:     ${entry.until.toISOString()}`);
+  console.log('');
+  console.log('   Clear:   node scripts/pause-rebuild.js --clear');
+  console.log('   Bypass:  node scripts/rebuild-all-reviews.js --ignore-pause');
+  console.log('');
+  console.log('Exiting cleanly (exit 0) so CI does not alert — pause is intentional.');
+  process.exit(0);
+}
 
 // Load show dates and status for production-date guard
 const showsData = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'data', 'shows.json'), 'utf8'));

--- a/scripts/rebuild-all-reviews.js
+++ b/scripts/rebuild-all-reviews.js
@@ -38,7 +38,7 @@ const { parseStarRating, parseLetterGrade, parseOriginalScore, LETTER_GRADE_OUTL
 const { excerptMentionsWrongShow, isTourReviewExcerpt, isFilmTvReview } = require('./lib/excerpt-validation');
 const { shouldRejectAsReservation, isInternalNote, hasCopyrightChrome } = require('./lib/pull-quote-guards');
 const { emitStage } = require('./lib/stage-latency');
-const { isRoundupUrl, isVenueMismatch, shouldSkipWrongProductionAudit, buildShowKeywordSet, findShowKeywordInText, checkLlmVerificationAgainstKeywords, pickRerouteTarget, buildMultiProdYearGuard, isIncludableForRebuild } = require('./lib/review-guards');
+const { isRoundupUrl, isVenueMismatch, shouldSkipWrongProductionAudit, buildShowKeywordSet, findShowKeywordInText, checkLlmVerificationAgainstKeywords, pickRerouteTarget, buildMultiProdYearGuard, isIncludableForRebuild, hasStrongDifferentShowSignal } = require('./lib/review-guards');
 const { normalizeThumb, normalizePublishDate, fixMojibake, fixMissingPeriods, isJunkExcerpt, isGenericQuote, trimToCompleteSentence, normalizeQuoteWrapping, cleanExcerpt, isContentVerificationActive, getBestScore: _getBestScoreCore, scoreToBucket, scoreToThumb, extractDateFromUrl } = require('./lib/rebuild-helpers');
 const { isLondonMarket, isUkOutletUrl } = require('./lib/venue-classification');
 const { isBlockedReviewUrl } = require('./lib/domain-filters');
@@ -1209,7 +1209,14 @@ const crossShowFingerprints = new Map();
       try {
         const d = JSON.parse(fs.readFileSync(path.join(sDir, f), 'utf8'));
         const cv = d.contentVerification;
-        if (!cv || (cv.confidence !== 'high' && cv.confidence !== 'medium')) continue;
+        if (!cv) continue;
+        // Schmigadoon 2026-04-21 bypass: CV rows with confidence='low' AND explicit
+        // "completely different show" markers are treated as eligible for promotion.
+        // The temporal override downgraded them, but the CV.issues evidence is definitive.
+        const cvLowButStrong = cv.confidence === 'low'
+          && cv.wrongProduction === true
+          && hasStrongDifferentShowSignal(cv.issues, cv.reasoning);
+        if (cv.confidence !== 'high' && cv.confidence !== 'medium' && !cvLowButStrong) continue;
         // Staleness check
         let stale = false;
         if (d.textFetchedAt && cv.verifiedAt) {
@@ -1232,8 +1239,12 @@ const crossShowFingerprints = new Map();
             && !shouldSkipWrongProductionAudit(d) && !d.allowEarlyDate && !d.allowCrossMarket) {
           // [GUARD:CV-PRE-PASS] DoaS Apr 9-10 #10: was the source of the bug.
           d.wrongProduction = true;
-          d.wrongProductionReason = d.wrongProductionReason || `CV-promoted: ${(cv.reasoning || '').substring(0, 200)}`;
+          const promotionPath = cvLowButStrong ? 'CV-low-but-strong-signal' : 'CV-promoted';
+          d.wrongProductionReason = d.wrongProductionReason || `${promotionPath}: ${(cv.reasoning || '').substring(0, 200)}`;
           promoted = true;
+          if (cvLowButStrong) {
+            stats.cvLowStrongSignalPromoted = (stats.cvLowStrongSignalPromoted || 0) + 1;
+          }
         }
         const wpConf = cv.confidence || 'medium';
         const skipLondon = isLondonMarket(sCat) && isUkOutletUrl(d.url) && wpConf !== 'high';
@@ -1631,7 +1642,17 @@ showDirs.forEach(showId => {
       // (contentVerification may be set by a different pipeline than the one that creates the file)
       // IMPORTANT: Skip promotion if contentVerification is stale — i.e., the fullText was
       // fetched AFTER verification ran. The verification was done on old/bad content.
-      if (data.contentVerification && (data.contentVerification.confidence === 'high' || data.contentVerification.confidence === 'medium')) {
+      //
+      // Schmigadoon 2026-04-21 bypass: CV rows with confidence='low' AND explicit
+      // "completely different show" markers in issues/reasoning (e.g., EBT-as-Schmigadoon)
+      // are also promoted. The temporal override downgraded them to 'low' but the
+      // evidence is definitive, not a subtle LLM FP. hasStrongDifferentShowSignal
+      // identifies those rows.
+      const cvLowButStrong = data.contentVerification
+        && data.contentVerification.confidence === 'low'
+        && data.contentVerification.wrongProduction === true
+        && hasStrongDifferentShowSignal(data.contentVerification.issues, data.contentVerification.reasoning);
+      if (data.contentVerification && (data.contentVerification.confidence === 'high' || data.contentVerification.confidence === 'medium' || cvLowButStrong)) {
         const cv = data.contentVerification;
 
         // Staleness check: if text was fetched after verification, skip promotion
@@ -1668,15 +1689,22 @@ showDirs.forEach(showId => {
           // Only promote wrongProduction if:
           // 1. Not already flagged, no override/manual clear
           // 2. LLM confidence is high or medium (skip low — likely temporal proximity override)
+          //    EXCEPTION: low confidence + strong "different show" markers in issues/reasoning
+          //    still promote — that's definitive evidence, not a subtle FP near opening.
           const wpConfidence = cv.confidence || 'medium';
           const isHighMediumConfidence = wpConfidence === 'high' || wpConfidence === 'medium';
+          const promotionEligibleConfidence = isHighMediumConfidence || cvLowButStrong;
           if (cv.wrongProduction === true && data.wrongProduction !== true
               && !shouldSkipWrongProductionAudit(data)
-              && isHighMediumConfidence && !data.allowEarlyDate && !data.allowCrossMarket) {
+              && promotionEligibleConfidence && !data.allowEarlyDate && !data.allowCrossMarket) {
             // [GUARD:CV-MAIN-LOOP]
             data.wrongProduction = true;
-            data.wrongProductionReason = `CV-promoted: ${(cv.reasoning || '').substring(0, 200)}`;
+            const promotionPath = cvLowButStrong ? 'CV-low-but-strong-signal' : 'CV-promoted';
+            data.wrongProductionReason = `${promotionPath}: ${(cv.reasoning || '').substring(0, 200)}`;
             promoted = true;
+            if (cvLowButStrong) {
+              stats.cvLowStrongSignalPromoted = (stats.cvLowStrongSignalPromoted || 0) + 1;
+            }
           }
           // Skip London/UK auto-promotion UNLESS LLM confidence is high (high-confidence
           // wrongArticle means the fetched text is genuinely for a different show/venue)

--- a/scripts/validate-data.js
+++ b/scripts/validate-data.js
@@ -2649,17 +2649,48 @@ function validateUnscoredReviewTexts() {
   const orphanedGaps = gaps.filter((g) => !g.pending);
 
   if (pendingGaps.length > 0) {
-    console.log('');
-    console.log('  Pending scoring (scoreExtractionPending=true) — first 5:');
-    for (const g of pendingGaps.slice(0, 5)) {
-      console.log(`    ${g.showDir}/${g.file} | ${g.outlet} / ${g.critic} | tier=${g.tier} age=${g.ageDays}d`);
-    }
-    if (pendingGaps.length > 5) console.log(`    ... and ${pendingGaps.length - 5} more`);
-    console.log('');
-    warn(
-      `${pendingGaps.length} review-text file(s) marked scoreExtractionPending ` +
-      `but not yet scored — pipeline should pick them up on next run`
+    // Split fresh vs stuck. Files that have been scoreExtractionPending for
+    // more than STUCK_PENDING_DAYS are a louder signal — the scorer should
+    // have picked them up by now. Schmigadoon 2026 Bug #11: pending files sat
+    // for weeks because nothing audited staleness.
+    const STUCK_PENDING_DAYS = 7;
+    const stuckPendingGaps = pendingGaps.filter(
+      (g) => g.ageDays != null && g.ageDays > STUCK_PENDING_DAYS
     );
+    const freshPendingGaps = pendingGaps.filter(
+      (g) => !(g.ageDays != null && g.ageDays > STUCK_PENDING_DAYS)
+    );
+
+    if (freshPendingGaps.length > 0) {
+      console.log('');
+      console.log(`  Pending scoring (scoreExtractionPending=true, age ≤ ${STUCK_PENDING_DAYS}d) — first 5:`);
+      for (const g of freshPendingGaps.slice(0, 5)) {
+        console.log(`    ${g.showDir}/${g.file} | ${g.outlet} / ${g.critic} | tier=${g.tier} age=${g.ageDays}d`);
+      }
+      if (freshPendingGaps.length > 5) console.log(`    ... and ${freshPendingGaps.length - 5} more`);
+      console.log('');
+      warn(
+        `${freshPendingGaps.length} review-text file(s) marked scoreExtractionPending ` +
+        `but not yet scored — pipeline should pick them up on next run`
+      );
+    }
+
+    if (stuckPendingGaps.length > 0) {
+      console.log('');
+      console.log(`  STUCK pending scoring (scoreExtractionPending=true, age > ${STUCK_PENDING_DAYS}d) — first 5:`);
+      for (const g of stuckPendingGaps.slice(0, 5)) {
+        console.log(`    ${g.showDir}/${g.file} | ${g.outlet} / ${g.critic} | tier=${g.tier} age=${g.ageDays}d`);
+      }
+      if (stuckPendingGaps.length > 5) console.log(`    ... and ${stuckPendingGaps.length - 5} more`);
+      console.log('');
+      warn(
+        `${stuckPendingGaps.length} review-text file(s) have been scoreExtractionPending ` +
+        `for more than ${STUCK_PENDING_DAYS} days — the pipeline has NOT picked them up. ` +
+        `Fix: run \`node scripts/retry-pending-scores.js --show=<show-id>\` or flag them ` +
+        `with rejectionReason/wrongProduction if they should be excluded. ` +
+        `Leaving stuck pending files accumulates silent scoring gaps.`
+      );
+    }
   }
 
   if (orphanedGaps.length > 0) {

--- a/tests/unit/anticipatory-preview-gate.test.mjs
+++ b/tests/unit/anticipatory-preview-gate.test.mjs
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for isAnticipatoryPreviewPost
+ * (scripts/lib/content-filters.js — Schmigadoon 2026 Bug #5).
+ *
+ * Background: For Schmigadoon's 2026-04-20 opening, a frontmezzjunkies
+ * post published 2026-04-04 (16 days pre-opening) was treated as a
+ * review and scored 76. frontmezzjunkies routinely publishes "anticipation"
+ * pieces pre-opening — well-written, excited, but not reviews.
+ *
+ * This gate fires INSIDE collect-review-texts.js/updateReviewJson right
+ * after publishDate extraction, BEFORE the file is written. A miss here =
+ * an anticipatory preview piece reaching reviews.json as a scored review.
+ *
+ * Mirrors semantics of the post-broadcast audit check at
+ * scripts/lib/opening-night-checks/publish-date-pre-opening.check.js
+ * (GRACE_DAYS_BEFORE_OPENING = 2 for default outlets).
+ *
+ * Preview-heavy outlets use a tighter 0-day grace: must publish on or
+ * after openingDate.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const {
+  isAnticipatoryPreviewPost,
+  PREVIEW_HEAVY_OUTLETS,
+  DEFAULT_GRACE_DAYS_BEFORE_OPENING,
+  PREVIEW_HEAVY_GRACE_DAYS,
+} = require('../../scripts/lib/content-filters.js');
+
+describe('PREVIEW_HEAVY_OUTLETS catalogue integrity', () => {
+  test('includes frontmezzjunkies (Schmigadoon 2026 incident)', () => {
+    assert.ok(PREVIEW_HEAVY_OUTLETS.has('frontmezzjunkies'));
+  });
+
+  test('includes Broadway Direct (both spellings)', () => {
+    assert.ok(PREVIEW_HEAVY_OUTLETS.has('broadwaydirect'));
+    assert.ok(PREVIEW_HEAVY_OUTLETS.has('broadway-direct'));
+  });
+
+  test('does NOT include T1 news outlets (legitimate embargo-lift coverage)', () => {
+    for (const t1 of ['nyt', 'variety', 'hollywoodreporter', 'vulture', 'wsj']) {
+      assert.ok(!PREVIEW_HEAVY_OUTLETS.has(t1), `T1 outlet "${t1}" should not be preview-heavy`);
+    }
+  });
+
+  test('default grace is 2 days; preview-heavy grace is 0', () => {
+    assert.strictEqual(DEFAULT_GRACE_DAYS_BEFORE_OPENING, 2);
+    assert.strictEqual(PREVIEW_HEAVY_GRACE_DAYS, 0);
+  });
+});
+
+describe('isAnticipatoryPreviewPost — Schmigadoon 2026 regression', () => {
+  test('frontmezzjunkies 16 days before opening → rejected', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-04', '2026-04-20', 'frontmezzjunkies');
+    assert.strictEqual(r.rejected, true);
+    assert.strictEqual(r.outletCategory, 'preview-heavy');
+    assert.strictEqual(r.daysBeforeOpening, 16);
+    assert.match(r.reason, /preview-heavy/);
+  });
+
+  test('humanReviewedEarlyPublish=true bypasses the gate (curator override)', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-04', '2026-04-20', 'frontmezzjunkies', {
+      humanReviewedEarlyPublish: true,
+    });
+    assert.strictEqual(r.rejected, false);
+  });
+});
+
+describe('isAnticipatoryPreviewPost — preview-heavy outlets (0-day grace)', () => {
+  test('frontmezzjunkies 1 day before opening → rejected', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-19', '2026-04-20', 'frontmezzjunkies');
+    assert.strictEqual(r.rejected, true);
+    assert.strictEqual(r.outletCategory, 'preview-heavy');
+  });
+
+  test('frontmezzjunkies exactly on opening day → passes', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-20', '2026-04-20', 'frontmezzjunkies');
+    assert.strictEqual(r.rejected, false);
+  });
+
+  test('frontmezzjunkies 1 day after opening → passes', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-21', '2026-04-20', 'frontmezzjunkies');
+    assert.strictEqual(r.rejected, false);
+  });
+
+  test('broadwaydirect 5 days before opening → rejected', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-15', '2026-04-20', 'broadwaydirect');
+    assert.strictEqual(r.rejected, true);
+    assert.strictEqual(r.outletCategory, 'preview-heavy');
+  });
+
+  test('broadway-direct alias also rejected', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-15', '2026-04-20', 'broadway-direct');
+    assert.strictEqual(r.rejected, true);
+  });
+
+  test('outlet id is case-insensitive', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-04', '2026-04-20', 'FrontMezzJunkies');
+    assert.strictEqual(r.rejected, true);
+    assert.strictEqual(r.outletCategory, 'preview-heavy');
+  });
+});
+
+describe('isAnticipatoryPreviewPost — non-preview outlets (2-day grace)', () => {
+  test('NYT 2 days before opening → passes (within default grace)', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-18', '2026-04-20', 'nyt');
+    assert.strictEqual(r.rejected, false);
+  });
+
+  test('NYT 3 days before opening → rejected (exceeds 2-day grace)', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-17', '2026-04-20', 'nyt');
+    assert.strictEqual(r.rejected, true);
+    assert.strictEqual(r.outletCategory, 'default');
+    assert.strictEqual(r.daysBeforeOpening, 3);
+  });
+
+  test('Variety on opening day → passes', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-20', '2026-04-20', 'variety');
+    assert.strictEqual(r.rejected, false);
+  });
+
+  test('retrospective review (historical show, publishDate = openingDate) → passes', () => {
+    const r = isAnticipatoryPreviewPost('2015-08-06', '2015-08-06', 'nyt');
+    assert.strictEqual(r.rejected, false);
+  });
+
+  test('post-opening NYT review → passes', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-25', '2026-04-20', 'nyt');
+    assert.strictEqual(r.rejected, false);
+  });
+});
+
+describe('isAnticipatoryPreviewPost — opts.graceDays overrides', () => {
+  test('opts.graceDays overrides default for non-preview outlet', () => {
+    // With graceDays=7, a 5-day-before review passes that would otherwise be rejected
+    const r = isAnticipatoryPreviewPost('2026-04-15', '2026-04-20', 'nyt', { graceDays: 7 });
+    assert.strictEqual(r.rejected, false);
+  });
+
+  test('opts.gracePreviewHeavyOutlet overrides for preview-heavy outlet', () => {
+    // With gracePreviewHeavyOutlet=10, a 5-day frontmezz review passes
+    const r = isAnticipatoryPreviewPost('2026-04-15', '2026-04-20', 'frontmezzjunkies', {
+      gracePreviewHeavyOutlet: 10,
+    });
+    assert.strictEqual(r.rejected, false);
+  });
+});
+
+describe('isAnticipatoryPreviewPost — fail-safe defaults', () => {
+  test('null publishDate → fail-open (not rejected)', () => {
+    const r = isAnticipatoryPreviewPost(null, '2026-04-20', 'frontmezzjunkies');
+    assert.strictEqual(r.rejected, false);
+  });
+
+  test('null openingDate → fail-open', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-04', null, 'frontmezzjunkies');
+    assert.strictEqual(r.rejected, false);
+  });
+
+  test('invalid date string → fail-open', () => {
+    const r = isAnticipatoryPreviewPost('not-a-date', '2026-04-20', 'frontmezzjunkies');
+    assert.strictEqual(r.rejected, false);
+  });
+
+  test('null outletId → defaults to non-preview grace', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-18', '2026-04-20', null);
+    assert.strictEqual(r.rejected, false); // within 2-day grace
+    const r2 = isAnticipatoryPreviewPost('2026-04-17', '2026-04-20', null);
+    assert.strictEqual(r2.rejected, true); // exceeds 2-day grace
+    assert.strictEqual(r2.outletCategory, 'default');
+  });
+
+  test('empty opts object behaves as defaults', () => {
+    const r = isAnticipatoryPreviewPost('2026-04-04', '2026-04-20', 'frontmezzjunkies', {});
+    assert.strictEqual(r.rejected, true);
+  });
+});

--- a/tests/unit/content-verifier.test.mjs
+++ b/tests/unit/content-verifier.test.mjs
@@ -18,6 +18,39 @@ const { heuristicVerify, quickValidityCheck, contentHash } = require('../../scri
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE = path.join(__dirname, '..', 'fixtures', 'content-verifier-golden', 'real-world-fixtures.json');
 
+describe('prompt language ship-check (Schmigadoon 2026 Bug #7)', () => {
+  // The LLM call sends the prompt built inside verifyContent; we read the function
+  // source to prove the "Reviews OF vs mentions OF" language is still present.
+  // This is a ship-check, not a behavior check — behavior lives in the eval harness.
+  const srcPath = path.join(__dirname, '..', '..', 'scripts', 'lib', 'content-verifier.js');
+  const source = fs.readFileSync(srcPath, 'utf8');
+
+  test('prompt contains the Kennedy-Center-mention FP guardrail', () => {
+    assert.ok(
+      source.includes('"Reviews OF" vs "mentions OF"'),
+      'CV prompt must include the "Reviews OF vs mentions OF" nuance'
+    );
+    assert.ok(
+      source.includes('Schmigadoon 2026 FP class'),
+      'CV prompt must cite the Schmigadoon 2026 FP class so future editors know why'
+    );
+  });
+
+  test('prompt tells the LLM not to flag on mention alone', () => {
+    assert.ok(
+      /Do not flag on mention alone/.test(source),
+      'CV prompt must explicitly say "Do not flag on mention alone"'
+    );
+  });
+
+  test('prompt demands high confidence when flagging wrongProduction', () => {
+    assert.ok(
+      /set wrongProduction=true with confidence="high"/.test(source),
+      'CV prompt must require confidence=high for wrongProduction=true'
+    );
+  });
+});
+
 describe('heuristicVerify fallback', () => {
   test('short content -> invalid', () => {
     const r = heuristicVerify({ scrapedText: 'tiny', showTitle: 'Wicked' });

--- a/tests/unit/rebuild-pause.test.mjs
+++ b/tests/unit/rebuild-pause.test.mjs
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for scripts/lib/rebuild-pause.js (Schmigadoon 2026 Bug #12).
+ *
+ * This lib is the read-side of the opening-night rebuild-pause tombstone.
+ * A miss here means a rebuild could race a hand-edited reviews.json during
+ * the morning broadcast window (the Schmigadoon 2026 scenario).
+ *
+ * Fail-open semantics are load-bearing: a corrupt or missing tombstone must
+ * NOT pause rebuilds permanently. We explicitly test the failure modes.
+ */
+
+import { test, describe, before, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { isRebuildPaused, readRebuildPause } = require('../../scripts/lib/rebuild-pause.js');
+
+// Use a temp file per test run so we don't touch the real tombstone path.
+let tmpDir;
+let tombstonePath;
+
+before(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rebuild-pause-test-'));
+  tombstonePath = path.join(tmpDir, 'rebuild-pause.json');
+});
+
+after(() => {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+function writeTombstone(body) {
+  fs.writeFileSync(tombstonePath, typeof body === 'string' ? body : JSON.stringify(body));
+}
+
+function clearTombstone() {
+  try { fs.unlinkSync(tombstonePath); } catch {}
+}
+
+describe('isRebuildPaused — fail-open defaults', () => {
+  test('missing file → not paused', () => {
+    clearTombstone();
+    assert.strictEqual(isRebuildPaused(Date.now(), tombstonePath), false);
+  });
+
+  test('invalid JSON → not paused (fail-open)', () => {
+    writeTombstone('not json {{');
+    assert.strictEqual(isRebuildPaused(Date.now(), tombstonePath), false);
+  });
+
+  test('missing `until` field → not paused', () => {
+    writeTombstone({ reason: 'no until' });
+    assert.strictEqual(isRebuildPaused(Date.now(), tombstonePath), false);
+  });
+
+  test('invalid `until` string → not paused', () => {
+    writeTombstone({ until: 'definitely-not-a-date' });
+    assert.strictEqual(isRebuildPaused(Date.now(), tombstonePath), false);
+  });
+
+  test('null body → not paused', () => {
+    writeTombstone('null');
+    assert.strictEqual(isRebuildPaused(Date.now(), tombstonePath), false);
+  });
+});
+
+describe('isRebuildPaused — active window', () => {
+  test('until is in the future → paused', () => {
+    const future = new Date(Date.now() + 30 * 60000).toISOString();
+    writeTombstone({ until: future, reason: 'opening-night hotfix' });
+    assert.strictEqual(isRebuildPaused(Date.now(), tombstonePath), true);
+  });
+
+  test('until is in the past → not paused (expired)', () => {
+    const past = new Date(Date.now() - 5 * 60000).toISOString();
+    writeTombstone({ until: past, reason: 'stale' });
+    assert.strictEqual(isRebuildPaused(Date.now(), tombstonePath), false);
+  });
+
+  test('until is exactly now → not paused (strict greater-than)', () => {
+    const now = Date.now();
+    writeTombstone({ until: new Date(now).toISOString(), reason: 'boundary' });
+    assert.strictEqual(isRebuildPaused(now, tombstonePath), false);
+  });
+
+  test('custom nowMs — tests pause at a specific simulated time', () => {
+    const until = new Date('2026-04-21T13:30:00Z').toISOString();
+    writeTombstone({ until });
+    // At 13:00, still paused
+    assert.strictEqual(
+      isRebuildPaused(new Date('2026-04-21T13:00:00Z').getTime(), tombstonePath),
+      true,
+    );
+    // At 14:00, no longer paused
+    assert.strictEqual(
+      isRebuildPaused(new Date('2026-04-21T14:00:00Z').getTime(), tombstonePath),
+      false,
+    );
+  });
+});
+
+describe('readRebuildPause — structured read', () => {
+  test('returns parsed fields when present', () => {
+    const until = new Date('2026-04-21T13:30:00Z').toISOString();
+    writeTombstone({
+      until,
+      pausedAt: '2026-04-21T13:00:00Z',
+      pausedBy: 'tompryor',
+      reason: 'opening-night hotfix',
+    });
+    const entry = readRebuildPause(tombstonePath);
+    assert.ok(entry);
+    assert.strictEqual(entry.until.toISOString(), until);
+    assert.strictEqual(entry.pausedAt, '2026-04-21T13:00:00Z');
+    assert.strictEqual(entry.pausedBy, 'tompryor');
+    assert.strictEqual(entry.reason, 'opening-night hotfix');
+  });
+
+  test('returns null on missing file', () => {
+    clearTombstone();
+    assert.strictEqual(readRebuildPause(tombstonePath), null);
+  });
+
+  test('coerces non-string fields to empty strings', () => {
+    writeTombstone({
+      until: new Date(Date.now() + 60000).toISOString(),
+      pausedAt: 12345,           // wrong type
+      pausedBy: { nested: 1 },   // wrong type
+      reason: ['array'],         // wrong type
+    });
+    const entry = readRebuildPause(tombstonePath);
+    assert.ok(entry);
+    assert.strictEqual(entry.pausedAt, '');
+    assert.strictEqual(entry.pausedBy, '');
+    assert.strictEqual(entry.reason, '');
+  });
+});

--- a/tests/unit/review-guards.test.mjs
+++ b/tests/unit/review-guards.test.mjs
@@ -15,6 +15,8 @@ const {
   checkLlmVerificationAgainstKeywords,
   pickRerouteTarget,
   shouldSkipWrongProductionAudit,
+  applyTemporalOverrides,
+  hasStrongDifferentShowSignal,
 } = require('../../scripts/lib/review-guards.js');
 
 describe('isLikelyWrongProduction', () => {
@@ -296,5 +298,102 @@ describe('shouldSkipWrongProductionAudit', () => {
 
   test('allowCrossMarket=false does not skip', () => {
     assert.strictEqual(shouldSkipWrongProductionAudit({ allowCrossMarket: false }), false);
+  });
+});
+
+describe('hasStrongDifferentShowSignal', () => {
+  test('empty/null inputs return false', () => {
+    assert.strictEqual(hasStrongDifferentShowSignal(null, null), false);
+    assert.strictEqual(hasStrongDifferentShowSignal([], ''), false);
+    assert.strictEqual(hasStrongDifferentShowSignal(undefined, undefined), false);
+  });
+
+  test('generic issues without strong markers return false', () => {
+    const issues = ['Text is truncated mid-sentence at 3678 characters', 'Review is short'];
+    assert.strictEqual(hasStrongDifferentShowSignal(issues, 'Generic LLM reasoning'), false);
+  });
+
+  test('"does not appear in" in issues → true', () => {
+    const issues = ["Expected show 'Schmigadoon!' does not appear in scraped content at all"];
+    assert.strictEqual(hasStrongDifferentShowSignal(issues, ''), true);
+  });
+
+  test('"completely different show" in issues → true', () => {
+    const issues = ['The production described is completely different show'];
+    assert.strictEqual(hasStrongDifferentShowSignal(issues, ''), true);
+  });
+
+  test('"reviews the wrong production" in reasoning → true', () => {
+    assert.strictEqual(
+      hasStrongDifferentShowSignal([], 'The critic reviews the wrong production entirely'),
+      true
+    );
+  });
+
+  test('"unrelated to the expected" in reasoning → true', () => {
+    assert.strictEqual(
+      hasStrongDifferentShowSignal([], 'The scraped content is unrelated to the expected Schmigadoon review'),
+      true
+    );
+  });
+
+  test('EBT-as-Schmigadoon fixture (real-world case)', () => {
+    // Exact issues/reasoning from 2026-04-21 Schmigadoon opening-night failure.
+    const issues = [
+      "Review is about 'Every Brilliant Thing' (Daniel Radcliffe one-person show), not 'Schmigadoon!'",
+      "Text is truncated mid-sentence at 3678 characters",
+      "Expected show 'Schmigadoon!' does not appear in scraped content at all",
+      "The production described features Daniel Radcliffe in a play by Duncan Macmillan and Jonny Donahoe — completely different show",
+    ];
+    assert.strictEqual(hasStrongDifferentShowSignal(issues, ''), true);
+  });
+});
+
+describe('applyTemporalOverrides — strong-signal bypass (Schmigadoon 2026-04-21 EBT class)', () => {
+  test('within-30d opening-week review without strong signal: downgrades as before', () => {
+    const r = applyTemporalOverrides(true, false, 'high', '2026-04-20', '2026-04-21');
+    assert.strictEqual(r.wpConfidence, 'low', 'opening-week FP is downgraded (preserves Giant safety net)');
+    assert.strictEqual(r.bypassedForStrongSignal, false);
+  });
+
+  test('within-30d opening-week review WITH strong "does not appear in" signal: bypass', () => {
+    const ebtIssues = [
+      "Expected show 'Schmigadoon!' does not appear in scraped content at all",
+      "completely different show",
+    ];
+    const r = applyTemporalOverrides(true, false, 'high', '2026-04-20', '2026-04-21', {
+      issues: ebtIssues,
+      reasoning: "reviews the wrong production entirely",
+    });
+    assert.strictEqual(r.wpConfidence, 'high', 'strong signal should NOT be downgraded');
+    assert.strictEqual(r.bypassedForStrongSignal, true);
+  });
+
+  test('within-30d + strong signal + medium confidence: retains medium', () => {
+    const r = applyTemporalOverrides(true, false, 'medium', '2026-04-20', '2026-04-21', {
+      issues: ['reviews the wrong production'],
+    });
+    assert.strictEqual(r.wpConfidence, 'medium');
+    assert.strictEqual(r.bypassedForStrongSignal, true);
+  });
+
+  test('strong signal but NOT wrongProduction flag: no-op', () => {
+    // If wpFlag=false, there's nothing to downgrade anyway. Just verify it doesn't throw.
+    const r = applyTemporalOverrides(false, false, 'high', '2026-04-20', '2026-04-21', {
+      issues: ['does not appear in content'],
+    });
+    assert.strictEqual(r.wpConfidence, 'high');
+    assert.strictEqual(r.bypassedForStrongSignal, true);
+  });
+
+  test('no cvContext: backward compat, old callers still work', () => {
+    const r = applyTemporalOverrides(true, false, 'high', '2026-04-20', '2026-04-21');
+    assert.strictEqual(r.wpConfidence, 'low');
+    assert.strictEqual(r.bypassedForStrongSignal, false);
+  });
+
+  test('outside-30d window: no downgrade regardless of signal', () => {
+    const r = applyTemporalOverrides(true, false, 'high', '2026-04-20', '2026-02-01');
+    assert.strictEqual(r.wpConfidence, 'high');
   });
 });

--- a/tests/unit/review-write-guard.test.mjs
+++ b/tests/unit/review-write-guard.test.mjs
@@ -8,7 +8,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
-const { safeWriteReview, checkForDataLoss, checkUrlCollision } = require('../../scripts/lib/review-write-guard');
+const { safeWriteReview, checkForDataLoss, checkUrlCollision, coerceAssignedScore } = require('../../scripts/lib/review-write-guard');
 
 let tmpDir;
 beforeEach(() => {
@@ -268,6 +268,118 @@ describe('force=true audit trail', () => {
 
     const forceWarnings = warnings.filter(w => w.includes('[review-write-guard] FORCE write'));
     assert.equal(forceWarnings.length, 0, `Expected no FORCE write warning for new file, got: ${JSON.stringify(forceWarnings)}`);
+  });
+});
+
+describe('coerceAssignedScore (Schmigadoon 2026 Bug #6 — schema drift block)', () => {
+  test('passes through null assignedScore unchanged', () => {
+    const data = { assignedScore: null };
+    const result = coerceAssignedScore(data);
+    assert.equal(result.changed, false);
+    assert.equal(data.assignedScore, null);
+  });
+
+  test('passes through finite number unchanged', () => {
+    const data = { assignedScore: 85 };
+    const result = coerceAssignedScore(data);
+    assert.equal(result.changed, false);
+    assert.equal(data.assignedScore, 85);
+  });
+
+  test('coerces "2/4 stars" string (NY Post Schmigadoon bug) via parseRating → 50', () => {
+    const data = { assignedScore: '2/4 stars' };
+    const result = coerceAssignedScore(data);
+    assert.equal(result.changed, true);
+    assert.equal(data.assignedScore, 50);
+    assert.equal(data._assignedScoreCoercedFrom, '2/4 stars');
+  });
+
+  test('coerces "3/5 stars" Guardian-style string → 60', () => {
+    const data = { assignedScore: '3/5 stars' };
+    const result = coerceAssignedScore(data);
+    assert.equal(result.changed, true);
+    assert.equal(data.assignedScore, 60);
+  });
+
+  test('coerces letter grade "B+" → 80', () => {
+    const data = { assignedScore: 'B+' };
+    const result = coerceAssignedScore(data);
+    assert.equal(result.changed, true);
+    assert.equal(data.assignedScore, 80);
+  });
+
+  test('prefers originalScoreNormalized over string parse', () => {
+    const data = {
+      assignedScore: '2/4 stars',
+      originalScoreNormalized: 52,
+    };
+    const result = coerceAssignedScore(data);
+    assert.equal(result.changed, true);
+    assert.equal(data.assignedScore, 52);
+    assert.equal(result.reason, 'from-originalScoreNormalized');
+  });
+
+  test('ignores out-of-range originalScoreNormalized', () => {
+    const data = {
+      assignedScore: '2/4 stars',
+      originalScoreNormalized: 999,
+    };
+    const result = coerceAssignedScore(data);
+    assert.equal(data.assignedScore, 50);
+    assert.equal(result.reason, 'parsed-as-star_4');
+  });
+
+  test('unparseable string → null + needsReview flag', () => {
+    const data = { assignedScore: 'garbage data' };
+    const result = coerceAssignedScore(data);
+    assert.equal(result.changed, true);
+    assert.equal(data.assignedScore, null);
+    assert.equal(data._assignedScoreCoercionFailed, true);
+    assert.equal(data.needsReview, true);
+  });
+
+  test('safeWriteReview blocks schema-drifted string assignedScore from hitting disk', () => {
+    const filePath = path.join(tmpDir, 'schema-drift.json');
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
+    try {
+      safeWriteReview(filePath, {
+        showId: 'schmigadoon-2026',
+        outletId: 'nypost',
+        criticName: 'Johnny Oleksinski',
+        assignedScore: '2/4 stars',
+        scoreSource: 'html-star',
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const written = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    assert.equal(written.assignedScore, 50);
+    assert.equal(written._assignedScoreCoercedFrom, '2/4 stars');
+    assert.ok(warnings.some(w => w.includes('assignedScore coerced')));
+  });
+
+  test('safeWriteReview coercion survives through preservation logic (existing string value)', () => {
+    const filePath = path.join(tmpDir, 'existing-string.json');
+    fs.writeFileSync(filePath, JSON.stringify({
+      showId: 'test',
+      assignedScore: '2/4 stars',
+      originalScoreNormalized: 50,
+    }, null, 2));
+
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
+    try {
+      safeWriteReview(filePath, { showId: 'test', outletId: 'nypost' });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const written = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    assert.equal(written.assignedScore, 50);
   });
 });
 

--- a/tests/unit/tryout-url-filter.test.mjs
+++ b/tests/unit/tryout-url-filter.test.mjs
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for hasTryoutUrlMarker and TRYOUT_URL_MARKERS
+ * (scripts/lib/content-filters.js — Schmigadoon 2026 Bug #8).
+ *
+ * The filter is applied at SERP discovery time by url-discovery.js
+ * and at BWW-roundup slug validation time by bww-roundup-validator.js.
+ * A miss here = a wrong-production URL shipping into reviews.json.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { hasTryoutUrlMarker, TRYOUT_URL_MARKERS } = require('../../scripts/lib/content-filters.js');
+const { validateBWWRoundupUrlMatchesShow } = require('../../scripts/lib/bww-roundup-validator.js');
+
+describe('TRYOUT_URL_MARKERS catalogue integrity', () => {
+  test('includes the core Schmigadoon 2026 incident markers', () => {
+    const required = [
+      'world-premiere',
+      'kennedy-center',
+      'pre-broadway',
+      'tryout',
+      'out-of-town',
+    ];
+    for (const m of required) {
+      assert.ok(TRYOUT_URL_MARKERS.includes(m), `missing required marker: ${m}`);
+    }
+  });
+
+  test('includes the TV/film/streaming markers (Apple TV+ Schmigadoon class)', () => {
+    const required = ['tv-review', 'film-review', 'apple-tv', 'streaming-review'];
+    for (const m of required) {
+      assert.ok(TRYOUT_URL_MARKERS.includes(m), `missing required marker: ${m}`);
+    }
+  });
+
+  test('all markers are lowercase (hasTryoutUrlMarker lower-cases input)', () => {
+    for (const m of TRYOUT_URL_MARKERS) {
+      assert.strictEqual(m, m.toLowerCase(), `marker not lowercase: ${m}`);
+    }
+  });
+
+  test('no generic words like "review" or "theater" (would cause FPs)', () => {
+    const banned = ['review', 'theater', 'theatre', 'show', 'musical'];
+    for (const m of TRYOUT_URL_MARKERS) {
+      for (const b of banned) {
+        assert.notStrictEqual(m, b, `generic marker "${b}" would cause FPs`);
+      }
+    }
+  });
+});
+
+describe('hasTryoutUrlMarker behavior', () => {
+  test('Kennedy Center world-premiere URL → rejected (Schmigadoon 2026 incident)', () => {
+    const r = hasTryoutUrlMarker('https://www.broadwayworld.com/article/Review-Roundup-SCHMIGADOON-Kennedy-Center-World-Premiere-20250616');
+    assert.strictEqual(r.rejected, true);
+    assert.ok(['world-premiere', 'kennedy-center'].includes(r.marker));
+  });
+
+  test('Apple TV+ review URL → rejected', () => {
+    const r = hasTryoutUrlMarker('https://variety.com/2021/tv/reviews/schmigadoon-tv-review-apple-tv-1234902395/');
+    assert.strictEqual(r.rejected, true);
+  });
+
+  test('La Jolla Playhouse tryout URL → rejected', () => {
+    const r = hasTryoutUrlMarker('https://latimes.com/entertainment/theater/story/la-jolla-playhouse-world-premiere-12345');
+    assert.strictEqual(r.rejected, true);
+  });
+
+  test('legitimate Broadway NYT review URL → accepted', () => {
+    const r = hasTryoutUrlMarker('https://www.nytimes.com/2026/04/20/theater/schmigadoon-review.html');
+    assert.strictEqual(r.rejected, false);
+  });
+
+  test('legitimate BWW Broadway roundup URL → accepted', () => {
+    const r = hasTryoutUrlMarker('https://www.broadwayworld.com/article/Review-Roundup-SCHMIGADOON-Opens-on-Broadway-20260420');
+    assert.strictEqual(r.rejected, false);
+  });
+
+  test('null/undefined/empty input → not rejected (safe default)', () => {
+    assert.strictEqual(hasTryoutUrlMarker(null).rejected, false);
+    assert.strictEqual(hasTryoutUrlMarker(undefined).rejected, false);
+    assert.strictEqual(hasTryoutUrlMarker('').rejected, false);
+    assert.strictEqual(hasTryoutUrlMarker(42).rejected, false);
+  });
+
+  test('case-insensitive match (uppercase URL segment)', () => {
+    const r = hasTryoutUrlMarker('https://www.broadwayworld.com/article/SOMETHING-WORLD-PREMIERE-Review');
+    assert.strictEqual(r.rejected, true);
+  });
+
+  test('underscore variant (world_premiere) also rejected', () => {
+    const r = hasTryoutUrlMarker('https://example.com/something_world_premiere_review');
+    assert.strictEqual(r.rejected, true);
+  });
+});
+
+describe('bww-roundup-validator still rejects tryout slugs after refactor', () => {
+  test('Schmigadoon Kennedy Center roundup URL rejected for Schmigadoon', () => {
+    const ok = validateBWWRoundupUrlMatchesShow(
+      'https://www.broadwayworld.com/article/Review-Roundup-SCHMIGADOON-Kennedy-Center-World-Premiere-20250616',
+      'Schmigadoon'
+    );
+    assert.strictEqual(ok, false);
+  });
+
+  test('La Jolla tryout roundup rejected even with matching title words', () => {
+    const ok = validateBWWRoundupUrlMatchesShow(
+      'https://www.broadwayworld.com/article/Review-Roundup-SOMESHOW-La-Jolla-Tryout-20250101',
+      'Someshow'
+    );
+    assert.strictEqual(ok, false);
+  });
+
+  test('clean Broadway roundup URL still accepted', () => {
+    const ok = validateBWWRoundupUrlMatchesShow(
+      'https://www.broadwayworld.com/article/Review-Roundup-HAMILTON-Opens-on-Broadway-20150806',
+      'Hamilton'
+    );
+    assert.strictEqual(ok, true);
+  });
+});

--- a/tests/unit/url-content-sanity.test.mjs
+++ b/tests/unit/url-content-sanity.test.mjs
@@ -1,0 +1,296 @@
+/**
+ * Unit tests for validateContentMentionsShow
+ * (scripts/lib/content-quality.js — Schmigadoon 2026 Bug #2).
+ *
+ * Background: BrightData returned an "Everybody's Talking About Jamie" (EBT)
+ * article when asked for a Schmigadoon review URL. The fetched page was a
+ * complete, well-formed theater article — but about the wrong show. The
+ * existing validateShowMentioned() gate only checked presence, not count,
+ * so a single fleeting "Schmigadoon" mention in a long EBT piece could slip
+ * past and reach scoring as an override-eligible review.
+ *
+ * validateContentMentionsShow adds a cheap deterministic gate BEFORE LLM
+ * content verification spends tokens:
+ *   - Text ≥1500 chars needs ≥3 show-token mentions
+ *   - Text <1500 chars needs ≥1 show-token mention
+ *   - HTML <title> (if provided) must reference the show, else reject
+ *
+ * A miss here = a wrong-show full-text review reaching updateReviewJson.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { validateContentMentionsShow } = require('../../scripts/lib/content-quality.js');
+
+describe('validateContentMentionsShow — EBT-as-Schmigadoon regression', () => {
+  test('long EBT article with 0 Schmigadoon mentions → rejected', () => {
+    const ebtText = `
+      Everybody's Talking About Jamie returns to the West End this spring for
+      a limited engagement. The coming-of-age musical, based on the BBC Three
+      documentary film "Jamie: Drag Queen at 16," first opened at the Sheffield
+      Crucible in 2017 before transferring to London. The production stars a
+      new cast including a fresh lead actor making his West End debut. The
+      show runs two and a half hours with one interval and features songs by
+      Dan Gillespie Sells and book by Tom MacRae. Critics praised the original
+      London production for its warmth, its honesty about queer teenagerhood,
+      and its emotional central performance. This revival takes the same
+      design team as the original and promises to retain the heart of the
+      piece while refreshing the staging for a new generation of audiences.
+      The show examines themes of identity, acceptance, and the courage
+      required to be visibly yourself in a world that often prefers conformity.
+      Performances run through September at the Peacock Theatre.
+    `.repeat(3);
+    const r = validateContentMentionsShow(ebtText, null, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.valid, false);
+    assert.strictEqual(r.mentionCount, 0);
+    assert.strictEqual(r.threshold, 3);
+    assert.match(r.reason, /mentioned 0×/);
+  });
+
+  test('long EBT article with 1 fleeting Schmigadoon mention → still rejected', () => {
+    // Build a ≥1500-char article with exactly ONE mention of "Schmigadoon"
+    // (a fleeting comparative reference). Long-text threshold is 3, so this
+    // must be rejected.
+    const filler = (
+      'Everybody is Talking About Jamie returns to the West End this spring. ' +
+      'The coming of age musical first opened at the Sheffield Crucible in 2017. ' +
+      'The production stars a new cast including a fresh lead actor making his ' +
+      'West End debut. Critics praised the original London production for its ' +
+      'warmth and honesty. This revival takes the same design team as the ' +
+      'original and promises to retain the heart of the piece while refreshing ' +
+      'the staging for new audiences. The show examines themes of identity, ' +
+      'acceptance, and courage. Performances run through September. '
+    ).repeat(3);
+    const ebtText = filler +
+      '(One critic compared it favorably to Schmigadoon, another musical about conformity.) ' +
+      filler;
+    assert.ok(ebtText.length >= 1500, 'setup: must be long-text');
+    const r = validateContentMentionsShow(ebtText, null, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.valid, false);
+    assert.strictEqual(r.mentionCount, 1);
+    assert.strictEqual(r.threshold, 3);
+  });
+});
+
+describe('validateContentMentionsShow — legitimate Schmigadoon review', () => {
+  test('real Schmigadoon review with many mentions → valid', () => {
+    const schmigText = `
+      Schmigadoon arrives on Broadway after its celebrated Apple TV+ run, and
+      the stage adaptation of Schmigadoon proves even sharper than its
+      streaming predecessor. The Schmigadoon book leans into the absurdity
+      of its Brigadoon-meets-Oklahoma! premise, sending two modern hikers
+      into a town where everyone breaks into 1940s-style song. Schmigadoon's
+      cast delivers its parody of golden-age musical theater with both
+      affection and bite. The production opened last night at the Lunt-Fontanne.
+    `.repeat(3);
+    const r = validateContentMentionsShow(schmigText, null, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.valid, true);
+    assert.ok(r.mentionCount >= 3);
+  });
+});
+
+describe('validateContentMentionsShow — length-based threshold', () => {
+  test('short text (<1500 chars) with 1 mention → valid (threshold = 1)', () => {
+    const shortText = 'A brief capsule review of Schmigadoon on Broadway.';
+    const r = validateContentMentionsShow(shortText, null, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.threshold, 1);
+    assert.strictEqual(r.mentionCount, 1);
+  });
+
+  test('short text (<1500 chars) with 0 mentions → rejected', () => {
+    const shortText = 'A brief capsule review of an unrelated musical on Broadway.';
+    const r = validateContentMentionsShow(shortText, null, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.valid, false);
+    assert.strictEqual(r.mentionCount, 0);
+  });
+
+  test('long text (≥1500 chars) with 1 mention → rejected (threshold = 3)', () => {
+    const filler = 'This is filler text to pad the length above the 1500-char threshold. '.repeat(40);
+    const longText = `A review mentioning Schmigadoon once. ${filler}`;
+    assert.ok(longText.length >= 1500, 'setup: text must be ≥1500 chars');
+    const r = validateContentMentionsShow(longText, null, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.valid, false);
+    assert.strictEqual(r.threshold, 3);
+    assert.strictEqual(r.mentionCount, 1);
+  });
+
+  test('length threshold boundary: exactly 1500 chars uses long threshold', () => {
+    const shortEnough = 'Schmigadoon. '.padEnd(1499, ' ');
+    const atBoundary = 'Schmigadoon. '.padEnd(1500, ' ');
+    assert.strictEqual(shortEnough.length, 1499);
+    assert.strictEqual(atBoundary.length, 1500);
+    const rShort = validateContentMentionsShow(shortEnough, null, 'Schmigadoon', null);
+    const rLong = validateContentMentionsShow(atBoundary, null, 'Schmigadoon', null);
+    assert.strictEqual(rShort.threshold, 1);
+    assert.strictEqual(rLong.threshold, 3);
+  });
+});
+
+describe('validateContentMentionsShow — HTML <title> cross-check', () => {
+  test('HTML <title> matches show → valid', () => {
+    const text = 'A brief review of Schmigadoon.';
+    const html = '<html><head><title>Schmigadoon Review — NYT</title></head><body>...</body></html>';
+    const r = validateContentMentionsShow(text, html, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.htmlTitleMatch, true);
+    assert.strictEqual(r.htmlTitle, 'Schmigadoon Review — NYT');
+  });
+
+  test('HTML <title> references wrong show → rejected even with body mention', () => {
+    const text = 'Schmigadoon is mentioned once but the page is really about something else.';
+    const html = '<html><head><title>Everybody\'s Talking About Jamie — Review</title></head><body>...</body></html>';
+    const r = validateContentMentionsShow(text, html, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.valid, false);
+    assert.strictEqual(r.htmlTitleMatch, false);
+    assert.match(r.reason, /HTML <title>/);
+  });
+
+  test('HTML provided but no <title> tag → htmlTitleMatch null, passes on body alone', () => {
+    const text = 'A brief review of Schmigadoon.';
+    const html = '<html><head></head><body>no title tag here</body></html>';
+    const r = validateContentMentionsShow(text, html, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.valid, true);
+    assert.strictEqual(r.htmlTitleMatch, null);
+    assert.strictEqual(r.htmlTitle, null);
+  });
+
+  test('no HTML provided → htmlTitleMatch null, pass/fail on body only', () => {
+    const text = 'Schmigadoon is great.';
+    const r = validateContentMentionsShow(text, null, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.htmlTitle, null);
+    assert.strictEqual(r.htmlTitleMatch, null);
+    assert.strictEqual(r.valid, true);
+  });
+
+  test('HTML <title> with whitespace/newlines is normalized', () => {
+    const text = 'Brief Schmigadoon review.';
+    const html = '<title>\n   Schmigadoon   Review\n   on Broadway\n  </title>';
+    const r = validateContentMentionsShow(text, html, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.htmlTitle, 'Schmigadoon Review on Broadway');
+    assert.strictEqual(r.htmlTitleMatch, true);
+  });
+});
+
+describe('validateContentMentionsShow — showId fallback (no title)', () => {
+  test('extracts significant words from showId when no title given', () => {
+    const text = 'A review of the Broadway production at the Lunt-Fontanne.';
+    const r = validateContentMentionsShow(text, null, null, 'schmigadoon-2026');
+    // showId "schmigadoon-2026" → token "schmigadoon" (year stripped)
+    // Body has no "schmigadoon" → 0 mentions → rejected
+    assert.strictEqual(r.valid, false);
+    assert.strictEqual(r.mentionCount, 0);
+  });
+
+  test('showId token matches body text → valid', () => {
+    const text = 'A brief review of Schmigadoon on Broadway.';
+    const r = validateContentMentionsShow(text, null, null, 'schmigadoon-2026');
+    assert.strictEqual(r.valid, true);
+    assert.ok(r.mentionCount >= 1);
+  });
+
+  test('short ID words (≤4 chars) are NOT used as tokens (false-positive guard)', () => {
+    // "cats-2024" → id base "cats" is 4 chars, filtered out (word.length > 4 required)
+    // So with no title, there are zero tokens, mentionCount stays 0 → reject.
+    const text = 'This review discusses Cats, the famous Andrew Lloyd Webber musical.';
+    const r = validateContentMentionsShow(text, null, null, 'cats-2024');
+    assert.strictEqual(r.mentionCount, 0);
+    assert.strictEqual(r.valid, false);
+  });
+
+  test('"the" / "and" / "for" / "with" / "from" are filtered from ID tokens', () => {
+    // "the-band-and-the-phantom" → tokens after filter: "phantom" (>4 chars, not stopword)
+    // "band" (4 chars) filtered. "the"/"and" filtered.
+    const text = 'Review of a show mentioning Phantom in one place.';
+    const r = validateContentMentionsShow(text, null, null, 'the-band-and-the-phantom');
+    assert.ok(r.mentionCount >= 1, `expected phantom match, got ${r.mentionCount}`);
+  });
+});
+
+describe('validateContentMentionsShow — "The" prefix handling', () => {
+  test('title starting with "The" also matches without "The"', () => {
+    const text = 'A review of Phantom on Broadway.';
+    const r = validateContentMentionsShow(text, null, 'The Phantom', 'the-phantom');
+    // Both "the phantom" and "phantom" are tokens; "phantom" matches the body.
+    assert.ok(r.mentionCount >= 1);
+    assert.strictEqual(r.valid, true);
+  });
+
+  test('title "The" alone (≤2 chars after strip) is not added as token', () => {
+    // "The" (lowercase "the", 3 chars) — add the full title token. Strip "the " → "" (length 0),
+    // skipped. So tokens = {"the"}. Body has no standalone "the" as whole word? It does,
+    // but that would be a false-positive — we guard against that with the "showTitle.length > 2"
+    // precondition. Here showTitle is "The", 3 chars, so it IS added. This is a known edge case
+    // for one-word "The" titles (none exist on Broadway but confirm no crash).
+    const r = validateContentMentionsShow('body the body', null, 'The', null);
+    assert.strictEqual(typeof r.valid, 'boolean'); // just confirm no crash
+  });
+});
+
+describe('validateContentMentionsShow — safe defaults', () => {
+  test('null text → invalid, mentionCount 0', () => {
+    const r = validateContentMentionsShow(null, null, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.valid, false);
+    assert.strictEqual(r.mentionCount, 0);
+    assert.strictEqual(r.reason, 'empty text');
+  });
+
+  test('undefined text → invalid', () => {
+    const r = validateContentMentionsShow(undefined, null, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.valid, false);
+  });
+
+  test('empty string text → invalid', () => {
+    const r = validateContentMentionsShow('', null, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.valid, false);
+  });
+
+  test('non-string text (number) → invalid', () => {
+    const r = validateContentMentionsShow(42, null, 'Schmigadoon', 'schmigadoon-2026');
+    assert.strictEqual(r.valid, false);
+  });
+
+  test('text but no showTitle AND no showId → 0 tokens, 0 mentions, rejected', () => {
+    const r = validateContentMentionsShow('Any text at all here', null, null, null);
+    assert.strictEqual(r.valid, false);
+    assert.strictEqual(r.mentionCount, 0);
+  });
+
+  test('opts.minMentionsLong override respected', () => {
+    const longText = 'Schmigadoon. '.padEnd(1600, ' ');
+    const rDefault = validateContentMentionsShow(longText, null, 'Schmigadoon', null);
+    const rLenient = validateContentMentionsShow(longText, null, 'Schmigadoon', null, { minMentionsLong: 1 });
+    assert.strictEqual(rDefault.valid, false); // 1 mention, threshold 3
+    assert.strictEqual(rLenient.valid, true);  // 1 mention, threshold 1
+  });
+
+  test('opts.minMentionsShort override respected', () => {
+    const shortText = 'Schmigadoon review.';
+    const rDefault = validateContentMentionsShow(shortText, null, 'Schmigadoon', null);
+    const rStrict = validateContentMentionsShow(shortText, null, 'Schmigadoon', null, { minMentionsShort: 2 });
+    assert.strictEqual(rDefault.valid, true);  // 1 mention, threshold 1
+    assert.strictEqual(rStrict.valid, false);  // 1 mention, threshold 2
+  });
+});
+
+describe('validateContentMentionsShow — word boundary correctness', () => {
+  test('single-word title uses word boundaries (no substring FP)', () => {
+    // "Cats" as a title should NOT match "scatter" or "category"
+    const text = 'The show takes place in scattered categories, with a catalog of songs.';
+    const r = validateContentMentionsShow(text, null, 'Phantom', null);
+    // Title "Phantom" not in body → 0 mentions
+    // But crucially: "catalog"/"scattered"/"category" did not match substring tokens we don't have.
+    assert.strictEqual(r.mentionCount, 0);
+  });
+
+  test('multi-word title uses substring match (no \\b)', () => {
+    // "The Book of Mormon" is multi-word → substring match (no \b gating)
+    const text = 'A review of The Book of Mormon on Broadway.';
+    const r = validateContentMentionsShow(text, null, 'The Book of Mormon', 'the-book-of-mormon');
+    assert.ok(r.mentionCount >= 1);
+    assert.strictEqual(r.valid, true);
+  });
+});


### PR DESCRIPTION
## Summary

Works through all 12 items from the Schmigadoon 2026 opening-night postmortem (`/Users/tompryor/Documents/claude-outputs/schmigadoon-2026-opening-night-postmortem.md`). 8 bug classes fired on 2026-04-21 — each is now either (a) fixed in code with regression tests or (b) filed as a self-contained Notion follow-up card.

**Code fixes (8 commits ahead of main):**

- **Bug #3/#4 (c17e0418e6)** — temporal override bypass when CV has strong different-show signal. `[OVERRIDE: review within 1d of opening]` no longer clears `wrongProduction` when content verification has high-confidence different-show signals (slug mismatch, BWW roundup pointing to wrong show, etc.).
- **Bug #6 (78a2cb2ffc)** — coerce non-numeric `assignedScore` at write time. Stops the nypost "2/4 stars" string-vs-number schema drift at ingest instead of at rebuild.
- **Bug #7 (1a8be3d349)** — CV prompt distinguishes reviews OF a tryout from reviews MENTIONING one. Vincentelli NYT / NY Sun Gardner no longer false-positive on Kennedy Center historical context or Smash comparatives.
- **Bug #8 (06c4c7b7d2)** — SERP URL prefilter for tryout / TV / world-premiere / Kennedy Center patterns. Rejects wrong-production URLs at discovery time, before they burn scrape credits.
- **Bug #2 (04aa52f355)** — post-fetch URL→content sanity check. After every BrightData fetch, verify the show title appears in the body ≥N times. Forensic HTML still archived on rejection.
- **Bug #5 (4410c4d2ec)** — outlet-aware anticipatory pre-opening gate. frontmezzjunkies / broadwaydirect: 0-day grace (must publish on/after opening). Default: 2-day grace (matches post-broadcast audit). Bypass: `humanReviewedEarlyPublish: true`.
- **Bug #11 (a2f7c9cf1f)** — validator escalates `scoreExtractionPending` files stuck >7 days separately from fresh pending. Explicit remediation command in the warn message.
- **Bug #12 (0d769922aa)** — rebuild pause tombstone for opening-night manual-edit race. `scripts/pause-rebuild.js --minutes=30 --cancel-in-flight` blocks rebuild-all-reviews.js from racing a hand-edited reviews.json during the broadcast window.

**Notion cards filed:**

- Review-count drift health check (reviews.json vs review-texts per show): `349637c5-416f-814d-bb9e-e97d65d47309`
- WSJ paywall failure despite cookie infrastructure: `349637c5-416f-8107-8fa9-e39b295a5282`
- send-opening-night-broadcast.js draft-state reconciliation: `349637c5-416f-81cc-85ae-c5e8ed3921e5`

## Test plan

- [x] 78 unit tests pass across 4 new/touched spec files (anticipatory-preview-gate, rebuild-pause, url-content-sanity, tryout-url-filter).
- [x] `node scripts/pause-rebuild.js --minutes=5 --reason=test` + `node scripts/rebuild-all-reviews.js` verified early-exit path.
- [x] `node scripts/rebuild-all-reviews.js --ignore-pause` verified bypass.
- [x] `node scripts/pause-rebuild.js --clear` + `--status` verified tombstone lifecycle.
- [x] `node --check` on all new/modified scripts.
- [ ] CI green on this PR (unit-tests job, lint-workflows, scraper-cookie-wiring — the last one has a known 40% IPC flake; re-dispatch if flaky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)