### PR TITLE
feat: advanced filter panel (Production / Score tier / Awards / Genre / Tickets)

### DIFF
--- a/src/app/off-broadway/page.tsx
+++ b/src/app/off-broadway/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 import { getOffBroadwayShows, getMarketStats } from '@/lib/data-core';
+import { getAwardWinnerSets } from '@/lib/data-awards';
 import { serializeShowForClient } from '@/lib/serialize-show';
 import { generateBreadcrumbSchema, generateItemListSchema, BASE_URL } from '@/lib/seo';
 import OffBroadwayPageClient from '@/components/OffBroadwayPageClient';
@@ -82,6 +83,7 @@ export default function OffBroadwayPage() {
             broadway: getMarketStats().nyc.openShows,
             offBroadway: getMarketStats().offBroadway?.openShows ?? 0,
           }}
+          awardWinnerSets={getAwardWinnerSets()}
         />
       </Suspense>
     </>

--- a/src/app/off-west-end/page.tsx
+++ b/src/app/off-west-end/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 import { getOffWestEndShows, getMarketStats } from '@/lib/data-core';
+import { getAwardWinnerSets } from '@/lib/data-awards';
 import { serializeShowForClient } from '@/lib/serialize-show';
 import { generateBreadcrumbSchema, generateItemListSchema, BASE_URL } from '@/lib/seo';
 import OffWestEndPageClient from '@/components/OffWestEndPageClient';
@@ -80,6 +81,7 @@ export default function OffWestEndPage() {
             westEnd: getMarketStats().westEnd.openShows,
             offWestEnd: getMarketStats().offWestEnd?.openShows ?? 0,
           }}
+          awardWinnerSets={getAwardWinnerSets()}
         />
       </Suspense>
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import crypto from 'crypto';
 import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { getBroadwayShows, getOffBroadwayShows, getWestEndShows, getDataStats, getUpcomingShows, getNYTCriticsPickShowIds, getMarketStats } from '@/lib/data-core';
+import { getAwardWinnerSets } from '@/lib/data-awards';
 import type { ComputedShow } from '@/lib/data-types';
 import { serializeShowForClient } from '@/lib/serialize-show';
 import { hasEnoughReviews } from '@/config/score-buckets';
@@ -283,6 +284,7 @@ export default function HomePage() {
             broadway: getMarketStats().nyc.openShows,
             offBroadway: getMarketStats().offBroadway?.openShows ?? 0,
           }}
+          awardWinnerSets={getAwardWinnerSets()}
         />
       </Suspense>
     </>

--- a/src/app/west-end/page.tsx
+++ b/src/app/west-end/page.tsx
@@ -4,6 +4,7 @@ import { Metadata } from 'next';
 import fs from 'fs';
 import path from 'path';
 import { getWestEndShows, getMarketStats } from '@/lib/data-core';
+import { getAwardWinnerSets } from '@/lib/data-awards';
 import { serializeShowForClient } from '@/lib/serialize-show';
 import { generateBreadcrumbSchema, generateItemListSchema, BASE_URL } from '@/lib/seo';
 import WestEndPageClient from '@/components/WestEndPageClient';
@@ -132,6 +133,7 @@ export default function WestEndPage() {
           lotteryShows={lotteryShowsList}
           rushShows={rushShowsList}
           marketOpenCounts={marketOpenCounts}
+          awardWinnerSets={getAwardWinnerSets()}
         />
       </Suspense>
     </>

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -290,13 +290,19 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
         }
       }
 
-      // Sync to URL without triggering navigation
-      const urlParams = new URLSearchParams();
-      if (next.status !== DEFAULT_STATUS) urlParams.set('status', next.status);
-      if (next.sort !== DEFAULT_SORT) urlParams.set('sort', next.sort);
-      if (next.type !== DEFAULT_TYPE) urlParams.set('type', next.type);
-      if (next.scoreMode !== DEFAULT_SCORE_MODE) urlParams.set('scoreMode', next.scoreMode);
-      if (next.q) urlParams.set('q', next.q);
+      // Sync to URL without triggering navigation. Preserve unknown params
+      // (e.g. panel filters: production/awards/score_tier/genre/tickets/years)
+      // so the panel state survives inline-filter changes.
+      const urlParams = new URLSearchParams(window.location.search);
+      const setOrDelete = (key: string, value: string, isDefault: boolean) => {
+        if (isDefault) urlParams.delete(key);
+        else urlParams.set(key, value);
+      };
+      setOrDelete('status', next.status, next.status === DEFAULT_STATUS);
+      setOrDelete('sort', next.sort, next.sort === DEFAULT_SORT);
+      setOrDelete('type', next.type, next.type === DEFAULT_TYPE);
+      setOrDelete('scoreMode', next.scoreMode, next.scoreMode === DEFAULT_SCORE_MODE);
+      setOrDelete('q', next.q, !next.q);
 
       const paramString = urlParams.toString();
       window.history.replaceState({}, '', paramString ? `/?${paramString}` : '/');
@@ -507,7 +513,7 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
   }, [allShows, fuseResults, statusFilter, type, searchQuery, sort, scoreMode, isEffectivelyOpen]);
 
   // Advanced filter panel — applies on top of inline-filtered shows
-  const panel = usePanelFilters({ shows: filteredAndSortedShows, awardWinnerSets });
+  const panel = usePanelFilters({ shows: filteredAndSortedShows, awardWinnerSets, scoreMode });
   const [isPanelOpen, setIsPanelOpen] = useState(false);
 
   // Hide status chip when it would be redundant

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -13,6 +13,10 @@ const FooterEmailCapture = lazy(() => import('@/components/FooterEmailCapture'))
 const HomepageExplainerShelf = lazy(() => import('@/components/HomepageExplainerShelf'));
 import type { ScoreModeParam } from '@/components/show-cards';
 import type { AwardWinnerSets } from '@/lib/data-awards';
+import { FilterButton } from '@/components/filters/FilterButton';
+import { FilterPanel } from '@/components/filters/FilterPanel';
+import { ActiveFilterChips } from '@/components/filters/ActiveFilterChips';
+import { usePanelFilters } from '@/lib/hooks/usePanelFilters';
 
 export interface FeaturedRowData {
   title: string;
@@ -203,7 +207,7 @@ function FeaturedRow({ title, shows, viewAllHref, minCount = 4 }: { title: strin
 }
 
 // Inner component that uses searchParams
-function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [], westEndShows = [], totalShows, totalReviews, totalCritics = 0, totalOutlets = 0, skipHero, skipFirstMusicals, featuredRows = [], marketOpenCounts }: HomePageClientProps) {
+function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [], westEndShows = [], totalShows, totalReviews, totalCritics = 0, totalOutlets = 0, skipHero, skipFirstMusicals, featuredRows = [], marketOpenCounts, awardWinnerSets }: HomePageClientProps) {
   const initialSearchParams = useSearchParams();
 
   // Local state for instant updates (no full-page reload)
@@ -502,6 +506,10 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
     return result;
   }, [allShows, fuseResults, statusFilter, type, searchQuery, sort, scoreMode, isEffectivelyOpen]);
 
+  // Advanced filter panel — applies on top of inline-filtered shows
+  const panel = usePanelFilters({ shows: filteredAndSortedShows, awardWinnerSets });
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
+
   // Hide status chip when it would be redundant
   const shouldHideStatus = statusFilter !== 'all';
 
@@ -544,7 +552,7 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
       )}
 
       {/* Search */}
-      <div id="search" className="relative mb-4 sm:mb-6 scroll-mt-24" role="search">
+      <div id="search" className="relative mb-2 scroll-mt-24" role="search">
         <label htmlFor="show-search" className="sr-only">Search Broadway shows</label>
         <div className="absolute inset-y-0 left-4 flex items-center pointer-events-none">
           <SearchIcon />
@@ -559,10 +567,37 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
             setSearchInput(val);         // sync update — keeps input responsive
             updateParams({ q: val });    // deferred via startTransition — filters catch up
           }}
-          className="search-input pl-12 focus-visible:outline-none"
+          className="search-input pl-12 pr-14 focus-visible:outline-none"
           autoComplete="off"
         />
+        <div className="absolute inset-y-0 right-2 flex items-center">
+          <FilterButton
+            activeCount={panel.activeCount}
+            isOpen={isPanelOpen}
+            onClick={() => setIsPanelOpen((v) => !v)}
+            controlsId="advanced-filter-panel"
+          />
+        </div>
       </div>
+
+      {/* Active panel-filter chips */}
+      <div className="mb-2 sm:mb-4">
+        <ActiveFilterChips
+          chips={panel.chips}
+          onRemove={panel.removeChip}
+          onClearAll={panel.clearAll}
+        />
+      </div>
+
+      {/* Filter Panel (sheet on mobile, popover on desktop) */}
+      <FilterPanel
+        isOpen={isPanelOpen}
+        onClose={() => setIsPanelOpen(false)}
+        selectedByGroup={panel.selectedByGroup}
+        onToggle={panel.toggleOption}
+        onClearAll={panel.clearAll}
+        resultCount={panel.filteredShows.length}
+      />
 
       {/* Market + Type Filter Row */}
       <div className="flex items-center gap-2 sm:gap-4 mb-4">
@@ -634,9 +669,9 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
 
       {/* Show List */}
       <h2 className="sr-only">Broadway Shows</h2>
-      <ShowCardList shows={filteredAndSortedShows} hideStatus={shouldHideStatus} scoreMode={scoreMode} />
+      <ShowCardList shows={panel.filteredShows} hideStatus={shouldHideStatus} scoreMode={scoreMode} />
 
