### PR TITLE
feat(pipeline): add stage-2→3 review count invariant to generate-mobile-show-details

### DIFF
--- a/scripts/generate-mobile-show-details.js
+++ b/scripts/generate-mobile-show-details.js
@@ -192,6 +192,7 @@ const visibleShows = shows.filter(show =>
 
 let generated = 0;
 let totalSize = 0;
+const invariantChecks = new Map(); // showId → expected reviewEntries.length at write time
 
 for (const show of visibleShows) {
   const allShowReviews = reviewsByShow[show.id] || [];
@@ -494,9 +495,33 @@ for (const show of visibleShows) {
   const filePath = path.join(outputDir, `${show.id}.json`);
   const json = JSON.stringify(detail);
   fs.writeFileSync(filePath, json);
+  invariantChecks.set(show.id, reviewEntries.length);
   generated++;
   totalSize += json.length;
 }
+
+// Stage-2→3 invariant: verify each written file's review count matches the
+// in-memory reviewEntries array at write time. Catches stale-variable bugs
+// (wrong reviewsByShow, dedup logic error) before the data lands in public/.
+let invariantErrors = 0;
+for (const [showId, expectedCount] of invariantChecks) {
+  try {
+    const written = JSON.parse(fs.readFileSync(path.join(outputDir, `${showId}.json`), 'utf-8'));
+    const actualCount = written.rv ? written.rv.length : 0;
+    if (actualCount !== expectedCount) {
+      console.error(`✗ Invariant: ${showId} — in-memory reviewEntries=${expectedCount}, written rv=${actualCount}`);
+      invariantErrors++;
+    }
+  } catch (err) {
+    console.error(`✗ Invariant: ${showId} — failed to read back: ${err.message}`);
+    invariantErrors++;
+  }
+}
+if (invariantErrors > 0) {
+  console.error(`✗ Invariant check failed: ${invariantErrors} show(s) have stage-2→3 count mismatches. Aborting.`);
+  process.exit(1);
+}
+console.log(`✓ Invariant: ${generated} shows, all stage-2→3 counts match.`);
 
 const avgSize = generated > 0 ? (totalSize / generated / 1024).toFixed(1) : 0;
 const totalKB = (totalSize / 1024).toFixed(0);


### PR DESCRIPTION
## Summary

- After writing all per-show JSONs, reads each file back and asserts that the written `rv` array length matches the in-memory `reviewEntries` array length at write time
- Exits 1 on any mismatch, logging the show ID + counts (`✗ Invariant: {showId} — in-memory reviewEntries=N, written rv=M`)
- On success, logs `✓ Invariant: N shows, all stage-2→3 counts match.` before the existing summary line

Catches stale-variable bugs (wrong `reviewsByShow`, dedup logic errors, partial JSON writes) before bad data lands in `public/data/shows/`. This is the fix for the 2026-04-15 silent-drop surface where stage-2 had 21 reviews but stage-3 had 13 with no alert.

Corresponds to **Option B′ Phase 1 Edit 1**. Part of plan: https://www.notion.so/34b637c5416f81da9cf7d0b0eb6b205e

## Test plan

- [ ] Merge only after a clean `rebuild-fast` run completes with exit 0 and the `✓ Invariant:` line visible in CI logs
- [ ] Acceptance criterion: mutating the script to produce a wrong count → exits 1 → rebuild-fast fails → no bad data committed

---
_Generated by [Claude Code](https://claude.ai/code/session_01PS577KPTQR54cwAKANuSoe)_