### PR TITLE
docs(vercelignore): document data/audit/ exclusion rationale

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -2,6 +2,8 @@
 .claude/worktrees/
 
 # Large data directories not needed after build (reduces upload file count)
+# data/audit/ is excluded explicitly to prevent audit JSON files from counting
+# against Vercel's 100MB static output cap (Option B' Phase 1 Edit 6).
 data/review-texts/
 data/aggregator-archive/
 data/archives/


### PR DESCRIPTION
## Summary

- Edit 6 from Option B′ Phase 1 is a **documented no-op**: `data/audit/` was already present in `.vercelignore`
- Adds a comment making the intent explicit: audit JSON files must not count against Vercel's 100MB static output cap

No functional change. Pre-flight check confirmed `data/audit/` was already excluded.

Corresponds to **Option B′ Phase 1 Edit 6**. Part of plan: https://www.notion.so/34b637c5416f81da9cf7d0b0eb6b205e

## Test plan

- [ ] `cat .vercelignore` confirms `data/audit/` is present — verified ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01PS577KPTQR54cwAKANuSoe)_