### PR TITLE
docs(pipeline): document stage-2→3 invariant coverage in opening-night-poller

### DIFF
--- a/.github/workflows/opening-night-poller.yml
+++ b/.github/workflows/opening-night-poller.yml
@@ -394,6 +394,10 @@ jobs:
 
       - name: Regenerate mobile detail JSONs (fast_path)
         if: inputs.fast_path && steps.fast_rebuild.outcome == 'success'
+        # Calls the canonical script directly — the stage-2→3 invariant (pipeline-invariant-generator)
+        # lives inside generate-mobile-show-details.js and fires here automatically.
+        # continue-on-error is intentional: invariant failure is logged + exits 1 (loud), but
+        # opening-night deploys must not be blocked by an assertion (non-blocking by design).
         run: node scripts/generate-mobile-show-details.js
         continue-on-error: true
 


### PR DESCRIPTION
## Summary

- Edit 2 from Option B′ Phase 1 is a **documented skip**: the poller's fast-path calls `generate-mobile-show-details.js` directly (line 397), so the invariant added in `pipeline-invariant-generator` fires here automatically — no separate inline logic needed
- Adds a comment to the "Regenerate mobile detail JSONs" step explaining this coverage and why `continue-on-error: true` is intentional

`continue-on-error: true` is correct here: the invariant exits 1 on mismatch (loud, visible in CI logs) but opening-night deploys must not be blocked by an assertion (non-blocking by design per Option B′ safety constraint 3).

Corresponds to **Option B′ Phase 1 Edit 2 (skip)**. Part of plan: https://www.notion.so/34b637c5416f81da9cf7d0b0eb6b205e

## Test plan

- [ ] YAML parses cleanly (verified with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] No functional change — comment only

---
_Generated by [Claude Code](https://claude.ai/code/session_01PS577KPTQR54cwAKANuSoe)_