-      {filteredAndSortedShows.length === 0 && !archiveShows && (statusFilter === 'all' || statusFilter === 'closed') && (
+      {panel.filteredShows.length === 0 && !archiveShows && (statusFilter === 'all' || statusFilter === 'closed') && (
         <div className="space-y-3" role="status" aria-label="Loading shows">
           {[1, 2, 3, 4, 5].map(i => (
             <div key={i} className="animate-pulse h-24 bg-surface-overlay rounded-xl" />
@@ -644,7 +679,7 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
         </div>
       )}
 
-      {filteredAndSortedShows.length === 0 && (archiveShows || (statusFilter !== 'all' && statusFilter !== 'closed')) && (
+      {panel.filteredShows.length === 0 && (archiveShows || (statusFilter !== 'all' && statusFilter !== 'closed')) && (
         <div className="card text-center py-16 px-6" role="status" aria-live="polite">
           <div className="w-16 h-16 rounded-full bg-surface-overlay mx-auto mb-4 flex items-center justify-center">
             <svg className="w-8 h-8 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -670,7 +705,7 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
       )}
 
       <div className="mt-8 flex items-baseline justify-between text-sm text-gray-400">
-        <span>{filteredAndSortedShows.length} shows</span>
+        <span>{panel.filteredShows.length} shows</span>
         <Link href="/methodology" prefetch={false} className="text-brand hover:text-brand-hover transition-colors">
           How scores work →
         </Link>

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -12,6 +12,7 @@ import { hasEnoughReviews } from '@/config/score-buckets';
 const FooterEmailCapture = lazy(() => import('@/components/FooterEmailCapture'));
 const HomepageExplainerShelf = lazy(() => import('@/components/HomepageExplainerShelf'));
 import type { ScoreModeParam } from '@/components/show-cards';
+import type { AwardWinnerSets } from '@/lib/data-awards';
 
 export interface FeaturedRowData {
   title: string;
@@ -61,6 +62,8 @@ interface HomePageClientProps {
   featuredRows?: FeaturedRowData[];
   /** Open-show counts for the market pills (stable across filter state) */
   marketOpenCounts: { broadway: number; offBroadway: number };
+  /** Pre-computed award winner ID arrays (avoids client-side awards.json import) */
+  awardWinnerSets?: AwardWinnerSets;
 }
 
 // URL parameter values

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -31,6 +31,7 @@ export interface HomepageShow {
   status: string;
   type: string;
   isRevival?: boolean;
+  season?: string;
   tags?: string[];
   ageRecommendation?: string;
   creativeTeam?: Array<{ name: string; role: string }>;

--- a/src/components/OffBroadwayPageClient.tsx
+++ b/src/components/OffBroadwayPageClient.tsx
@@ -150,12 +150,17 @@ function OffBroadwayPageInner({ shows, totalShows, totalReviews, marketOpenCount
         }
       }
 
-      const urlParams = new URLSearchParams();
-      if (next.status !== DEFAULT_STATUS) urlParams.set('status', next.status);
-      if (next.sort !== DEFAULT_SORT) urlParams.set('sort', next.sort);
-      if (next.type !== DEFAULT_TYPE) urlParams.set('type', next.type);
-      if (next.scoreMode !== DEFAULT_SCORE_MODE) urlParams.set('scoreMode', next.scoreMode);
-      if (next.q) urlParams.set('q', next.q);
+      // Preserve unknown params (panel filters) so they survive inline-filter changes
+      const urlParams = new URLSearchParams(window.location.search);
+      const setOrDelete = (key: string, value: string, isDefault: boolean) => {
+        if (isDefault) urlParams.delete(key);
+        else urlParams.set(key, value);
+      };
+      setOrDelete('status', next.status, next.status === DEFAULT_STATUS);
+      setOrDelete('sort', next.sort, next.sort === DEFAULT_SORT);
+      setOrDelete('type', next.type, next.type === DEFAULT_TYPE);
+      setOrDelete('scoreMode', next.scoreMode, next.scoreMode === DEFAULT_SCORE_MODE);
+      setOrDelete('q', next.q, !next.q);
 
       const paramString = urlParams.toString();
       window.history.replaceState({}, '', paramString ? `/off-broadway?${paramString}` : '/off-broadway');
@@ -312,7 +317,7 @@ function OffBroadwayPageInner({ shows, totalShows, totalReviews, marketOpenCount
     return result;
   }, [shows, fuseResults, statusFilter, type, searchQuery, sort, scoreMode]);
 
-  const panel = usePanelFilters({ shows: filteredAndSortedShows, awardWinnerSets });
+  const panel = usePanelFilters({ shows: filteredAndSortedShows, awardWinnerSets, scoreMode });
   const [isPanelOpen, setIsPanelOpen] = useState(false);
 
   const shouldHideStatus = statusFilter !== 'all';

--- a/src/components/OffBroadwayPageClient.tsx
+++ b/src/components/OffBroadwayPageClient.tsx
@@ -8,6 +8,7 @@ import { SCORE_TIERS, ToggleBar, ScoreToggle, ShowListCard, MiniShowCard } from 
 import MarketFilterBar from '@/components/MarketFilterBar';
 import { GoldListCTA } from '@/components/gold-list/GoldListCTA';
 import type { ScoreModeParam } from '@/components/show-cards';
+import type { AwardWinnerSets } from '@/lib/data-awards';
 import { hasEnoughReviews } from '@/config/score-buckets';
 
 // Serialized show data passed from server component
@@ -38,6 +39,7 @@ interface OffBroadwayPageClientProps {
   totalReviews: number;
   /** Open-show counts for the market pills */
   marketOpenCounts: { broadway: number; offBroadway: number };
+  awardWinnerSets?: AwardWinnerSets;
 }
 
 // URL parameter values

--- a/src/components/OffBroadwayPageClient.tsx
+++ b/src/components/OffBroadwayPageClient.tsx
@@ -9,6 +9,10 @@ import MarketFilterBar from '@/components/MarketFilterBar';
 import { GoldListCTA } from '@/components/gold-list/GoldListCTA';
 import type { ScoreModeParam } from '@/components/show-cards';
 import type { AwardWinnerSets } from '@/lib/data-awards';
+import { FilterButton } from '@/components/filters/FilterButton';
+import { FilterPanel } from '@/components/filters/FilterPanel';
+import { ActiveFilterChips } from '@/components/filters/ActiveFilterChips';
+import { usePanelFilters } from '@/lib/hooks/usePanelFilters';
 import { hasEnoughReviews } from '@/config/score-buckets';
 
 // Serialized show data passed from server component
@@ -106,7 +110,7 @@ function FeaturedRow({ title, shows }: { title: string; shows: OffBroadwayShow[]
 }
 
 // Inner component that uses searchParams
-function OffBroadwayPageInner({ shows, totalShows, totalReviews, marketOpenCounts }: OffBroadwayPageClientProps) {
+function OffBroadwayPageInner({ shows, totalShows, totalReviews, marketOpenCounts, awardWinnerSets }: OffBroadwayPageClientProps) {
   const initialSearchParams = useSearchParams();
 
   const [filters, setFilters] = useState(() => ({
@@ -308,6 +312,9 @@ function OffBroadwayPageInner({ shows, totalShows, totalReviews, marketOpenCount
     return result;
   }, [shows, fuseResults, statusFilter, type, searchQuery, sort, scoreMode]);
 
+  const panel = usePanelFilters({ shows: filteredAndSortedShows, awardWinnerSets });
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
+
   const shouldHideStatus = statusFilter !== 'all';
 
   return (
@@ -343,7 +350,7 @@ function OffBroadwayPageInner({ shows, totalShows, totalReviews, marketOpenCount
       )}
 
       {/* Search */}
-      <div id="search" className="relative mb-4 sm:mb-6 scroll-mt-24" role="search">
+      <div id="search" className="relative mb-2 scroll-mt-24" role="search">
         <label htmlFor="ob-show-search" className="sr-only">Search Off-Broadway shows</label>
         <div className="absolute inset-y-0 left-4 flex items-center pointer-events-none">
           <SearchIcon />
@@ -358,10 +365,35 @@ function OffBroadwayPageInner({ shows, totalShows, totalReviews, marketOpenCount
             setSearchInput(val);
             updateParams({ q: val });
           }}
-          className="search-input pl-12 focus-visible:outline-none"
+          className="search-input pl-12 pr-14 focus-visible:outline-none"
           autoComplete="off"
         />
+        <div className="absolute inset-y-0 right-2 flex items-center">
+          <FilterButton
+            activeCount={panel.activeCount}
+            isOpen={isPanelOpen}
+            onClick={() => setIsPanelOpen((v) => !v)}
+            controlsId="advanced-filter-panel"
+          />
+        </div>
       </div>
+
+      <div className="mb-2 sm:mb-4">
+        <ActiveFilterChips
+          chips={panel.chips}
+          onRemove={panel.removeChip}
+          onClearAll={panel.clearAll}
+        />
+      </div>
+
+      <FilterPanel
+        isOpen={isPanelOpen}
+        onClose={() => setIsPanelOpen(false)}
+        selectedByGroup={panel.selectedByGroup}
+        onToggle={panel.toggleOption}
+        onClearAll={panel.clearAll}
+        resultCount={panel.filteredShows.length}
+      />
 
       {/* Market + Type Filter Row */}
       <div className="flex items-center gap-2 sm:gap-4 mb-4">
@@ -418,9 +450,9 @@ function OffBroadwayPageInner({ shows, totalShows, totalReviews, marketOpenCount
 
       {/* Show List */}
       <h2 className="sr-only">Off-Broadway Shows</h2>
-      <ShowCardList shows={filteredAndSortedShows} hideStatus={shouldHideStatus} scoreMode={scoreMode} />
+      <ShowCardList shows={panel.filteredShows} hideStatus={shouldHideStatus} scoreMode={scoreMode} />
 
-      {filteredAndSortedShows.length === 0 && (
+      {panel.filteredShows.length === 0 && (
         <div className="card text-center py-16 px-6" role="status" aria-live="polite">
           <div className="w-16 h-16 rounded-full bg-surface-overlay mx-auto mb-4 flex items-center justify-center">
             <svg className="w-8 h-8 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -446,7 +478,7 @@ function OffBroadwayPageInner({ shows, totalShows, totalReviews, marketOpenCount
       )}
 
       <div className="mt-8 flex items-baseline justify-between text-sm text-gray-400">
-        <span>{filteredAndSortedShows.length} shows</span>
+        <span>{panel.filteredShows.length} shows</span>
         <Link href="/methodology" prefetch={false} className="text-brand hover:text-brand-hover transition-colors">
           How scores work →
         </Link>

--- a/src/components/OffBroadwayPageClient.tsx
+++ b/src/components/OffBroadwayPageClient.tsx
@@ -21,6 +21,8 @@ export interface OffBroadwayShow {
   status: string;
   type: string;
   isRevival?: boolean;
+  season?: string;
+  tags?: string[];
   reviewYearNote?: string;
   images?: { thumbnail?: string; poster?: string; hero?: string };
   criticScore?: { score?: number; reviewCount?: number; tier1Count?: number; tier2Count?: number };

--- a/src/components/OffWestEndPageClient.tsx
+++ b/src/components/OffWestEndPageClient.tsx
@@ -21,6 +21,8 @@ export interface OffWestEndShow {
   status: string;
   type: string;
   isRevival?: boolean;
+  season?: string;
+  tags?: string[];
   reviewYearNote?: string;
   images?: { thumbnail?: string; poster?: string; hero?: string };
   criticScore?: { score?: number; reviewCount?: number; tier1Count?: number; tier2Count?: number };

--- a/src/components/OffWestEndPageClient.tsx
+++ b/src/components/OffWestEndPageClient.tsx
@@ -150,12 +150,17 @@ function OffWestEndPageInner({ shows, totalShows, totalReviews, marketOpenCounts
         }
       }
 
-      const urlParams = new URLSearchParams();
-      if (next.status !== DEFAULT_STATUS) urlParams.set('status', next.status);
-      if (next.sort !== DEFAULT_SORT) urlParams.set('sort', next.sort);
-      if (next.type !== DEFAULT_TYPE) urlParams.set('type', next.type);
-      if (next.scoreMode !== DEFAULT_SCORE_MODE) urlParams.set('scoreMode', next.scoreMode);
-      if (next.q) urlParams.set('q', next.q);
+      // Preserve unknown params (panel filters) so they survive inline-filter changes
+      const urlParams = new URLSearchParams(window.location.search);
+      const setOrDelete = (key: string, value: string, isDefault: boolean) => {
+        if (isDefault) urlParams.delete(key);
+        else urlParams.set(key, value);
+      };
+      setOrDelete('status', next.status, next.status === DEFAULT_STATUS);
+      setOrDelete('sort', next.sort, next.sort === DEFAULT_SORT);
+      setOrDelete('type', next.type, next.type === DEFAULT_TYPE);
+      setOrDelete('scoreMode', next.scoreMode, next.scoreMode === DEFAULT_SCORE_MODE);
+      setOrDelete('q', next.q, !next.q);
 
       const paramString = urlParams.toString();
       window.history.replaceState({}, '', paramString ? `/off-west-end?${paramString}` : '/off-west-end');
@@ -312,7 +317,7 @@ function OffWestEndPageInner({ shows, totalShows, totalReviews, marketOpenCounts
     return result;
   }, [shows, fuseResults, statusFilter, type, searchQuery, sort, scoreMode]);
 
-  const panel = usePanelFilters({ shows: filteredAndSortedShows, awardWinnerSets });
+  const panel = usePanelFilters({ shows: filteredAndSortedShows, awardWinnerSets, scoreMode });
   const [isPanelOpen, setIsPanelOpen] = useState(false);
 
   const shouldHideStatus = statusFilter !== 'all';

--- a/src/components/OffWestEndPageClient.tsx
+++ b/src/components/OffWestEndPageClient.tsx
@@ -9,6 +9,10 @@ import MarketFilterBar from '@/components/MarketFilterBar';
 import type { ScoreModeParam } from '@/components/show-cards';
 import { GoldListCTA } from '@/components/gold-list/GoldListCTA';
 import type { AwardWinnerSets } from '@/lib/data-awards';
+import { FilterButton } from '@/components/filters/FilterButton';
+import { FilterPanel } from '@/components/filters/FilterPanel';
+import { ActiveFilterChips } from '@/components/filters/ActiveFilterChips';
+import { usePanelFilters } from '@/lib/hooks/usePanelFilters';
 import { hasEnoughReviews } from '@/config/score-buckets';
 
 // Serialized show data passed from server component
@@ -106,7 +110,7 @@ function FeaturedRow({ title, shows }: { title: string; shows: OffWestEndShow[] 
 }
 
 // Inner component that uses searchParams
-function OffWestEndPageInner({ shows, totalShows, totalReviews, marketOpenCounts }: OffWestEndPageClientProps) {
+function OffWestEndPageInner({ shows, totalShows, totalReviews, marketOpenCounts, awardWinnerSets }: OffWestEndPageClientProps) {
   const initialSearchParams = useSearchParams();
 
   const [filters, setFilters] = useState(() => ({
@@ -308,6 +312,9 @@ function OffWestEndPageInner({ shows, totalShows, totalReviews, marketOpenCounts
     return result;
   }, [shows, fuseResults, statusFilter, type, searchQuery, sort, scoreMode]);
 
+  const panel = usePanelFilters({ shows: filteredAndSortedShows, awardWinnerSets });
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
+
   const shouldHideStatus = statusFilter !== 'all';
 
   return (
@@ -343,7 +350,7 @@ function OffWestEndPageInner({ shows, totalShows, totalReviews, marketOpenCounts
       )}
 
       {/* Search */}
-      <div id="search" className="relative mb-4 sm:mb-6 scroll-mt-24" role="search">
+      <div id="search" className="relative mb-2 scroll-mt-24" role="search">
         <label htmlFor="owe-show-search" className="sr-only">Search Off-West End shows</label>
         <div className="absolute inset-y-0 left-4 flex items-center pointer-events-none">
           <SearchIcon />
@@ -358,10 +365,35 @@ function OffWestEndPageInner({ shows, totalShows, totalReviews, marketOpenCounts
             setSearchInput(val);
             updateParams({ q: val });
           }}
-          className="search-input pl-12 focus-visible:outline-none"
+          className="search-input pl-12 pr-14 focus-visible:outline-none"
           autoComplete="off"
         />
+        <div className="absolute inset-y-0 right-2 flex items-center">
+          <FilterButton
+            activeCount={panel.activeCount}
+            isOpen={isPanelOpen}
+            onClick={() => setIsPanelOpen((v) => !v)}
+            controlsId="advanced-filter-panel"
+          />
+        </div>
       </div>
+
+      <div className="mb-2 sm:mb-4">
+        <ActiveFilterChips
+          chips={panel.chips}
+          onRemove={panel.removeChip}
+          onClearAll={panel.clearAll}
+        />
+      </div>
+
+      <FilterPanel
+        isOpen={isPanelOpen}
+        onClose={() => setIsPanelOpen(false)}
+        selectedByGroup={panel.selectedByGroup}
+        onToggle={panel.toggleOption}
+        onClearAll={panel.clearAll}
+        resultCount={panel.filteredShows.length}
+      />
 
       {/* Market + Type Filter Row */}
       <div className="flex items-center gap-2 sm:gap-4 mb-4">
@@ -418,9 +450,9 @@ function OffWestEndPageInner({ shows, totalShows, totalReviews, marketOpenCounts
 
       {/* Show List */}
       <h2 className="sr-only">Off-West End Shows</h2>
-      <ShowCardList shows={filteredAndSortedShows} hideStatus={shouldHideStatus} scoreMode={scoreMode} />
+      <ShowCardList shows={panel.filteredShows} hideStatus={shouldHideStatus} scoreMode={scoreMode} />
 
-      {filteredAndSortedShows.length === 0 && (
+      {panel.filteredShows.length === 0 && (
         <div className="card text-center py-16 px-6" role="status" aria-live="polite">
           <div className="w-16 h-16 rounded-full bg-surface-overlay mx-auto mb-4 flex items-center justify-center">
             <svg className="w-8 h-8 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -446,7 +478,7 @@ function OffWestEndPageInner({ shows, totalShows, totalReviews, marketOpenCounts
       )}
 
       <div className="mt-8 flex items-baseline justify-between text-sm text-gray-400">
-        <span>{filteredAndSortedShows.length} shows</span>
+        <span>{panel.filteredShows.length} shows</span>
         <Link href="/west-end/methodology" prefetch={false} className="text-violet-400 hover:text-violet-300 transition-colors">
           How scores work →
         </Link>

--- a/src/components/OffWestEndPageClient.tsx
+++ b/src/components/OffWestEndPageClient.tsx
@@ -8,6 +8,7 @@ import { SCORE_TIERS, ToggleBar, ScoreToggle, ShowListCard, MiniShowCard } from 
 import MarketFilterBar from '@/components/MarketFilterBar';
 import type { ScoreModeParam } from '@/components/show-cards';
 import { GoldListCTA } from '@/components/gold-list/GoldListCTA';
+import type { AwardWinnerSets } from '@/lib/data-awards';
 import { hasEnoughReviews } from '@/config/score-buckets';
 
 // Serialized show data passed from server component
@@ -38,6 +39,7 @@ interface OffWestEndPageClientProps {
   totalReviews: number;
   /** Open-show counts for the market pills */
   marketOpenCounts: { westEnd: number; offWestEnd: number };
+  awardWinnerSets?: AwardWinnerSets;
 }
 
 // URL parameter values

--- a/src/components/WestEndPageClient.tsx
+++ b/src/components/WestEndPageClient.tsx
@@ -165,13 +165,18 @@ function WestEndPageInner({ shows, totalShows, totalReviews, scoredShows, lotter
         }
       }
 
-      const urlParams = new URLSearchParams();
-      if (next.status !== DEFAULT_STATUS) urlParams.set('status', next.status);
-      if (next.sort !== DEFAULT_SORT) urlParams.set('sort', next.sort);
-      if (next.type !== DEFAULT_TYPE) urlParams.set('type', next.type);
-      if (next.scoreMode !== DEFAULT_SCORE_MODE) urlParams.set('scoreMode', next.scoreMode);
-      if (next.q) urlParams.set('q', next.q);
-      if (next.venue === 'west-end-only') urlParams.set('venue', next.venue);
+      // Preserve unknown params (panel filters) so they survive inline-filter changes
+      const urlParams = new URLSearchParams(window.location.search);
+      const setOrDelete = (key: string, value: string, isDefault: boolean) => {
+        if (isDefault) urlParams.delete(key);
+        else urlParams.set(key, value);
+      };
+      setOrDelete('status', next.status, next.status === DEFAULT_STATUS);
+      setOrDelete('sort', next.sort, next.sort === DEFAULT_SORT);
+      setOrDelete('type', next.type, next.type === DEFAULT_TYPE);
+      setOrDelete('scoreMode', next.scoreMode, next.scoreMode === DEFAULT_SCORE_MODE);
+      setOrDelete('q', next.q, !next.q);
+      setOrDelete('venue', next.venue, next.venue !== 'west-end-only');
 
       const paramString = urlParams.toString();
       window.history.replaceState({}, '', paramString ? `/west-end?${paramString}` : '/west-end');
@@ -402,7 +407,7 @@ function WestEndPageInner({ shows, totalShows, totalReviews, scoredShows, lotter
     return result;
   }, [shows, fuseResults, statusFilter, type, searchQuery, sort, scoreMode, venueFilter]);
 
-  const panel = usePanelFilters({ shows: filteredAndSortedShows, awardWinnerSets });
+  const panel = usePanelFilters({ shows: filteredAndSortedShows, awardWinnerSets, scoreMode });
   const [isPanelOpen, setIsPanelOpen] = useState(false);
 
   const shouldHideStatus = statusFilter !== 'all';

--- a/src/components/WestEndPageClient.tsx
+++ b/src/components/WestEndPageClient.tsx
@@ -8,6 +8,10 @@ import { SCORE_TIERS, ToggleBar, ScoreToggle, ShowListCard, MiniShowCard } from 
 import MarketFilterBar from '@/components/MarketFilterBar';
 import type { ScoreModeParam } from '@/components/show-cards';
 import type { AwardWinnerSets } from '@/lib/data-awards';
+import { FilterButton } from '@/components/filters/FilterButton';
+import { FilterPanel } from '@/components/filters/FilterPanel';
+import { ActiveFilterChips } from '@/components/filters/ActiveFilterChips';
+import { usePanelFilters } from '@/lib/hooks/usePanelFilters';
 import { hasEnoughReviews } from '@/config/score-buckets';
 
 // Serialized show data passed from server component
@@ -118,7 +122,7 @@ function FeaturedRow({ title, subtitle, shows }: { title: string; subtitle?: str
 }
 
 // Inner component that uses searchParams
-function WestEndPageInner({ shows, totalShows, totalReviews, scoredShows, lotteryShows = [], rushShows = [], marketOpenCounts }: WestEndPageClientProps) {
+function WestEndPageInner({ shows, totalShows, totalReviews, scoredShows, lotteryShows = [], rushShows = [], marketOpenCounts, awardWinnerSets }: WestEndPageClientProps) {
   const initialSearchParams = useSearchParams();
 
   const [filters, setFilters] = useState(() => ({
@@ -398,6 +402,9 @@ function WestEndPageInner({ shows, totalShows, totalReviews, scoredShows, lotter
     return result;
   }, [shows, fuseResults, statusFilter, type, searchQuery, sort, scoreMode, venueFilter]);
 
+  const panel = usePanelFilters({ shows: filteredAndSortedShows, awardWinnerSets });
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
+
   const shouldHideStatus = statusFilter !== 'all';
 
   return (
@@ -431,7 +438,7 @@ function WestEndPageInner({ shows, totalShows, totalReviews, scoredShows, lotter
       )}
 
       {/* Search */}
-      <div id="search" className="relative mb-4 sm:mb-6 scroll-mt-24" role="search">
+      <div id="search" className="relative mb-2 scroll-mt-24" role="search">
         <label htmlFor="we-show-search" className="sr-only">Search West End shows</label>
         <div className="absolute inset-y-0 left-4 flex items-center pointer-events-none">
           <SearchIcon />
@@ -446,10 +453,35 @@ function WestEndPageInner({ shows, totalShows, totalReviews, scoredShows, lotter
             setSearchInput(val);
             updateParams({ q: val });
           }}
-          className="search-input pl-12 focus-visible:outline-none"
+          className="search-input pl-12 pr-14 focus-visible:outline-none"
           autoComplete="off"
         />
+        <div className="absolute inset-y-0 right-2 flex items-center">
+          <FilterButton
+            activeCount={panel.activeCount}
+            isOpen={isPanelOpen}
+            onClick={() => setIsPanelOpen((v) => !v)}
+            controlsId="advanced-filter-panel"
+          />
+        </div>
       </div>
+
+      <div className="mb-2 sm:mb-4">
+        <ActiveFilterChips
+          chips={panel.chips}
+          onRemove={panel.removeChip}
+          onClearAll={panel.clearAll}
+        />
+      </div>
+
+      <FilterPanel
+        isOpen={isPanelOpen}
+        onClose={() => setIsPanelOpen(false)}
+        selectedByGroup={panel.selectedByGroup}
+        onToggle={panel.toggleOption}
+        onClearAll={panel.clearAll}
+        resultCount={panel.filteredShows.length}
+      />
 
       {/* Market + Type Filter Row */}
       <div className="flex items-center gap-2 sm:gap-4 mb-4">
@@ -522,9 +554,9 @@ function WestEndPageInner({ shows, totalShows, totalReviews, scoredShows, lotter
 
       {/* Show List */}
       <h2 className="sr-only">West End Shows</h2>
-      <ShowCardList shows={filteredAndSortedShows} hideStatus={shouldHideStatus} scoreMode={scoreMode} />
+      <ShowCardList shows={panel.filteredShows} hideStatus={shouldHideStatus} scoreMode={scoreMode} />
 
-      {filteredAndSortedShows.length === 0 && (
+      {panel.filteredShows.length === 0 && (
         <div className="card text-center py-16 px-6" role="status" aria-live="polite">
           <div className="w-16 h-16 rounded-full bg-surface-overlay mx-auto mb-4 flex items-center justify-center">
             <svg className="w-8 h-8 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -550,7 +582,7 @@ function WestEndPageInner({ shows, totalShows, totalReviews, scoredShows, lotter
       )}
 
       <div className="mt-8 flex items-baseline justify-between text-sm text-gray-400">
-        <span>{filteredAndSortedShows.length} shows</span>
+        <span>{panel.filteredShows.length} shows</span>
         <Link href="/methodology" prefetch={false} className="text-brand hover:text-brand-hover transition-colors">
           How scores work →
         </Link>

--- a/src/components/WestEndPageClient.tsx
+++ b/src/components/WestEndPageClient.tsx
@@ -7,6 +7,7 @@ import type Fuse from 'fuse.js';
 import { SCORE_TIERS, ToggleBar, ScoreToggle, ShowListCard, MiniShowCard } from '@/components/show-cards';
 import MarketFilterBar from '@/components/MarketFilterBar';
 import type { ScoreModeParam } from '@/components/show-cards';
+import type { AwardWinnerSets } from '@/lib/data-awards';
 import { hasEnoughReviews } from '@/config/score-buckets';
 
 // Serialized show data passed from server component
@@ -45,6 +46,7 @@ interface WestEndPageClientProps {
   rushShows?: WestEndShow[];
   /** Open-show counts for the market pills */
   marketOpenCounts: { westEnd: number; offWestEnd: number };
+  awardWinnerSets?: AwardWinnerSets;
 }
 
 // URL parameter values

--- a/src/components/WestEndPageClient.tsx
+++ b/src/components/WestEndPageClient.tsx
@@ -21,6 +21,7 @@ export interface WestEndShow {
   status: string;
   type: string;
   isRevival?: boolean;
+  season?: string;
   reviewYearNote?: string;
   images?: { thumbnail?: string; poster?: string; hero?: string };
   criticScore?: { score?: number; reviewCount?: number; tier1Count?: number; tier2Count?: number };

--- a/src/components/filters/ActiveFilterChips.tsx
+++ b/src/components/filters/ActiveFilterChips.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+export interface ActiveFilterChip {
+  /** Stable key — typically the predicate id */
+  key: string;
+  label: string;
+}
+
+interface ActiveFilterChipsProps {
+  chips: ActiveFilterChip[];
+  onRemove: (key: string) => void;
+  onClearAll: () => void;
+}
+
+/**
+ * Horizontal chip row shown below the search bar when any panel filter
+ * is active. Each chip removes its filter; "Clear all" removes all panel
+ * filters (existing inline filters — Status/Sort/Type — untouched).
+ */
+export function ActiveFilterChips({ chips, onRemove, onClearAll }: ActiveFilterChipsProps) {
+  if (chips.length === 0) return null;
+
+  return (
+    <div
+      className="flex items-center gap-1.5 px-1 pb-2 overflow-x-auto flex-nowrap scrollbar-hide [mask-image:linear-gradient(to_right,black_calc(100%-24px),transparent_100%)] sm:[mask-image:none]"
+      role="group"
+      aria-label="Active filters"
+    >
+      {chips.map((chip) => (
+        <button
+          key={chip.key}
+          type="button"
+          onClick={() => onRemove(chip.key)}
+          aria-label={`Remove ${chip.label}`}
+          className="flex-shrink-0 inline-flex items-center gap-1 bg-brand/10 border border-brand/30 text-brand text-xs font-semibold pl-2.5 pr-1.5 py-1.5 rounded-full hover:bg-brand/20 transition-colors"
+        >
+          <span>{chip.label}</span>
+          <svg viewBox="0 0 12 12" stroke="currentColor" strokeWidth={2} fill="none" className="w-3 h-3">
+            <path d="M2 2 L10 10 M10 2 L2 10" />
+          </svg>
+        </button>
+      ))}
+      <button
+        type="button"
+        onClick={onClearAll}
+        className="flex-shrink-0 ml-auto pl-2 text-xs text-gray-400 hover:text-white underline underline-offset-4"
+      >
+        Clear all
+      </button>
+    </div>
+  );
+}

--- a/src/components/filters/FilterButton.tsx
+++ b/src/components/filters/FilterButton.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+interface FilterButtonProps {
+  activeCount: number;
+  isOpen: boolean;
+  onClick: () => void;
+  controlsId?: string;
+}
+
+/**
+ * Filter icon button intended to live inside the search bar (right side).
+ * Shows a numeric badge when filters are applied.
+ */
+export function FilterButton({ activeCount, isOpen, onClick, controlsId }: FilterButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-expanded={isOpen}
+      aria-controls={controlsId}
+      aria-label={activeCount > 0 ? `Filters (${activeCount} active)` : 'Open filters'}
+      className={`relative w-10 h-10 inline-flex items-center justify-center rounded-lg transition-colors ${
+        isOpen || activeCount > 0
+          ? 'text-brand'
+          : 'text-gray-300 hover:text-white'
+      }`}
+    >
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={activeCount > 0 || isOpen ? 2.4 : 2} strokeLinecap="round" className="w-5 h-5">
+        <line x1="4" y1="6" x2="20" y2="6" />
+        <line x1="7" y1="12" x2="17" y2="12" />
+        <line x1="10" y1="18" x2="14" y2="18" />
+      </svg>
+      {activeCount > 0 && (
+        <span className="absolute top-1 right-1 min-w-[16px] h-4 px-1 bg-brand text-gray-900 text-[10px] font-bold rounded-full flex items-center justify-center border-2 border-surface-raised box-content tabular-nums">
+          {activeCount}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/components/filters/FilterPanel.tsx
+++ b/src/components/filters/FilterPanel.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useEffect, useId } from 'react';
+import { useFocusTrap } from '@/lib/hooks/useFocusTrap';
+import { FILTER_GROUPS } from './filter-ui-config';
+import { FilterPillGroup } from './FilterPillGroup';
+
+interface FilterPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  selectedByGroup: Record<string, ReadonlySet<string>>;
+  onToggle: (paramKey: string, id: string) => void;
+  onClearAll: () => void;
+  resultCount: number;
+}
+
+/**
+ * Bottom-sheet on mobile (<640px), popover on desktop (>=640px).
+ * Wraps focus, dismisses on Esc, applies live (no separate Apply button —
+ * the bottom button shows the result count and acts as a confirm/close).
+ */
+export function FilterPanel({
+  isOpen,
+  onClose,
+  selectedByGroup,
+  onToggle,
+  onClearAll,
+  resultCount,
+}: FilterPanelProps) {
+  const headingId = useId();
+  const containerRef = useFocusTrap<HTMLDivElement>(isOpen);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', onKey);
+    // Lock body scroll while open (mobile sheet)
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm sm:bg-black/30"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Sheet (mobile) / Popover (desktop) */}
+      <div
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        className={[
+          // Mobile: full-width bottom sheet
+          'fixed bottom-0 left-0 right-0 z-50 max-h-[78vh] flex flex-col',
+          'bg-surface-raised border-t border-white/10 rounded-t-2xl shadow-[0_-10px_40px_rgba(0,0,0,0.5)]',
+          // Desktop: centered popover
+          'sm:bottom-auto sm:top-24 sm:left-1/2 sm:right-auto sm:-translate-x-1/2 sm:w-[420px] sm:max-h-[80vh] sm:rounded-2xl sm:border sm:shadow-2xl',
+          'animate-in slide-in-from-bottom-4 sm:slide-in-from-top-2 duration-200',
+        ].join(' ')}
+      >
+        {/* Drag handle (mobile) */}
+        <div className="sm:hidden w-9 h-1 bg-white/15 rounded-full mx-auto mt-2 mb-1 flex-shrink-0" aria-hidden="true" />
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-white/5 flex-shrink-0">
+          <h2 id={headingId} className="text-base font-bold text-white">Filters</h2>
+          <button
+            type="button"
+            onClick={onClearAll}
+            className="text-sm text-gray-400 hover:text-white"
+          >
+            Reset
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-2">
+          {FILTER_GROUPS.map((group) => (
+            <div key={group.paramKey} className="py-3 border-b border-white/5 last:border-b-0">
+              <h3 className="text-[11px] font-bold uppercase tracking-wider text-gray-500 mb-2.5">
+                {group.label}
+              </h3>
+              <FilterPillGroup
+                options={group.options.map((o) => ({ value: o.id, label: o.label }))}
+                selected={selectedByGroup[group.paramKey] ?? new Set()}
+                onToggle={(id) => onToggle(group.paramKey, id)}
+                ariaLabel={`${group.label} filters`}
+              />
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="flex-shrink-0 px-5 py-3 border-t border-white/5 bg-surface-raised">
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-full bg-brand text-gray-900 font-bold py-3.5 rounded-xl text-sm tracking-wide shadow-glow-sm hover:bg-brand-hover transition-colors"
+          >
+            Show {resultCount} {resultCount === 1 ? 'show' : 'shows'}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/filters/FilterPillGroup.tsx
+++ b/src/components/filters/FilterPillGroup.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+interface FilterPillOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface FilterPillGroupProps<T extends string> {
+  options: FilterPillOption<T>[];
+  /** Currently-selected values (multi-select) */
+  selected: ReadonlySet<T>;
+  /** Toggle a single option */
+  onToggle: (value: T) => void;
+  ariaLabel?: string;
+}
+
+/**
+ * Multi-select pill group. Visually matches ToggleBar variant="pill"
+ * (src/components/show-cards/ToggleBar.tsx) but allows multiple
+ * concurrent selections. Used inside the advanced filter panel.
+ */
+export function FilterPillGroup<T extends string>({ options, selected, onToggle, ariaLabel }: FilterPillGroupProps<T>) {
+  return (
+    <div className="flex flex-wrap items-center gap-2" role="group" aria-label={ariaLabel}>
+      {options.map((opt) => {
+        const isSelected = selected.has(opt.value);
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onToggle(opt.value)}
+            aria-pressed={isSelected}
+            className={`px-3 sm:px-4 py-2.5 sm:py-2 min-h-[44px] sm:min-h-0 text-xs sm:text-sm leading-none font-semibold inline-flex items-center gap-1.5 justify-center rounded-full transition-all ${
+              isSelected
+                ? 'bg-brand/10 text-brand border border-brand/40'
+                : 'bg-surface-overlay text-gray-300 border border-white/10 hover:text-white hover:border-white/20'
+            }`}
+          >
+            {opt.label}
+            {isSelected && (
+              <span className="w-3.5 h-3.5 rounded-full bg-brand text-gray-900 inline-flex items-center justify-center text-[10px] font-bold">
+                ✓
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/filters/filter-ui-config.ts
+++ b/src/components/filters/filter-ui-config.ts
@@ -1,0 +1,104 @@
+/**
+ * Single source of truth for panel filter UI metadata + predicate wiring.
+ * The panel reads this to render groups; the hook reads it to apply
+ * predicates against the show list.
+ */
+import {
+  type FilterPredicate,
+  PRODUCTION_ORIGINAL,
+  PRODUCTION_REVIVAL,
+  AWARD_TONY_WINNER,
+  AWARD_TONY_NOMINEE,
+  AWARD_OLIVIER_WINNER,
+  AWARD_OLIVIER_NOMINEE,
+  AWARD_DRAMA_DESK_WINNER,
+  AWARD_PULITZER,
+  TICKETS_LOTTERY,
+  TICKETS_RUSH,
+  GENRE_COMEDY,
+  GENRE_DRAMA,
+  FORMAT_JUKEBOX,
+  FORMAT_CONCERT,
+  FORMAT_SOLO_SHOW,
+  FORMAT_IMMERSIVE,
+  FORMAT_REVUE,
+  SOURCE_BASED_ON_BOOK,
+  SOURCE_BASED_ON_TRUE_STORY,
+  SOURCE_FILM_ADAPTATION,
+  SOURCE_DISNEY,
+} from '@/lib/show-filter-predicates';
+
+export interface FilterOption {
+  /** Stable id — used in URL and as predicate key */
+  id: string;
+  label: string;
+  predicate: FilterPredicate;
+}
+
+export interface FilterGroupConfig {
+  /** URL param key (e.g. "production") — comma-separated multi-value */
+  paramKey: string;
+  label: string;
+  options: FilterOption[];
+}
+
+export const FILTER_GROUPS: FilterGroupConfig[] = [
+  {
+    paramKey: 'production',
+    label: 'Production',
+    options: [
+      { id: 'original', label: 'Original', predicate: PRODUCTION_ORIGINAL },
+      { id: 'revival', label: 'Revival', predicate: PRODUCTION_REVIVAL },
+    ],
+  },
+  {
+    paramKey: 'awards',
+    label: 'Awards',
+    options: [
+      { id: 'tony-winner', label: 'Tony winner', predicate: AWARD_TONY_WINNER },
+      { id: 'tony-nominee', label: 'Tony nominee', predicate: AWARD_TONY_NOMINEE },
+      { id: 'olivier-winner', label: 'Olivier winner', predicate: AWARD_OLIVIER_WINNER },
+      { id: 'olivier-nominee', label: 'Olivier nominee', predicate: AWARD_OLIVIER_NOMINEE },
+      { id: 'drama-desk', label: 'Drama Desk winner', predicate: AWARD_DRAMA_DESK_WINNER },
+      { id: 'pulitzer', label: 'Pulitzer (Drama)', predicate: AWARD_PULITZER },
+    ],
+  },
+  {
+    paramKey: 'genre',
+    label: 'Genre & format',
+    options: [
+      { id: 'comedy', label: 'Comedy', predicate: GENRE_COMEDY },
+      { id: 'drama', label: 'Drama', predicate: GENRE_DRAMA },
+      { id: 'jukebox', label: 'Jukebox', predicate: FORMAT_JUKEBOX },
+      { id: 'concert', label: 'Concert', predicate: FORMAT_CONCERT },
+      { id: 'solo-show', label: 'Solo show', predicate: FORMAT_SOLO_SHOW },
+      { id: 'immersive', label: 'Immersive', predicate: FORMAT_IMMERSIVE },
+      { id: 'revue', label: 'Revue', predicate: FORMAT_REVUE },
+      { id: 'based-on-book', label: 'Based on book', predicate: SOURCE_BASED_ON_BOOK },
+      { id: 'based-on-true-story', label: 'Based on true story', predicate: SOURCE_BASED_ON_TRUE_STORY },
+      { id: 'film-adaptation', label: 'Film adaptation', predicate: SOURCE_FILM_ADAPTATION },
+      { id: 'disney', label: 'Disney', predicate: SOURCE_DISNEY },
+    ],
+  },
+  {
+    paramKey: 'tickets',
+    label: 'Tickets & access',
+    options: [
+      { id: 'lottery', label: 'Has lottery', predicate: TICKETS_LOTTERY },
+      { id: 'rush', label: 'Has rush', predicate: TICKETS_RUSH },
+    ],
+  },
+];
+
+/** All param keys owned by the panel — used to scope Reset / Clear-all */
+export const PANEL_PARAM_KEYS: ReadonlySet<string> = new Set([
+  ...FILTER_GROUPS.map((g) => g.paramKey),
+  'years', // time-period range (Sprint 3)
+  'score_tier', // score-tier multi-select (Sprint 3)
+]);
+
+/** Look up an option by paramKey + id */
+export function findFilterOption(paramKey: string, id: string): FilterOption | undefined {
+  const group = FILTER_GROUPS.find((g) => g.paramKey === paramKey);
+  return group?.options.find((o) => o.id === id);
+}

--- a/src/components/filters/filter-ui-config.ts
+++ b/src/components/filters/filter-ui-config.ts
@@ -13,6 +13,11 @@ import {
   AWARD_OLIVIER_NOMINEE,
   AWARD_DRAMA_DESK_WINNER,
   AWARD_PULITZER,
+  SCORE_TIER_CRITICAL_GOLD,
+  SCORE_TIER_RECOMMENDED,
+  SCORE_TIER_WORTH_SEEING,
+  SCORE_TIER_SKIPPABLE,
+  SCORE_TIER_CRITICAL_MISS,
   TICKETS_LOTTERY,
   TICKETS_RUSH,
   GENRE_COMEDY,
@@ -49,6 +54,17 @@ export const FILTER_GROUPS: FilterGroupConfig[] = [
     options: [
       { id: 'original', label: 'Original', predicate: PRODUCTION_ORIGINAL },
       { id: 'revival', label: 'Revival', predicate: PRODUCTION_REVIVAL },
+    ],
+  },
+  {
+    paramKey: 'score_tier',
+    label: 'Score tier',
+    options: [
+      { id: 'critical-gold', label: 'Critical Gold (83+)', predicate: SCORE_TIER_CRITICAL_GOLD },
+      { id: 'recommended', label: 'Recommended (75–82)', predicate: SCORE_TIER_RECOMMENDED },
+      { id: 'worth-seeing', label: 'Worth Seeing (65–74)', predicate: SCORE_TIER_WORTH_SEEING },
+      { id: 'skippable', label: 'Skippable (55–64)', predicate: SCORE_TIER_SKIPPABLE },
+      { id: 'critical-miss', label: 'Critical Miss (<55)', predicate: SCORE_TIER_CRITICAL_MISS },
     ],
   },
   {
@@ -93,8 +109,7 @@ export const FILTER_GROUPS: FilterGroupConfig[] = [
 /** All param keys owned by the panel — used to scope Reset / Clear-all */
 export const PANEL_PARAM_KEYS: ReadonlySet<string> = new Set([
   ...FILTER_GROUPS.map((g) => g.paramKey),
-  'years', // time-period range (Sprint 3)
-  'score_tier', // score-tier multi-select (Sprint 3)
+  'years', // time-period range (Sprint 3 — slider not yet shipped)
 ]);
 
 /** Look up an option by paramKey + id */

--- a/src/components/filters/filter-ui-config.ts
+++ b/src/components/filters/filter-ui-config.ts
@@ -12,7 +12,6 @@ import {
   AWARD_OLIVIER_WINNER,
   AWARD_OLIVIER_NOMINEE,
   AWARD_DRAMA_DESK_WINNER,
-  AWARD_PULITZER,
   SCORE_TIER_CRITICAL_GOLD,
   SCORE_TIER_RECOMMENDED,
   SCORE_TIER_WORTH_SEEING,
@@ -23,15 +22,15 @@ import {
   GENRE_COMEDY,
   GENRE_DRAMA,
   FORMAT_JUKEBOX,
-  FORMAT_CONCERT,
-  FORMAT_SOLO_SHOW,
-  FORMAT_IMMERSIVE,
-  FORMAT_REVUE,
   SOURCE_BASED_ON_BOOK,
   SOURCE_BASED_ON_TRUE_STORY,
   SOURCE_FILM_ADAPTATION,
   SOURCE_DISNEY,
 } from '@/lib/show-filter-predicates';
+// Excluded from v1 — match 0 (concert, revue) or 0 currently-open shows
+// (solo-show, immersive). Predicates remain in show-filter-predicates.ts
+// and can be re-added when tag coverage improves.
+// AWARD_PULITZER: 1 entry in awards.json (Hamilton only) — defer until backfilled.
 
 export interface FilterOption {
   /** Stable id — used in URL and as predicate key */
@@ -76,7 +75,6 @@ export const FILTER_GROUPS: FilterGroupConfig[] = [
       { id: 'olivier-winner', label: 'Olivier winner', predicate: AWARD_OLIVIER_WINNER },
       { id: 'olivier-nominee', label: 'Olivier nominee', predicate: AWARD_OLIVIER_NOMINEE },
       { id: 'drama-desk', label: 'Drama Desk winner', predicate: AWARD_DRAMA_DESK_WINNER },
-      { id: 'pulitzer', label: 'Pulitzer (Drama)', predicate: AWARD_PULITZER },
     ],
   },
   {
@@ -86,10 +84,6 @@ export const FILTER_GROUPS: FilterGroupConfig[] = [
       { id: 'comedy', label: 'Comedy', predicate: GENRE_COMEDY },
       { id: 'drama', label: 'Drama', predicate: GENRE_DRAMA },
       { id: 'jukebox', label: 'Jukebox', predicate: FORMAT_JUKEBOX },
-      { id: 'concert', label: 'Concert', predicate: FORMAT_CONCERT },
-      { id: 'solo-show', label: 'Solo show', predicate: FORMAT_SOLO_SHOW },
-      { id: 'immersive', label: 'Immersive', predicate: FORMAT_IMMERSIVE },
-      { id: 'revue', label: 'Revue', predicate: FORMAT_REVUE },
       { id: 'based-on-book', label: 'Based on book', predicate: SOURCE_BASED_ON_BOOK },
       { id: 'based-on-true-story', label: 'Based on true story', predicate: SOURCE_BASED_ON_TRUE_STORY },
       { id: 'film-adaptation', label: 'Film adaptation', predicate: SOURCE_FILM_ADAPTATION },

--- a/src/components/show-cards/types.ts
+++ b/src/components/show-cards/types.ts
@@ -23,6 +23,7 @@ export interface ShowCardShow {
   status: string;
   type: string;
   isRevival?: boolean;
+  season?: string;
   reviewYearNote?: string;
   images?: { thumbnail?: string; poster?: string; hero?: string };
   criticScore?: { score?: number; reviewCount?: number; tier1Count?: number; tier2Count?: number };

--- a/src/lib/data-awards.ts
+++ b/src/lib/data-awards.ts
@@ -1,5 +1,7 @@
 // Awards data module
-// Imports: awards.json only (~35 KB)
+// Imports: awards.json (~612 KB) — server-only. Never import this from a
+// client component. For client filtering, see getAwardWinnerSets() which
+// returns small ID arrays meant to be passed as props.
 
 import type { ShowAwards, AwardsDesignation } from './data-types';
 import awardsData from '../../data/awards.json';
@@ -111,4 +113,63 @@ export function isTopTonyWinner(showId: string): boolean {
  */
 export function getAwardsLastUpdated(): string {
   return awards._meta.lastUpdated;
+}
+
+/**
+ * Pre-compute the set of show IDs that won/were nominated for each award.
+ * Called once per page server-side; the resulting arrays ship to the client
+ * (~hundreds of strings) instead of the full 600KB awards.json blob.
+ *
+ * Predicates in src/lib/show-filter-predicates.ts consume these via
+ * FilterPredicateCtx (Sets reconstructed client-side from the arrays).
+ */
+export interface AwardWinnerSets {
+  tonyWinnerIds: string[];
+  tonyNomineeIds: string[];
+  olivierWinnerIds: string[];
+  olivierNomineeIds: string[];
+  dramaDeskWinnerIds: string[];
+  pulitzerWinnerIds: string[];
+}
+
+interface OlivierAwards {
+  wins?: string[];
+  nominations?: number;
+  nominatedFor?: string[];
+}
+
+export function getAwardWinnerSets(): AwardWinnerSets {
+  const tonyWinnerIds: string[] = [];
+  const tonyNomineeIds: string[] = [];
+  const olivierWinnerIds: string[] = [];
+  const olivierNomineeIds: string[] = [];
+  const dramaDeskWinnerIds: string[] = [];
+  const pulitzerWinnerIds: string[] = [];
+
+  for (const [showId, showAwards] of Object.entries(awards.shows)) {
+    if (showAwards.tony) {
+      const wins = showAwards.tony.wins?.length ?? 0;
+      const noms = showAwards.tony.nominations ?? 0;
+      if (wins > 0) tonyWinnerIds.push(showId);
+      if (wins > 0 || noms > 0) tonyNomineeIds.push(showId);
+    }
+    const olivier = (showAwards as ShowAwards & { olivier?: OlivierAwards }).olivier;
+    if (olivier) {
+      const wins = olivier.wins?.length ?? 0;
+      const noms = olivier.nominations ?? 0;
+      if (wins > 0) olivierWinnerIds.push(showId);
+      if (wins > 0 || noms > 0) olivierNomineeIds.push(showId);
+    }
+    if (showAwards.dramadesk?.wins?.length) dramaDeskWinnerIds.push(showId);
+    if (showAwards.pulitzer) pulitzerWinnerIds.push(showId);
+  }
+
+  return {
+    tonyWinnerIds,
+    tonyNomineeIds,
+    olivierWinnerIds,
+    olivierNomineeIds,
+    dramaDeskWinnerIds,
+    pulitzerWinnerIds,
+  };
 }

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useFocusTrap } from './useFocusTrap';

--- a/src/lib/hooks/useFocusTrap.ts
+++ b/src/lib/hooks/useFocusTrap.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react';
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+/**
+ * Trap Tab/Shift+Tab focus inside a container while `active` is true.
+ * Restores focus to the previously-focused element on deactivation.
+ *
+ * Usage:
+ *   const ref = useFocusTrap<HTMLDivElement>(isOpen);
+ *   return <div ref={ref}>...</div>;
+ */
+export function useFocusTrap<T extends HTMLElement = HTMLElement>(active: boolean) {
+  const containerRef = useRef<T | null>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+
+    const focusables = () =>
+      Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)).filter(
+        (el) => !el.hasAttribute('aria-hidden') && el.offsetParent !== null,
+      );
+
+    const initial = focusables()[0] ?? container;
+    initial.focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Tab') return;
+      const items = focusables();
+      if (items.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = items[0];
+      const last = items[items.length - 1];
+      const activeEl = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && activeEl === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && activeEl === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    container.addEventListener('keydown', handleKeyDown);
+    return () => {
+      container.removeEventListener('keydown', handleKeyDown);
+      previouslyFocused.current?.focus?.();
+    };
+  }, [active]);
+
+  return containerRef;
+}

--- a/src/lib/hooks/usePanelFilters.ts
+++ b/src/lib/hooks/usePanelFilters.ts
@@ -13,6 +13,8 @@ interface UsePanelFiltersArgs<T extends ShowCardShow> {
   shows: T[];
   /** Pre-computed award winner ID arrays from server */
   awardWinnerSets?: AwardWinnerSets;
+  /** Active score-mode — Score tier predicates filter against this score */
+  scoreMode?: 'critics' | 'audience';
 }
 
 interface UsePanelFiltersReturn<T extends ShowCardShow> {
@@ -41,6 +43,7 @@ interface UsePanelFiltersReturn<T extends ShowCardShow> {
 export function usePanelFilters<T extends ShowCardShow>({
   shows,
   awardWinnerSets,
+  scoreMode = 'critics',
 }: UsePanelFiltersArgs<T>): UsePanelFiltersReturn<T> {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -57,8 +60,9 @@ export function usePanelFilters<T extends ShowCardShow>({
       dramaDeskWinnerIds: new Set(ws?.dramaDeskWinnerIds ?? []),
       pulitzerWinnerIds: new Set(ws?.pulitzerWinnerIds ?? []),
       yearRange: null, // wired in Sprint 3
+      scoreMode,
     };
-  }, [awardWinnerSets]);
+  }, [awardWinnerSets, scoreMode]);
 
   // Parse selected ids per paramKey from URL
   const selectedByGroup = useMemo(() => {

--- a/src/lib/hooks/usePanelFilters.ts
+++ b/src/lib/hooks/usePanelFilters.ts
@@ -1,0 +1,167 @@
+'use client';
+
+import { useMemo, useCallback } from 'react';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+import type { ShowCardShow } from '@/components/show-cards/types';
+import type { FilterPredicateCtx } from '@/lib/show-filter-predicates';
+import type { AwardWinnerSets } from '@/lib/data-awards';
+import { FILTER_GROUPS, PANEL_PARAM_KEYS, findFilterOption, type FilterOption } from '@/components/filters/filter-ui-config';
+import type { ActiveFilterChip } from '@/components/filters/ActiveFilterChips';
+
+interface UsePanelFiltersArgs<T extends ShowCardShow> {
+  /** Pre-filtered shows from existing inline filters — panel applies on top */
+  shows: T[];
+  /** Pre-computed award winner ID arrays from server */
+  awardWinnerSets?: AwardWinnerSets;
+}
+
+interface UsePanelFiltersReturn<T extends ShowCardShow> {
+  /** Final shows after panel predicates */
+  filteredShows: T[];
+  /** Number of selected panel filter options across all groups */
+  activeCount: number;
+  /** Per-group selected sets, keyed by paramKey */
+  selectedByGroup: Record<string, ReadonlySet<string>>;
+  /** Toggle a single option in a group */
+  toggleOption: (paramKey: string, id: string) => void;
+  /** Remove a single chip */
+  removeChip: (chipKey: string) => void;
+  /** Clear every panel filter */
+  clearAll: () => void;
+  /** Chips for ActiveFilterChips */
+  chips: ActiveFilterChip[];
+}
+
+/**
+ * Owns the advanced-filter-panel state. Reads from URL searchParams,
+ * writes back via router.replace. Applies predicates as a final step
+ * on the already-filtered show list (purely additive — does not touch
+ * existing inline filter logic).
+ */
+export function usePanelFilters<T extends ShowCardShow>({
+  shows,
+  awardWinnerSets,
+}: UsePanelFiltersArgs<T>): UsePanelFiltersReturn<T> {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Build predicate ctx from server-supplied award sets (rebuild Sets once)
+  const ctx: FilterPredicateCtx = useMemo(() => {
+    const ws = awardWinnerSets;
+    return {
+      tonyWinnerIds: new Set(ws?.tonyWinnerIds ?? []),
+      tonyNomineeIds: new Set(ws?.tonyNomineeIds ?? []),
+      olivierWinnerIds: new Set(ws?.olivierWinnerIds ?? []),
+      olivierNomineeIds: new Set(ws?.olivierNomineeIds ?? []),
+      dramaDeskWinnerIds: new Set(ws?.dramaDeskWinnerIds ?? []),
+      pulitzerWinnerIds: new Set(ws?.pulitzerWinnerIds ?? []),
+      yearRange: null, // wired in Sprint 3
+    };
+  }, [awardWinnerSets]);
+
+  // Parse selected ids per paramKey from URL
+  const selectedByGroup = useMemo(() => {
+    const out: Record<string, ReadonlySet<string>> = {};
+    for (const group of FILTER_GROUPS) {
+      const raw = searchParams?.get(group.paramKey);
+      if (!raw) {
+        out[group.paramKey] = new Set();
+        continue;
+      }
+      const ids = raw
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      out[group.paramKey] = new Set(ids);
+    }
+    return out;
+  }, [searchParams]);
+
+  // Collect active predicates (multi-option = OR within group, AND across groups)
+  const activePredicatesByGroup: { paramKey: string; predicates: FilterOption[] }[] = useMemo(() => {
+    return FILTER_GROUPS.map((group) => {
+      const selected = selectedByGroup[group.paramKey];
+      const matched = group.options.filter((opt) => selected.has(opt.id));
+      return { paramKey: group.paramKey, predicates: matched };
+    }).filter((g) => g.predicates.length > 0);
+  }, [selectedByGroup]);
+
+  const filteredShows = useMemo(() => {
+    if (activePredicatesByGroup.length === 0) return shows;
+    return shows.filter((show) => {
+      for (const group of activePredicatesByGroup) {
+        // Within a group: any-of (OR)
+        const groupPasses = group.predicates.some((opt) => opt.predicate(show, ctx));
+        if (!groupPasses) return false;
+      }
+      return true;
+    });
+  }, [shows, activePredicatesByGroup, ctx]);
+
+  const activeCount = useMemo(
+    () => Object.values(selectedByGroup).reduce((sum, s) => sum + s.size, 0),
+    [selectedByGroup],
+  );
+
+  const chips: ActiveFilterChip[] = useMemo(() => {
+    const out: ActiveFilterChip[] = [];
+    for (const [paramKey, selected] of Object.entries(selectedByGroup)) {
+      Array.from(selected).forEach((id) => {
+        const option = findFilterOption(paramKey, id);
+        if (option) {
+          out.push({ key: `${paramKey}:${id}`, label: option.label });
+        }
+      });
+    }
+    return out;
+  }, [selectedByGroup]);
+
+  const writeParams = useCallback(
+    (mutate: (params: URLSearchParams) => void) => {
+      const params = new URLSearchParams(searchParams?.toString() ?? '');
+      mutate(params);
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [searchParams, router, pathname],
+  );
+
+  const toggleOption = useCallback(
+    (paramKey: string, id: string) => {
+      writeParams((params) => {
+        const current = (params.get(paramKey) ?? '').split(',').filter(Boolean);
+        const idx = current.indexOf(id);
+        if (idx >= 0) current.splice(idx, 1);
+        else current.push(id);
+        if (current.length > 0) params.set(paramKey, current.join(','));
+        else params.delete(paramKey);
+      });
+    },
+    [writeParams],
+  );
+
+  const removeChip = useCallback(
+    (chipKey: string) => {
+      const [paramKey, id] = chipKey.split(':');
+      if (paramKey && id) toggleOption(paramKey, id);
+    },
+    [toggleOption],
+  );
+
+  const clearAll = useCallback(() => {
+    writeParams((params) => {
+      Array.from(PANEL_PARAM_KEYS).forEach((key) => params.delete(key));
+    });
+  }, [writeParams]);
+
+  return {
+    filteredShows,
+    activeCount,
+    selectedByGroup,
+    toggleOption,
+    removeChip,
+    clearAll,
+    chips,
+  };
+}

--- a/src/lib/hooks/usePanelFilters.ts
+++ b/src/lib/hooks/usePanelFilters.ts
@@ -119,7 +119,10 @@ export function usePanelFilters<T extends ShowCardShow>({
 
   const writeParams = useCallback(
     (mutate: (params: URLSearchParams) => void) => {
-      const params = new URLSearchParams(searchParams?.toString() ?? '');
+      // Read from live URL — searchParams is React state and may lag behind
+      // rapid back-to-back updates, dropping params silently otherwise.
+      const live = typeof window !== 'undefined' ? window.location.search : (searchParams?.toString() ?? '');
+      const params = new URLSearchParams(live);
       mutate(params);
       const qs = params.toString();
       router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });

--- a/src/lib/serialize-show.ts
+++ b/src/lib/serialize-show.ts
@@ -23,6 +23,7 @@ export function serializeShowForClient(
     status: string;
     type: string;
     isRevival?: boolean | null;
+    season?: string | null;
     reviewYearNote?: string | null;
     images?: { thumbnail?: string; poster?: string; hero?: string };
     criticScore?: { score?: number; reviewCount?: number; tier1Count?: number; tier2Count?: number } | null;
@@ -61,6 +62,7 @@ export function serializeShowForClient(
     status: show.status,
     type: show.type,
     isRevival: show.isRevival ?? undefined,
+    season: show.season ?? undefined,
     reviewYearNote: show.reviewYearNote ?? undefined,
     images: show.images,
     criticScore: show.criticScore

--- a/src/lib/show-filter-predicates.ts
+++ b/src/lib/show-filter-predicates.ts
@@ -24,6 +24,8 @@ export interface FilterPredicateCtx {
   pulitzerWinnerIds: ReadonlySet<string>;
   /** Time-period range — inclusive on both ends; null = no time filter */
   yearRange: { from: number; to: number } | null;
+  /** Active score-mode — score-tier predicates evaluate against this score */
+  scoreMode: 'critics' | 'audience';
 }
 
 export type FilterPredicate = (show: ShowCardShow, ctx: FilterPredicateCtx) => boolean;
@@ -69,11 +71,13 @@ export const TIME_PERIOD_RANGE: FilterPredicate = (s, ctx) => {
 };
 
 // ─────────────── Score tier ───────────────
-// Uses the canonical buckets from src/config/score-buckets.ts. Filters
-// against criticScore for v1 — audience-mode coupling can come later.
+// Uses the canonical buckets from src/config/score-buckets.ts. Reads the
+// score that matches the active scoreMode (critics vs audience).
 
-const inScoreRange = (min: number, max: number): FilterPredicate => (s) => {
-  const score = s.criticScore?.score;
+const inScoreRange = (min: number, max: number): FilterPredicate => (s, ctx) => {
+  const score = ctx.scoreMode === 'audience'
+    ? s.audienceCombinedScore
+    : s.criticScore?.score;
   if (typeof score !== 'number') return false;
   return score >= min && score <= max;
 };

--- a/src/lib/show-filter-predicates.ts
+++ b/src/lib/show-filter-predicates.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure predicates for the advanced filter panel.
+ *
+ * Each predicate is a function `(show, ctx) => boolean`. The panel UI in
+ * src/components/filters/* wires user toggles to predicate IDs; the
+ * predicates run inside a useMemo and have no React dependency.
+ *
+ * Awards predicates rely on pre-computed Sets in `ctx` — never import
+ * awards.json directly here (it's 612KB; see data-awards.ts comment).
+ *
+ * Score-mode coupling: SCORE_TIER_* predicates evaluate against the
+ * currently-active scoreMode (critic vs audience). The hook that owns
+ * the panel state passes the right score into ctx.
+ */
+import type { ShowCardShow } from '@/components/show-cards/types';
+
+export interface FilterPredicateCtx {
+  /** Reconstructed Sets from AwardWinnerSets — O(1) lookup */
+  tonyWinnerIds: ReadonlySet<string>;
+  tonyNomineeIds: ReadonlySet<string>;
+  olivierWinnerIds: ReadonlySet<string>;
+  olivierNomineeIds: ReadonlySet<string>;
+  dramaDeskWinnerIds: ReadonlySet<string>;
+  pulitzerWinnerIds: ReadonlySet<string>;
+  /** Time-period range — inclusive on both ends; null = no time filter */
+  yearRange: { from: number; to: number } | null;
+}
+
+export type FilterPredicate = (show: ShowCardShow, ctx: FilterPredicateCtx) => boolean;
+
+// ─────────────── Production ───────────────
+
+export const PRODUCTION_ORIGINAL: FilterPredicate = (s) => s.isRevival !== true;
+export const PRODUCTION_REVIVAL: FilterPredicate = (s) => s.isRevival === true;
+
+// ─────────────── Awards ───────────────
+
+export const AWARD_TONY_WINNER: FilterPredicate = (s, ctx) => ctx.tonyWinnerIds.has(s.id);
+export const AWARD_TONY_NOMINEE: FilterPredicate = (s, ctx) => ctx.tonyNomineeIds.has(s.id);
+export const AWARD_OLIVIER_WINNER: FilterPredicate = (s, ctx) => ctx.olivierWinnerIds.has(s.id);
+export const AWARD_OLIVIER_NOMINEE: FilterPredicate = (s, ctx) => ctx.olivierNomineeIds.has(s.id);
+export const AWARD_DRAMA_DESK_WINNER: FilterPredicate = (s, ctx) => ctx.dramaDeskWinnerIds.has(s.id);
+export const AWARD_PULITZER: FilterPredicate = (s, ctx) => ctx.pulitzerWinnerIds.has(s.id);
+
+// ─────────────── Time period ───────────────
+
+/**
+ * Extract the year a show "belongs to" for time-period filtering.
+ * Prefers `season` (e.g., "2024-2025" → 2024), falls back to opening-year.
+ * Returns null if neither field is usable.
+ */
+export function getShowYear(show: ShowCardShow): number | null {
+  if (show.season) {
+    const match = show.season.match(/^(\d{4})/);
+    if (match) return parseInt(match[1], 10);
+  }
+  if (show.openingDate) {
+    const year = parseInt(show.openingDate.slice(0, 4), 10);
+    if (!isNaN(year)) return year;
+  }
+  return null;
+}
+
+export const TIME_PERIOD_RANGE: FilterPredicate = (s, ctx) => {
+  if (!ctx.yearRange) return true;
+  const year = getShowYear(s);
+  if (year === null) return false;
+  return year >= ctx.yearRange.from && year <= ctx.yearRange.to;
+};
+
+// ─────────────── Tickets & access ───────────────
+
+export const TICKETS_LOTTERY: FilterPredicate = (s) => s.tags?.includes('lottery') ?? false;
+export const TICKETS_RUSH: FilterPredicate = (s) => s.tags?.includes('rush') ?? false;
+
+// ─────────────── Genre & format (tag-based) ───────────────
+
+const tagPredicate = (tag: string): FilterPredicate => (s) => s.tags?.includes(tag) ?? false;
+
+export const GENRE_COMEDY = tagPredicate('comedy');
+export const GENRE_DRAMA = tagPredicate('drama');
+export const FORMAT_JUKEBOX = tagPredicate('jukebox');
+export const FORMAT_CONCERT = tagPredicate('concert');
+export const FORMAT_SOLO_SHOW = tagPredicate('solo-show');
+export const FORMAT_IMMERSIVE = tagPredicate('immersive');
+export const FORMAT_REVUE = tagPredicate('revue');
+export const SOURCE_BASED_ON_BOOK = tagPredicate('based-on-book');
+export const SOURCE_BASED_ON_TRUE_STORY = tagPredicate('based-on-true-story');
+export const SOURCE_FILM_ADAPTATION = tagPredicate('film-adaptation');
+export const SOURCE_DISNEY = tagPredicate('disney');

--- a/src/lib/show-filter-predicates.ts
+++ b/src/lib/show-filter-predicates.ts
@@ -68,6 +68,22 @@ export const TIME_PERIOD_RANGE: FilterPredicate = (s, ctx) => {
   return year >= ctx.yearRange.from && year <= ctx.yearRange.to;
 };
 
+// ─────────────── Score tier ───────────────
+// Uses the canonical buckets from src/config/score-buckets.ts. Filters
+// against criticScore for v1 — audience-mode coupling can come later.
+
+const inScoreRange = (min: number, max: number): FilterPredicate => (s) => {
+  const score = s.criticScore?.score;
+  if (typeof score !== 'number') return false;
+  return score >= min && score <= max;
+};
+
+export const SCORE_TIER_CRITICAL_GOLD = inScoreRange(83, 100);
+export const SCORE_TIER_RECOMMENDED = inScoreRange(75, 82);
+export const SCORE_TIER_WORTH_SEEING = inScoreRange(65, 74);
+export const SCORE_TIER_SKIPPABLE = inScoreRange(55, 64);
+export const SCORE_TIER_CRITICAL_MISS = inScoreRange(0, 54);
+
 // ─────────────── Tickets & access ───────────────
 
 export const TICKETS_LOTTERY: FilterPredicate = (s) => s.tags?.includes('lottery') ?? false;


### PR DESCRIPTION
## Summary

Adds a filter icon inside the search bar that opens a panel (bottom sheet on mobile, popover on desktop) for filters that don't fit on the existing inline filter rows. Built for advanced/archive use. Existing inline filters (Market / Type / Status / Sort / Score-mode) are untouched.

5 filter groups in v1: Production (Original/Revival), Score tier (5 buckets), Awards (Tony/Olivier/Drama Desk/Pulitzer), Genre & format (11 tags), Tickets & access (lottery/rush). Live-applies, URL-shareable, dismissable chips below the search.

Spec: `~/Documents/claude-outputs/filter-panel-spec.md`
Mockup: `~/Documents/claude-outputs/filter-panel-mockup.html`
Sprint plan: `~/Documents/claude-outputs/filter-panel-sprint-plan.md`
Notion: https://www.notion.so/34e637c5416f81cdb08ed6df02c8cd76

## What's in this PR

- `src/lib/show-filter-predicates.ts` — pure predicates, no React deps
- `src/lib/data-awards.ts` — adds `getAwardWinnerSets()` so the 612KB `awards.json` stays server-side; ~12KB of ID arrays ship to the client instead
- `src/lib/serialize-show.ts` + 4 client `Show` interfaces — `season` and `tags` plumbed through
- `src/lib/hooks/useFocusTrap.ts` — 30-line hook for the panel dialog
- `src/lib/hooks/usePanelFilters.ts` — owns URL state + applies predicates as a final pass on the existing filtered list (purely additive — no churn to existing inline filter logic)
- `src/components/filters/` — FilterButton, FilterPanel, FilterPillGroup, ActiveFilterChips, filter-ui-config.ts
- All 4 page clients wired (Home, OffBway, WE, OffWE)

## Tested at 390px (mobile)

- Production toggle narrows count, URL updates, chip appears
- Score tier toggle (Critical Gold) narrows correctly
- Awards toggle (Tony winner / Olivier winner) narrows correctly
- Multi-group stacking: Critical Gold + Revival = 3 shows on Broadway, URL `?score_tier=critical-gold&production=revival`
- Reload preserves URL state — badge "2", chips render, count correct
- Clear all removes panel filters but leaves `status=all&sort=score_desc` intact
- Inline filters (PLAYING / CLOSING / Musicals) still work — 39→14→5
- Genre (Comedy 612→22) and Tickets (lottery 22→5) predicates verified
- All 4 pages confirmed working: Home, /off-broadway, /west-end, /off-west-end
- Race condition fixed: rapid back-to-back clicks were dropping the first param (writeParams now reads from `window.location.search` live)

## Tested at 1440px (desktop)

- Popover renders centered (not anchored to icon — minor design deviation; functional)
- Reset / Show button work
- Existing layout untouched

## NOT tested

- Esc keyboard close (handler wired, not keystroke-tested)
- Focus-trap Tab cycle (hook wired, not manually traversed)
- Lighthouse a11y score
- Production build (pre-existing local failure: Sanity packages not in node_modules — same on main; will rely on CI/Vercel)

## Deferred to follow-up

- **Time period filter** (3-tier: Recent seasons / Decade / Custom range slider). Predicate stub exists; `ctx.yearRange` always null today. Sprint 3 of the plan.
- **Audience filters** (Family-friendly / LGBTQ / Latinx) — `family` tag covers 36 of 2,463 shows; others ≤2 each. Defer until tags are backfilled.
- **Limited run** in Production — only 2 shows tagged. Defer.
- **Empty state** when 0 shows match.
- **Animation polish** (basic Tailwind slide-in is in; smoother backdrop fade later).
- **Full a11y pass + VoiceOver test**.

## Test plan

- [ ] Verify filter icon visible and functional on all 4 list pages
- [ ] Toggle Production/Score tier/Awards/Genre/Tickets — confirm narrowing
- [ ] Toggle multi-group filters — confirm AND-across-groups, OR-within-group
- [ ] Reload preserves URL state
- [ ] Clear all removes only panel filters
- [ ] Existing Status/Sort/Type pills still work
- [ ] Esc closes the sheet/popover
- [ ] Tab cycles inside the open panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)