### PR TITLE
feat(filters): Sprint 3 — Time period filter + NEWEST/A-Z sort arrows

### DIFF
--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -606,6 +606,8 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
         onClose={() => setIsPanelOpen(false)}
         selectedByGroup={panel.selectedByGroup}
         onToggle={panel.toggleOption}
+        yearRange={panel.yearRange}
+        onYearRangeChange={panel.setYearRange}
         onClearAll={panel.clearAll}
         resultCount={panel.filteredShows.length}
       />

--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -72,7 +72,7 @@ interface HomePageClientProps {
 
 // URL parameter values
 type StatusParam = 'now_playing' | 'closed' | 'upcoming' | 'closing_soon' | 'all';
-type SortParam = 'recent' | 'score_desc' | 'score_asc' | 'alpha' | 'audience_buzz' | 'audience_asc';
+type SortParam = 'recent' | 'recent_asc' | 'score_desc' | 'score_asc' | 'alpha' | 'alpha_desc' | 'audience_buzz' | 'audience_asc';
 type TypeParam = 'all' | 'musical' | 'play';
 // Internal filter values
 type StatusFilter = 'all' | 'open' | 'closed' | 'previews' | 'closing_soon';
@@ -214,7 +214,7 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
   const [filters, setFilters] = useState(() => ({
     status: (['now_playing', 'closed', 'upcoming', 'closing_soon', 'all'].includes(initialSearchParams.get('status') as string)
       ? initialSearchParams.get('status') as StatusParam : DEFAULT_STATUS),
-    sort: (['recent', 'score_desc', 'score_asc', 'alpha', 'audience_buzz', 'audience_asc'].includes(initialSearchParams.get('sort') as string)
+    sort: (['recent', 'recent_asc', 'score_desc', 'score_asc', 'alpha', 'alpha_desc', 'audience_buzz', 'audience_asc'].includes(initialSearchParams.get('sort') as string)
       ? initialSearchParams.get('sort') as SortParam : DEFAULT_SORT),
     type: (['all', 'musical', 'play'].includes(initialSearchParams.get('type') as string)
       ? initialSearchParams.get('type') as TypeParam : DEFAULT_TYPE),
@@ -501,6 +501,11 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
           }
           case 'alpha':
             return a.title.toLowerCase().localeCompare(b.title.toLowerCase());
+          case 'alpha_desc':
+            return b.title.toLowerCase().localeCompare(a.title.toLowerCase());
+          case 'recent_asc':
+            // Oldest opening date first
+            return a.openingDate < b.openingDate ? -1 : a.openingDate > b.openingDate ? 1 : 0;
           case 'recent':
           default:
             // Most recent opening date first (ISO date strings are lexicographically sortable)
@@ -648,7 +653,10 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
         <ToggleBar
           label="SORT:"
           options={[
-            { value: 'recent' as SortParam, label: 'NEWEST' },
+            {
+              value: 'recent' as SortParam,
+              label: sort === 'recent' ? 'NEWEST ↓' : sort === 'recent_asc' ? 'NEWEST ↑' : 'NEWEST',
+            },
             {
               value: 'score_desc' as SortParam,
               label: sort === 'score_desc' ? 'CRITICS ↓' : sort === 'score_asc' ? 'CRITICS ↑' : 'CRITICS',
@@ -657,15 +665,28 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
               value: 'audience_buzz' as SortParam,
               label: sort === 'audience_buzz' ? 'AUDIENCE ↓' : sort === 'audience_asc' ? 'AUDIENCE ↑' : 'AUDIENCE',
             },
-            { value: 'alpha' as SortParam, label: 'A-Z' },
+            {
+              value: 'alpha' as SortParam,
+              label: sort === 'alpha' ? 'A-Z ↓' : sort === 'alpha_desc' ? 'A-Z ↑' : 'A-Z',
+            },
           ]}
-          value={sort === 'score_asc' ? 'score_desc' : sort === 'audience_asc' ? 'audience_buzz' : sort}
+          value={
+            sort === 'score_asc' ? 'score_desc'
+            : sort === 'audience_asc' ? 'audience_buzz'
+            : sort === 'recent_asc' ? 'recent'
+            : sort === 'alpha_desc' ? 'alpha'
+            : sort
+          }
           onChange={(s) => {
             let next: SortParam = s;
             if (s === 'score_desc') {
               next = sort === 'score_desc' ? 'score_asc' : 'score_desc';
             } else if (s === 'audience_buzz') {
               next = sort === 'audience_buzz' ? 'audience_asc' : 'audience_buzz';
+            } else if (s === 'recent') {
+              next = sort === 'recent' ? 'recent_asc' : 'recent';
+            } else if (s === 'alpha') {
+              next = sort === 'alpha' ? 'alpha_desc' : 'alpha';
             }
             updateParams({ sort: next });
           }}

--- a/src/components/OffBroadwayPageClient.tsx
+++ b/src/components/OffBroadwayPageClient.tsx
@@ -396,6 +396,8 @@ function OffBroadwayPageInner({ shows, totalShows, totalReviews, marketOpenCount
         onClose={() => setIsPanelOpen(false)}
         selectedByGroup={panel.selectedByGroup}
         onToggle={panel.toggleOption}
+        yearRange={panel.yearRange}
+        onYearRangeChange={panel.setYearRange}
         onClearAll={panel.clearAll}
         resultCount={panel.filteredShows.length}
       />

--- a/src/components/OffWestEndPageClient.tsx
+++ b/src/components/OffWestEndPageClient.tsx
@@ -396,6 +396,8 @@ function OffWestEndPageInner({ shows, totalShows, totalReviews, marketOpenCounts
         onClose={() => setIsPanelOpen(false)}
         selectedByGroup={panel.selectedByGroup}
         onToggle={panel.toggleOption}
+        yearRange={panel.yearRange}
+        onYearRangeChange={panel.setYearRange}
         onClearAll={panel.clearAll}
         resultCount={panel.filteredShows.length}
       />

--- a/src/components/WestEndPageClient.tsx
+++ b/src/components/WestEndPageClient.tsx
@@ -484,6 +484,8 @@ function WestEndPageInner({ shows, totalShows, totalReviews, scoredShows, lotter
         onClose={() => setIsPanelOpen(false)}
         selectedByGroup={panel.selectedByGroup}
         onToggle={panel.toggleOption}
+        yearRange={panel.yearRange}
+        onYearRangeChange={panel.setYearRange}
         onClearAll={panel.clearAll}
         resultCount={panel.filteredShows.length}
       />

--- a/src/components/filters/FilterPanel.tsx
+++ b/src/components/filters/FilterPanel.tsx
@@ -4,12 +4,15 @@ import { useEffect, useId } from 'react';
 import { useFocusTrap } from '@/lib/hooks/useFocusTrap';
 import { FILTER_GROUPS } from './filter-ui-config';
 import { FilterPillGroup } from './FilterPillGroup';
+import { TimePeriodSection } from './TimePeriodSection';
 
 interface FilterPanelProps {
   isOpen: boolean;
   onClose: () => void;
   selectedByGroup: Record<string, ReadonlySet<string>>;
   onToggle: (paramKey: string, id: string) => void;
+  yearRange: { from: number; to: number } | null;
+  onYearRangeChange: (range: { from: number; to: number } | null) => void;
   onClearAll: () => void;
   resultCount: number;
 }
@@ -24,6 +27,8 @@ export function FilterPanel({
   onClose,
   selectedByGroup,
   onToggle,
+  yearRange,
+  onYearRangeChange,
   onClearAll,
   resultCount,
 }: FilterPanelProps) {
@@ -88,17 +93,28 @@ export function FilterPanel({
 
         {/* Body */}
         <div className="flex-1 overflow-y-auto px-5 py-2">
-          {FILTER_GROUPS.map((group) => (
-            <div key={group.paramKey} className="py-3 border-b border-white/5 last:border-b-0">
-              <h3 className="text-[11px] font-bold uppercase tracking-wider text-gray-500 mb-2.5">
-                {group.label}
-              </h3>
-              <FilterPillGroup
-                options={group.options.map((o) => ({ value: o.id, label: o.label }))}
-                selected={selectedByGroup[group.paramKey] ?? new Set()}
-                onToggle={(id) => onToggle(group.paramKey, id)}
-                ariaLabel={`${group.label} filters`}
-              />
+          {FILTER_GROUPS.map((group, idx) => (
+            <div key={group.paramKey}>
+              <div className="py-3 border-b border-white/5">
+                <h3 className="text-[11px] font-bold uppercase tracking-wider text-gray-500 mb-2.5">
+                  {group.label}
+                </h3>
+                <FilterPillGroup
+                  options={group.options.map((o) => ({ value: o.id, label: o.label }))}
+                  selected={selectedByGroup[group.paramKey] ?? new Set()}
+                  onToggle={(id) => onToggle(group.paramKey, id)}
+                  ariaLabel={`${group.label} filters`}
+                />
+              </div>
+              {/* Insert Time period after Production (idx 0) */}
+              {idx === 0 && (
+                <div className="py-3 border-b border-white/5">
+                  <h3 className="text-[11px] font-bold uppercase tracking-wider text-gray-500 mb-2.5">
+                    Time period
+                  </h3>
+                  <TimePeriodSection yearRange={yearRange} onChange={onYearRangeChange} />
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/src/components/filters/TimePeriodSection.tsx
+++ b/src/components/filters/TimePeriodSection.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { YearRangeSlider } from './YearRangeSlider';
+
+interface TimePeriodSectionProps {
+  yearRange: { from: number; to: number } | null;
+  onChange: (range: { from: number; to: number } | null) => void;
+}
+
+const MIN_YEAR = 1950;
+const CURRENT_YEAR = new Date().getFullYear();
+
+const RECENT_SEASONS: { year: number; label: string }[] = Array.from({ length: 8 }, (_, i) => {
+  const year = CURRENT_YEAR - i;
+  return { year, label: `${year}–${String((year + 1) % 100).padStart(2, '0')}` };
+});
+
+const DECADES: { id: string; label: string; from: number; to: number }[] = [
+  { id: '2010s', label: '2010s', from: 2010, to: 2019 },
+  { id: '2000s', label: '2000s', from: 2000, to: 2009 },
+  { id: '1990s', label: '1990s', from: 1990, to: 1999 },
+  { id: '1980s', label: '1980s', from: 1980, to: 1989 },
+  { id: '1970s', label: '1970s', from: 1970, to: 1979 },
+  { id: '1960s', label: '1960s', from: 1960, to: 1969 },
+  { id: 'pre-1960', label: 'Pre-1960', from: 1950, to: 1959 },
+];
+
+/**
+ * Three views over a single {from, to} year range:
+ *  - Recent season pills: selected if range covers that single year
+ *  - Decade pills: selected if range fully spans the decade (or is exactly that decade)
+ *  - Custom slider: directly edits the range
+ *
+ * Tapping a pill SETS the range to that pill's bounds (not toggles within range).
+ * This mirrors the simpler "pick one preset, then refine" mental model.
+ */
+export function TimePeriodSection({ yearRange, onChange }: TimePeriodSectionProps) {
+  const isYearActive = (year: number) =>
+    !!yearRange && yearRange.from === year && yearRange.to === year;
+  const isDecadeActive = (from: number, to: number) =>
+    !!yearRange && yearRange.from === from && yearRange.to === to;
+
+  const onYearPill = (year: number) => {
+    if (isYearActive(year)) onChange(null);
+    else onChange({ from: year, to: year });
+  };
+  const onDecadePill = (from: number, to: number) => {
+    if (isDecadeActive(from, to)) onChange(null);
+    else onChange({ from, to });
+  };
+
+  return (
+    <div className="space-y-3">
+      <Sublabel>Recent seasons</Sublabel>
+      <div className="flex flex-wrap items-center gap-2">
+        {RECENT_SEASONS.map(({ year, label }) => (
+          <Pill
+            key={year}
+            label={label}
+            isSelected={isYearActive(year)}
+            onClick={() => onYearPill(year)}
+          />
+        ))}
+      </div>
+
+      <Sublabel>Decade</Sublabel>
+      <div className="flex flex-wrap items-center gap-2">
+        {DECADES.map(({ id, label, from, to }) => (
+          <Pill
+            key={id}
+            label={label}
+            isSelected={isDecadeActive(from, to)}
+            onClick={() => onDecadePill(from, to)}
+          />
+        ))}
+      </div>
+
+      <Sublabel>Custom range</Sublabel>
+      <YearRangeSlider
+        min={MIN_YEAR}
+        max={CURRENT_YEAR}
+        value={yearRange}
+        onChange={(r) => onChange(r)}
+        onClear={() => onChange(null)}
+      />
+    </div>
+  );
+}
+
+function Sublabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-[10px] font-bold uppercase tracking-wider text-gray-500">
+      {children}
+    </div>
+  );
+}
+
+function Pill({ label, isSelected, onClick }: { label: string; isSelected: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={isSelected}
+      className={`px-3 sm:px-4 py-2.5 sm:py-2 min-h-[44px] sm:min-h-0 text-xs sm:text-sm leading-none font-semibold inline-flex items-center gap-1.5 justify-center rounded-full transition-all ${
+        isSelected
+          ? 'bg-brand/10 text-brand border border-brand/40'
+          : 'bg-surface-overlay text-gray-300 border border-white/10 hover:text-white hover:border-white/20'
+      }`}
+    >
+      {label}
+      {isSelected && (
+        <span className="w-3.5 h-3.5 rounded-full bg-brand text-gray-900 inline-flex items-center justify-center text-[10px] font-bold">
+          ✓
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/components/filters/YearRangeSlider.tsx
+++ b/src/components/filters/YearRangeSlider.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useId } from 'react';
+
+interface YearRangeSliderProps {
+  min: number;
+  max: number;
+  /** Current range. null = not set yet (full range implied). */
+  value: { from: number; to: number } | null;
+  onChange: (range: { from: number; to: number }) => void;
+  /** Optional reset to "no range" */
+  onClear?: () => void;
+}
+
+/**
+ * Dual-handle year-range slider. Two stacked native <input type="range">
+ * elements with z-index trickery — the active thumb tracks the front layer
+ * so both handles remain operable. Emits {from, to} on each commit.
+ */
+export function YearRangeSlider({ min, max, value, onChange, onClear }: YearRangeSliderProps) {
+  const fromId = useId();
+  const toId = useId();
+  const from = value?.from ?? min;
+  const to = value?.to ?? max;
+  const range = max - min || 1;
+  const fromPct = ((from - min) / range) * 100;
+  const toPct = ((to - min) / range) * 100;
+
+  const handleFrom = (n: number) => {
+    const next = Math.min(n, to);
+    onChange({ from: next, to });
+  };
+  const handleTo = (n: number) => {
+    const next = Math.max(n, from);
+    onChange({ from, to: next });
+  };
+
+  return (
+    <div className="pt-1">
+      <div className="flex items-center gap-3">
+        <span className="bg-surface-overlay border border-white/10 text-gray-100 text-xs font-bold tabular-nums px-2 py-1 rounded-md min-w-[44px] text-center">
+          {from}
+        </span>
+        <div className="relative flex-1 h-6 flex items-center">
+          {/* Track background */}
+          <div className="absolute inset-x-0 h-1 bg-surface-overlay rounded-full" />
+          {/* Active fill between handles */}
+          <div
+            className="absolute h-1 bg-brand rounded-full shadow-[0_0_8px_rgba(212,165,116,0.4)]"
+            style={{ left: `${fromPct}%`, right: `${100 - toPct}%` }}
+          />
+          {/* Two stacked native ranges. Pointer-events on track only. */}
+          <input
+            id={fromId}
+            type="range"
+            min={min}
+            max={max}
+            value={from}
+            onChange={(e) => handleFrom(parseInt(e.target.value, 10))}
+            aria-label="Start year"
+            aria-valuemin={min}
+            aria-valuemax={max}
+            aria-valuenow={from}
+            className="absolute inset-0 w-full appearance-none bg-transparent pointer-events-none [&::-webkit-slider-thumb]:pointer-events-auto [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-brand [&::-webkit-slider-thumb]:shadow-md [&::-moz-range-thumb]:pointer-events-auto [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-white [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-brand"
+            style={{ zIndex: from > max - (max - min) * 0.1 ? 4 : 3 }}
+          />
+          <input
+            id={toId}
+            type="range"
+            min={min}
+            max={max}
+            value={to}
+            onChange={(e) => handleTo(parseInt(e.target.value, 10))}
+            aria-label="End year"
+            aria-valuemin={min}
+            aria-valuemax={max}
+            aria-valuenow={to}
+            className="absolute inset-0 w-full appearance-none bg-transparent pointer-events-none [&::-webkit-slider-thumb]:pointer-events-auto [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-brand [&::-webkit-slider-thumb]:shadow-md [&::-moz-range-thumb]:pointer-events-auto [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-white [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-brand"
+            style={{ zIndex: 5 }}
+          />
+        </div>
+        <span className="bg-surface-overlay border border-white/10 text-gray-100 text-xs font-bold tabular-nums px-2 py-1 rounded-md min-w-[44px] text-center">
+          {to}
+        </span>
+      </div>
+      <div className="flex items-center justify-between text-[10px] text-gray-500 tabular-nums mt-1 px-1">
+        <span>{min}</span>
+        {value && onClear && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-gray-400 hover:text-white underline underline-offset-2"
+          >
+            Clear range
+          </button>
+        )}
+        <span>{max}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/hooks/usePanelFilters.ts
+++ b/src/lib/hooks/usePanelFilters.ts
@@ -3,10 +3,21 @@
 import { useMemo, useCallback } from 'react';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import type { ShowCardShow } from '@/components/show-cards/types';
-import type { FilterPredicateCtx } from '@/lib/show-filter-predicates';
+import { type FilterPredicateCtx, TIME_PERIOD_RANGE } from '@/lib/show-filter-predicates';
 import type { AwardWinnerSets } from '@/lib/data-awards';
 import { FILTER_GROUPS, PANEL_PARAM_KEYS, findFilterOption, type FilterOption } from '@/components/filters/filter-ui-config';
 import type { ActiveFilterChip } from '@/components/filters/ActiveFilterChips';
+
+/** Parse "FROM-TO" into {from, to}; returns null if malformed. */
+function parseYearRange(raw: string | null): { from: number; to: number } | null {
+  if (!raw) return null;
+  const m = raw.match(/^(\d{4})-(\d{4})$/);
+  if (!m) return null;
+  const from = parseInt(m[1], 10);
+  const to = parseInt(m[2], 10);
+  if (isNaN(from) || isNaN(to) || from > to) return null;
+  return { from, to };
+}
 
 interface UsePanelFiltersArgs<T extends ShowCardShow> {
   /** Pre-filtered shows from existing inline filters — panel applies on top */
@@ -24,8 +35,12 @@ interface UsePanelFiltersReturn<T extends ShowCardShow> {
   activeCount: number;
   /** Per-group selected sets, keyed by paramKey */
   selectedByGroup: Record<string, ReadonlySet<string>>;
+  /** Year range tuple — null if no time-period filter */
+  yearRange: { from: number; to: number } | null;
   /** Toggle a single option in a group */
   toggleOption: (paramKey: string, id: string) => void;
+  /** Set the year range (or null to clear) */
+  setYearRange: (range: { from: number; to: number } | null) => void;
   /** Remove a single chip */
   removeChip: (chipKey: string) => void;
   /** Clear every panel filter */
@@ -49,6 +64,9 @@ export function usePanelFilters<T extends ShowCardShow>({
   const router = useRouter();
   const pathname = usePathname();
 
+  // Year range from URL — single source of truth for Time period
+  const yearRange = useMemo(() => parseYearRange(searchParams?.get('years') ?? null), [searchParams]);
+
   // Build predicate ctx from server-supplied award sets (rebuild Sets once)
   const ctx: FilterPredicateCtx = useMemo(() => {
     const ws = awardWinnerSets;
@@ -59,10 +77,10 @@ export function usePanelFilters<T extends ShowCardShow>({
       olivierNomineeIds: new Set(ws?.olivierNomineeIds ?? []),
       dramaDeskWinnerIds: new Set(ws?.dramaDeskWinnerIds ?? []),
       pulitzerWinnerIds: new Set(ws?.pulitzerWinnerIds ?? []),
-      yearRange: null, // wired in Sprint 3
+      yearRange,
       scoreMode,
     };
-  }, [awardWinnerSets, scoreMode]);
+  }, [awardWinnerSets, scoreMode, yearRange]);
 
   // Parse selected ids per paramKey from URL
   const selectedByGroup = useMemo(() => {
@@ -92,8 +110,11 @@ export function usePanelFilters<T extends ShowCardShow>({
   }, [selectedByGroup]);
 
   const filteredShows = useMemo(() => {
-    if (activePredicatesByGroup.length === 0) return shows;
+    const hasGroupFilters = activePredicatesByGroup.length > 0;
+    const hasYearFilter = yearRange !== null;
+    if (!hasGroupFilters && !hasYearFilter) return shows;
     return shows.filter((show) => {
+      if (hasYearFilter && !TIME_PERIOD_RANGE(show, ctx)) return false;
       for (const group of activePredicatesByGroup) {
         // Within a group: any-of (OR)
         const groupPasses = group.predicates.some((opt) => opt.predicate(show, ctx));
@@ -101,11 +122,13 @@ export function usePanelFilters<T extends ShowCardShow>({
       }
       return true;
     });
-  }, [shows, activePredicatesByGroup, ctx]);
+  }, [shows, activePredicatesByGroup, ctx, yearRange]);
 
   const activeCount = useMemo(
-    () => Object.values(selectedByGroup).reduce((sum, s) => sum + s.size, 0),
-    [selectedByGroup],
+    () =>
+      Object.values(selectedByGroup).reduce((sum, s) => sum + s.size, 0)
+      + (yearRange ? 1 : 0),
+    [selectedByGroup, yearRange],
   );
 
   const chips: ActiveFilterChip[] = useMemo(() => {
@@ -118,8 +141,14 @@ export function usePanelFilters<T extends ShowCardShow>({
         }
       });
     }
+    if (yearRange) {
+      const label = yearRange.from === yearRange.to
+        ? `${yearRange.from}–${String((yearRange.from + 1) % 100).padStart(2, '0')}`
+        : `${yearRange.from}–${yearRange.to}`;
+      out.push({ key: 'years:_range', label });
+    }
     return out;
-  }, [selectedByGroup]);
+  }, [selectedByGroup, yearRange]);
 
   const writeParams = useCallback(
     (mutate: (params: URLSearchParams) => void) => {
@@ -148,12 +177,26 @@ export function usePanelFilters<T extends ShowCardShow>({
     [writeParams],
   );
 
+  const setYearRange = useCallback(
+    (range: { from: number; to: number } | null) => {
+      writeParams((params) => {
+        if (range) params.set('years', `${range.from}-${range.to}`);
+        else params.delete('years');
+      });
+    },
+    [writeParams],
+  );
+
   const removeChip = useCallback(
     (chipKey: string) => {
+      if (chipKey === 'years:_range') {
+        setYearRange(null);
+        return;
+      }
       const [paramKey, id] = chipKey.split(':');
       if (paramKey && id) toggleOption(paramKey, id);
     },
-    [toggleOption],
+    [toggleOption, setYearRange],
   );
 
   const clearAll = useCallback(() => {
@@ -166,7 +209,9 @@ export function usePanelFilters<T extends ShowCardShow>({
     filteredShows,
     activeCount,
     selectedByGroup,
+    yearRange,
     toggleOption,
+    setYearRange,
     removeChip,
     clearAll,
     chips,


### PR DESCRIPTION
## Summary

Two additions to the advanced filter panel + homepage sort UI:

1. **Time period filter** — new section in the panel with three views over a single `{from, to}` year-range state:
   - Recent seasons (last 8: 2026–27 … 2019–20)
   - Decade buckets (2010s … Pre-1960)
   - Custom range slider (1950 → current year, dual-handle)
2. **NEWEST / A-Z sort arrows** on the homepage SORT row — mirrors the existing CRITICS / AUDIENCE asc/desc pattern. NEWEST defaults ↓ (newest first); tap toggles to ↑ (oldest first). A-Z defaults ↓ (A→Z); tap toggles to ↑ (Z→A).

## Implementation

**Time period:**
- New `src/components/filters/TimePeriodSection.tsx` — three sub-sections; tapping a pill SETS the range to that pill's bounds (no separate selection state).
- New `src/components/filters/YearRangeSlider.tsx` — two stacked native `input[type=range]` with thumb-only pointer events so both handles work.
- `usePanelFilters` parses `?years=FROM-TO` into `ctx.yearRange`, applies `TIME_PERIOD_RANGE` predicate, exposes `yearRange` + `setYearRange`. `years:_range` chip handled specially in `removeChip`. `activeCount` includes range when set.
- All 4 page clients pass `yearRange` + `onYearRangeChange` to FilterPanel.

**Sort arrows:**
- HomePageClient `SortParam` extended with `'recent_asc'` and `'alpha_desc'`.
- Sort cases added in `filteredAndSortedShows` for the new directions.
- URL allowlist updated.
- Homepage only — sibling pages don't have score/audience asc variants either.

## Verified live at 390px (mobile, Broadway homepage)

- Open panel → Production, Time period, Score tier, Awards, Genre & format, Tickets visible in order
- Decade pill 1990s → URL `?years=1990-1999`, count drops to 2
- Season pill 2020–21 → URL `?years=2020-2020`, count = 4
- Slider drag 1985 → 2010 → URL `?years=1985-2010`
- Close panel → chip "2020–21 ✕" appears below search, badge "1" on filter icon
- Reload `/?status=all&years=2020-2020` → badge "1", chip restored, count = 4
- Remove chip → `years` cleared, `status=all` preserved
- NEWEST shows ↓ in default state; tap → URL `?sort=recent_asc` and label flips to ↑
- A-Z shows ↓ (A→Z); tap → URL `?sort=alpha_desc` and label flips to ↑

## Not in this PR (next)

- **Type + Status mirrored as panel members** (badge + chips, while staying inline). User asked for this in same conversation — the discriminated-union refactor for single-select groups is the next chunk and was scoped out of this PR for safety.
- **Sort arrows on Off-Broadway / West End / Off-West-End** — those pages currently lack score/audience asc variants too; full pattern can replicate later.
- **Polish:** smoother backdrop fade, empty-state UI, full a11y VoiceOver test, desktop popover icon-anchoring.

## Test plan

- [ ] Tap filter icon on `/`, `/off-broadway`, `/west-end`, `/off-west-end` — Time period section visible
- [ ] Decade / Recent season / Slider all write `?years=FROM-TO`
- [ ] Reload preserves state
- [ ] Removing year chip via X clears only `years`
- [ ] NEWEST and A-Z toggle ↓/↑ on homepage SORT row

🤖 Generated with [Claude Code](https://claude.com/claude-code)