### PR TITLE
ui(show): Broadway Radar–inspired hero block (showPageRedesign v2)

### DIFF
--- a/src/app/show/[slug]/page.tsx
+++ b/src/app/show/[slug]/page.tsx
@@ -52,6 +52,7 @@ import { sortTicketLinks } from '@/lib/ticket-utils';
 import { getComparisonsForShow } from '@/config/comparisons';
 import ShowPageRatingConnected from '@/components/user/ShowPageRatingConnected';
 import ShowPageWatchlistButton from '@/components/user/ShowPageWatchlistButton';
+import ShowHeroRedesign from '@/components/show-page/ShowHeroRedesign';
 import ShowPageAddToListButton from '@/components/user/ShowPageAddToListButton';
 import ShowPageBookmark from '@/components/user/ShowPageBookmark';
 import TheaterScorecardCard from '@/components/TheaterScorecardCard';
@@ -366,178 +367,23 @@ export default async function ShowPage({ params }: { params: { slug: string } })
           { label: show.title },
         ]} />
 
-        {/* Redesigned mobile header — feature-flagged, demo only */}
+        {/* Redesigned mobile header — feature-flagged. v2 (Broadway Radar–inspired) lives
+            entirely inside ShowHeroRedesign; the legacy block below is kept only for the
+            unflagged path and for sm: viewports. See memory/feedback_show_page_redesign_v2_decisions.md. */}
         {featureFlags.showPageRedesign && (
-          <div className="sm:hidden card p-5 mb-6" data-testid="show-header-card-v2">
-            {/* Row 1: Image + Info */}
-            <div className="flex gap-4">
-              <div className="flex-shrink-0 w-28">
-                <div className="relative aspect-[2/3] rounded-xl overflow-visible shadow-2xl border border-white/10 bg-surface-raised">
-                  <ShowPageBookmark showId={show.id} size="compact" />
-                  <div className="absolute inset-0 rounded-xl overflow-hidden">
-                  <ShowImage
-                    sources={[
-                      show.images?.poster ? getOptimizedImageUrl(show.images.poster, 'poster') : null,
-                      show.images?.thumbnail ? getOptimizedImageUrl(show.images.thumbnail, 'poster') : null,
-                      show.images?.hero ? getOptimizedImageUrl(show.images.hero, 'poster') : null,
-                    ]}
-                    alt={`${show.title} poster`}
-                    width={176}
-                    height={264}
-                    decoding="async"
-                    priority
-                    sizes="112px"
-                    className="w-full h-full object-cover"
-                    fallback={
-                      <div className="w-full h-full flex items-center justify-center bg-surface-overlay">
-                        <span className="text-4xl text-gray-500">🎭</span>
-                      </div>
-                    }
-                  />
-                  </div>
-                </div>
-              </div>
-              <div className="flex-1 min-w-0">
-                {/* Pills */}
-                <div className="flex flex-wrap gap-1.5 mb-2">
-                  {show.category && show.category !== 'broadway' && (
-                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] leading-none font-semibold uppercase tracking-wide ${show.category === 'west-end' ? 'bg-teal-500/15 text-teal-400 border border-teal-500/30' : show.category === 'off-west-end' ? 'bg-violet-500/15 text-violet-400 border border-violet-500/30' : 'bg-indigo-500/15 text-indigo-400 border border-indigo-500/30'}`}>
-                      {show.category === 'west-end' ? 'West End' : show.category === 'off-west-end' ? 'Off-West End' : 'Off-Bway'}
-                    </span>
-                  )}
-                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] leading-none font-semibold uppercase tracking-wide ${show.type === 'musical' ? 'bg-purple-500/15 text-purple-400 border border-purple-500/30' : 'bg-blue-500/15 text-blue-400 border border-blue-500/30'}`}>
-                    {show.type === 'musical' ? 'Musical' : 'Play'}
-                  </span>
-                  {show.isRevival && (
-                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] leading-none font-semibold uppercase tracking-wide bg-gray-500/15 text-gray-400 border border-white/15">
-                      Revival
-                    </span>
-                  )}
-                  {show.limitedRun && (
-                    <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] leading-none font-semibold uppercase tracking-wide bg-rose-500/15 text-rose-400 border border-rose-500/30">
-                      Limited
-                    </span>
-                  )}
-                </div>
-                {/* Title */}
-                <h1 className="text-2xl font-extrabold text-white tracking-tight leading-tight mb-2">
-                  {show.title}
-                </h1>
-                {/* Meta — stacked for clarity */}
-                <div className="text-gray-400 text-sm space-y-0.5 leading-relaxed">
-                  {isWestEnd ? (
-                    <div><Link href={`/west-end/theater/${slugify(show.venue)}`} className="text-gray-300 font-medium hover:text-brand transition-colors">{show.venue}</Link></div>
-                  ) : isOffBroadway ? (
-                    <div className="text-gray-300 font-medium">{show.venue}</div>
-                  ) : (
-                    <>
-                      <div><Link href={`/theater/${slugify(show.venue)}`} className="text-gray-300 font-medium hover:text-brand transition-colors">{show.venue}</Link></div>
-                    </>
-                  )}
-                  {show.runtime && <div>{show.runtime}</div>}
-                  {show.status === 'previews' || show.status === 'upcoming' ? (
-                    formatDate(show.openingDate) ? <div>Opens {formatDate(show.openingDate)}</div> : null
-                  ) : (
-                    <>
-                      {formatDate(show.openingDate) && <div>Opened {formatDate(show.openingDate)}</div>}
-                      {show.closingDate && (
-                        <div className="text-amber-400">
-                          {show.status === 'closed' ? 'Closed' : 'Closes'} {formatDate(show.closingDate)}
-                        </div>
-                      )}
-                    </>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            {/* Row 2: Dual Score Boxes + Rating + Links */}
-            <div className="mt-4 space-y-4">
-              {/* Full-width separator */}
-              <div className="-mx-5 border-t border-white/10" />
-
-              {/* Score boxes */}
-              <div className="flex gap-3">
-                {/* Critic Score */}
-                <a href="#critic-reviews" className="flex items-center gap-2 flex-1 min-w-0">
-                  <div className={`w-14 h-14 rounded-lg flex items-center justify-center flex-shrink-0 ${scoreColorClass}`}>
-                    <span className="text-2xl font-extrabold">
-                      {showTBD ? 'TBD' : roundedScore}
-                    </span>
-                  </div>
-                  <div className="min-w-0">
-                    {showTBD ? (
-                      <div className="text-base font-bold text-gray-400">Awaiting Reviews</div>
-                    ) : sentiment && (
-                      <div className={`text-base font-bold truncate ${sentiment.colorClass}`}>{sentiment.label}</div>
-                    )}
-                    <div className="text-xs text-gray-500 leading-snug truncate">
-                      {reviewCount > 0 ? `${reviewCount} critic ${reviewCount === 1 ? 'review' : 'reviews'}` : 'No reviews yet'}
-                    </div>
-                  </div>
-                </a>
-                {/* Audience Score */}
-                {hasAudience && audienceGrade && (
-                  <a href="#audience" className="flex items-center gap-2 flex-1 min-w-0">
-                    <div className="w-14 h-14 rounded-lg flex items-center justify-center flex-shrink-0 text-xl font-extrabold" style={{ background: audienceGrade.color, color: audienceGrade.textColor }}>
-                      {audienceGrade.grade}
-                    </div>
-                    <div className="min-w-0">
-                      <div className="text-base font-bold truncate" style={{ color: audienceGrade.color }}>{audienceGrade.label}</div>
-                      <div className="text-xs text-gray-500 leading-snug truncate">
-                        {totalAudienceCount.toLocaleString('en-US')} audience reviews
-                      </div>
-                    </div>
-                  </a>
-                )}
-              </div>
-
-              {/* Full-width separator */}
-              <div className="-mx-5 border-t border-white/10" />
-
-              {/* User Rating — compact, internal border stripped */}
-              <div className="[&>div]:border-t-0 [&>div]:mt-0 [&>div]:pt-0 [&>div]:-mb-0">
-                <ShowPageRatingConnected
-                  showId={show.id}
-                  showTitle={show.title}
-                  previewDate={show.previewsStartDate}
-                  closingDate={show.closingDate}
-                />
-              </div>
-
-              {/* Full-width separator */}
-              <div className="-mx-5 border-t border-white/10" />
-
-              {/* Action Links + Watchlist — links scroll, watchlist always visible */}
-              <div className="flex items-center gap-2">
-                <div className="flex-1 min-w-0 overflow-x-auto flex-nowrap scrollbar-hide">
-                  <div className="flex gap-2 pb-1">
-                    <TicketButtonsAB
-                      showName={show.title}
-                      showId={show.id}
-                      showSlug={show.slug}
-                      showStatus={show.status}
-                      showCategory={show.category}
-                      showScore={show.criticScore?.score ?? null}
-                      ticketLinks={sortedTicketLinks}
-                      officialUrl={show.officialUrl}
-                      pageType="show"
-                      buttonClassName="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-surface-overlay hover:bg-white/10 text-gray-300 hover:text-white text-xs leading-none font-medium transition-colors border border-white/10 whitespace-nowrap flex-shrink-0"
-                    />
-                    {featureFlags.discountTickets && lotteryRush && show.status !== 'closed' && (
-                      <a
-                        href="#discount-tickets"
-                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-surface-overlay hover:bg-white/10 text-gray-500 hover:text-gray-300 text-xs leading-none font-medium transition-colors border border-white/5 whitespace-nowrap flex-shrink-0"
-                      >
-                        <TicketIcon />
-                        {lotteryRush.lottery ? (lotteryRush.lottery.price ? `${getCurrencySymbol(show.category)}${lotteryRush.lottery.price} Lottery` : 'Lottery Tickets') : lotteryRush.rush ? (lotteryRush.rush.price ? `${getCurrencySymbol(show.category)}${lotteryRush.rush.price} Rush` : 'Rush Tickets') : 'Discount Tickets'}
-                      </a>
-                    )}
-                  </div>
-                </div>
-                <ShowPageWatchlistButton showId={show.id} />
-              </div>
-            </div>
+          <div className="sm:hidden mb-6">
+            <ShowHeroRedesign
+              show={show}
+              consensusText={consensus?.text ?? null}
+              audienceGrade={audienceGrade}
+              audienceCount={totalAudienceCount}
+              hasAudience={hasAudience}
+              hasEnoughCriticReviews={!showTBD}
+              sortedTicketLinks={sortedTicketLinks}
+              lotteryRush={lotteryRush ?? null}
+              isWestEnd={isWestEnd}
+              isOffBroadway={isOffBroadway}
+            />
           </div>
         )}
 

--- a/src/components/TicketButtonsAB.tsx
+++ b/src/components/TicketButtonsAB.tsx
@@ -46,6 +46,18 @@ interface TicketButtonsABProps {
   maxButtons?: number;
   /** Class applied to each button pill */
   buttonClassName?: string;
+  /**
+   * When true, renders the first ticket link as a full-width primary CTA on its
+   * own row, followed by the remaining links + Official Site as inline secondary
+   * pills wrapped in a flex row. Used by the show-page redesign hero block.
+   * Tracking events stay identical to the inline-row default — same abVariantStr,
+   * same `linkPosition` ordering — so analyze-ab-test.js handles split traffic
+   * the same as inline traffic. Single-button A/B variant collapses to just the
+   * primary CTA in both modes.
+   */
+  splitVariant?: boolean;
+  /** Class applied to the first/primary CTA when splitVariant=true. */
+  primaryButtonClassName?: string;
 }
 
 /**
@@ -65,6 +77,8 @@ export default function TicketButtonsAB({
   showName, showId, showSlug, showStatus, showCategory, showScore,
   ticketLinks, officialUrl, pageType, maxButtons = 4,
   buttonClassName = "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-surface-overlay hover:bg-white/10 text-gray-300 hover:text-white text-xs leading-none font-medium transition-colors border border-white/10 whitespace-nowrap flex-shrink-0",
+  splitVariant = false,
+  primaryButtonClassName = "w-full inline-flex items-center justify-center gap-1.5 py-2.5 px-4 rounded-lg bg-gradient-brand text-white font-bold text-sm hover:shadow-glow-sm hover:scale-[1.01] active:scale-[0.99] transition-all whitespace-nowrap",
 }: TicketButtonsABProps) {
   const [abPlatformVariant, setAbPlatformVariant] = useState<string | null>(null);
   const [abButtonVariant, setAbButtonVariant] = useState<string | null>(null);
@@ -150,59 +164,107 @@ export default function TicketButtonsAB({
   if (!flagsLoaded) return null;
   if (showStatus === 'closed' || visibleLinks.length === 0) return null;
 
+  // Helpers — same TicketLink shape used by both modes; only the wrapper layout differs.
+  // `withArrow` adds a trailing `→` (split-variant primary CTA emphasis only).
+  const renderPrimary = (link: TicketLinkData, i: number, totalLinks: number, className: string, withArrow = false) => (
+    <TicketLink
+      key={link.platform}
+      showName={showName}
+      showId={showId}
+      showSlug={showSlug}
+      showStatus={showStatus}
+      showCategory={showCategory}
+      showScore={showScore}
+      platform={link.platform}
+      url={link.url}
+      pageType={pageType}
+      linkPosition={i}
+      totalLinks={totalLinks}
+      abVariant={abVariantStr}
+      className={className}
+    >
+      {link.priceFrom ? `Get Tickets from ${getCurrencySymbol(showCategory)}${link.priceFrom}` : `Get Tickets on ${link.platform}`}
+      {withArrow && <span aria-hidden="true">→</span>}
+    </TicketLink>
+  );
+
+  const renderSecondary = (link: TicketLinkData, i: number, totalLinks: number) => (
+    <TicketLink
+      key={link.platform}
+      showName={showName}
+      showId={showId}
+      showSlug={showSlug}
+      showStatus={showStatus}
+      showCategory={showCategory}
+      showScore={showScore}
+      platform={link.platform}
+      url={link.url}
+      pageType={pageType}
+      linkPosition={i}
+      totalLinks={totalLinks}
+      abVariant={abVariantStr}
+      className={buttonClassName}
+    >
+      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z" />
+      </svg>
+      {link.platform}
+    </TicketLink>
+  );
+
+  const renderOfficial = (linkPosition: number, totalLinks: number) => officialUrl ? (
+    <TicketLink
+      showName={showName}
+      showId={showId}
+      showSlug={showSlug}
+      showStatus={showStatus}
+      showCategory={showCategory}
+      showScore={showScore}
+      platform="Official Site"
+      url={officialUrl}
+      pageType={pageType}
+      linkPosition={linkPosition}
+      totalLinks={totalLinks}
+      className={buttonClassName}
+    >
+      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+      </svg>
+      Official Site
+    </TicketLink>
+  ) : null;
+
+  // splitVariant: primary CTA on its own row + secondary pills wrapped below.
+  // Single-button A/B variant collapses to just the primary in either mode.
+  if (splitVariant) {
+    const totalLinksInRow = visibleLinks.length + (!isSingleButton && officialUrl ? 1 : 0);
+    const primaryLink = visibleLinks[0];
+    const secondaryLinks = visibleLinks.slice(1);
+    const hasSecondary = !isSingleButton && (secondaryLinks.length > 0 || officialUrl);
+    return (
+      <>
+        {primaryLink && renderPrimary(primaryLink, 0, totalLinksInRow, primaryButtonClassName, /* withArrow */ true)}
+        {hasSecondary && (
+          <div className="flex flex-wrap gap-2">
+            {secondaryLinks.map((link, idx) => renderSecondary(link, idx + 1, totalLinksInRow))}
+            {!isSingleButton && renderOfficial(visibleLinks.length, totalLinksInRow)}
+          </div>
+        )}
+      </>
+    );
+  }
+
+  // Default inline mode (existing behavior — all callers other than ShowHeroRedesign).
+  // Primary uses buttonClassName (same as secondary), no arrow — matches pre-split rendering.
+  const inlineTotalLinks = visibleLinks.length + (!isSingleButton && officialUrl ? 1 : 0);
   return (
     <>
       {visibleLinks.map((link, i) => (
-        <TicketLink
-          key={link.platform}
-          showName={showName}
-          showId={showId}
-          showSlug={showSlug}
-          showStatus={showStatus}
-          showCategory={showCategory}
-          showScore={showScore}
-          platform={link.platform}
-          url={link.url}
-          pageType={pageType}
-          linkPosition={i}
-          totalLinks={visibleLinks.length}
-          abVariant={abVariantStr}
-          className={buttonClassName}
-        >
-          {i === 0 ? (
-            link.priceFrom ? `Get Tickets from ${getCurrencySymbol(showCategory)}${link.priceFrom}` : `Get Tickets on ${link.platform}`
-          ) : (
-            <>
-              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z" />
-              </svg>
-              {link.platform}
-            </>
-          )}
-        </TicketLink>
+        i === 0
+          ? renderPrimary(link, i, inlineTotalLinks, buttonClassName)
+          : renderSecondary(link, i, inlineTotalLinks)
       ))}
-      {/* In single-button variant, hide Official Site and secondary buttons */}
-      {!isSingleButton && officialUrl && (
-        <TicketLink
-          showName={showName}
-          showId={showId}
-          showSlug={showSlug}
-          showStatus={showStatus}
-          showCategory={showCategory}
-          showScore={showScore}
-          platform="Official Site"
-          url={officialUrl}
-          pageType={pageType}
-          linkPosition={visibleLinks.length}
-          totalLinks={visibleLinks.length + 1}
-          className={buttonClassName}
-        >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-          </svg>
-          Official Site
-        </TicketLink>
-      )}
+      {!isSingleButton && renderOfficial(visibleLinks.length, inlineTotalLinks)}
     </>
   );
 }

--- a/src/components/show-page/ShowHeroRedesign.tsx
+++ b/src/components/show-page/ShowHeroRedesign.tsx
@@ -1,0 +1,704 @@
+'use client';
+
+/**
+ * ShowHeroRedesign — Broadway Radar–inspired show-page hero block (mobile-first).
+ *
+ * Replaces the prior `featureFlags.showPageRedesign` block in src/app/show/[slug]/page.tsx.
+ * Renders: poster + title header, dual score boxes (critic + audience), distribution bar,
+ * Critics' Take, your-rating card (rated state), Want-to-See / Rate-it buttons,
+ * inline rate panel (web), primary tickets CTA + secondary tickets row, on-list caption.
+ *
+ * Decisions (see memory/feedback_show_page_redesign_v2_decisions.md):
+ *  • Score-card tap targets — both anchor to existing #critic-reviews / #audience.
+ *  • "Rate it again" with 1 rating → opens edit panel pre-filled (replaces existing).
+ *  • "Log another viewing" with 2+ ratings → opens fresh panel (appends).
+ *  • Date format: `Apr 10, 2026` always (matches existing /show convention).
+ *  • Multi-viewing card shows latest highlighted + "All N ratings →" footer link.
+ *  • No inline trash on the rating card — delete moves into the edit panel.
+ *  • Closed shows: rating card renders if rated; tickets CTA + secondary row hidden;
+ *    "Want to See" still functions ("wished I'd seen" semantics).
+ *  • Watchlist + rating are independent — Want to See persists after rating.
+ *  • <3 reviews → "Awaiting reviews" replaces score row + bar + Critics' Take.
+ *
+ * Deferred-auth flow mirrors ShowPageRatingConnected: pending action saved before
+ * showSignIn(); resumed when user lands back on this page authenticated.
+ */
+
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import {
+  ScoreBadge,
+  ScoreBreakdownBar,
+  FormatPill,
+  ProductionPill,
+  StatusBadge,
+  CategoryBadge,
+  getScoreTier,
+} from '@/components/show-cards';
+import StarRating from '@/components/user/StarRating';
+import ReviewPanel from '@/components/user/ReviewPanel';
+import ShowImage from '@/components/ShowImage';
+import ShowPageBookmark from '@/components/user/ShowPageBookmark';
+import TicketButtonsAB from '@/components/TicketButtonsAB';
+import { useAuth } from '@/contexts/AuthContext';
+import { useUserReviews } from '@/hooks/useUserReviews';
+import { useWatchlist } from '@/hooks/useWatchlist';
+import { useUserLists } from '@/hooks/useUserLists';
+import { useToastSafe } from '@/components/ui/Toast';
+import { savePendingAction, getPendingAction, clearPendingAction } from '@/lib/deferred-auth';
+import { supabaseRestInsert, supabaseRestUpdate } from '@/lib/supabase-rest';
+import { featureFlags } from '@/config/feature-flags';
+import { getOptimizedImageUrl } from '@/lib/images';
+import { getCurrencySymbol } from '@/lib/market-utils';
+import type { ComputedShow } from '@/lib/engine';
+
+/** Inlined to avoid pulling @/lib/data-core (server-only JSON imports) into the
+ *  client bundle. Matches the data-core slugify exactly. */
+function slugify(str: string): string {
+  return str.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
+import type { AudienceGrade } from '@/components/show-cards';
+import type { TicketLinkData } from '@/lib/ticket-utils';
+import type { UserReview } from '@/types/user';
+
+// ─── Props ───────────────────────────────────────────────────────────────
+
+interface ShowHeroRedesignProps {
+  show: ComputedShow;
+  consensusText: string | null;
+  audienceGrade: AudienceGrade | null;
+  audienceCount: number;
+  hasAudience: boolean;
+  hasEnoughCriticReviews: boolean;
+  sortedTicketLinks: TicketLinkData[];
+  lotteryRush: { lottery?: { price?: number | null } | null; rush?: { price?: number | null } | null } | null;
+  isWestEnd: boolean;
+  isOffBroadway: boolean;
+}
+
+// ─── Suspense wrapper (useSearchParams requires it for static prerender) ──
+
+export default function ShowHeroRedesign(props: ShowHeroRedesignProps) {
+  return (
+    <Suspense fallback={null}>
+      <Inner {...props} />
+    </Suspense>
+  );
+}
+
+// ─── Inner ───────────────────────────────────────────────────────────────
+
+function Inner({
+  show,
+  consensusText,
+  audienceGrade,
+  audienceCount,
+  hasAudience,
+  hasEnoughCriticReviews,
+  sortedTicketLinks,
+  lotteryRush,
+  isWestEnd,
+  isOffBroadway,
+}: ShowHeroRedesignProps) {
+  const { user, isAuthenticated, loading: authLoading, showSignIn } = useAuth();
+  const { reviews, getReviewsForShow, deleteReview } = useUserReviews(user?.id || null);
+  const { isWatchlisted, addToWatchlist, removeFromWatchlist, getWatchlist, watchlist } = useWatchlist(user?.id || null);
+  const { lists, getLists } = useUserLists(user?.id || null);
+  const { showToast } = useToastSafe();
+  const searchParams = useSearchParams();
+
+  const [ratePanelOpen, setRatePanelOpen] = useState(false);
+  const [editingReview, setEditingReview] = useState<UserReview | null>(null);
+  const [pendingRatingFromAuth, setPendingRatingFromAuth] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+  const hasExecutedPending = useRef(false);
+
+  // ?rate=1 / ?stars=N / ?edit=1 deep-link helpers (kept compatible with /my-shows entry points)
+  const [autoRate] = useState(() => searchParams.get('rate') === '1');
+  const autoRateStars = searchParams.get('stars') ? parseFloat(searchParams.get('stars')!) : null;
+  const [autoEditLatest] = useState(() => searchParams.get('edit') === '1');
+
+  // ─── Derived state ─────────────────────────────────────────────────────
+
+  const showReviews = reviews.filter(r => r.show_id === show.id);
+  const sortedReviews = [...showReviews].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  );
+  const latestReview = sortedReviews[0] ?? null;
+  const ratingCount = showReviews.length;
+  const hasRating = ratingCount > 0;
+  const isMulti = ratingCount > 1;
+  const onWatchlist = isWatchlisted(show.id);
+  const watchlistDate = watchlist.find(w => w.show_id === show.id)?.planned_date || null;
+
+  // Lists containing this show — caption only, no button on show page.
+  const listsWithShow = lists.filter(l =>
+    (l.all_show_ids ?? l.preview_show_ids ?? []).includes(show.id)
+  );
+  const firstListContainingShow = listsWithShow[0];
+
+  const score = show.criticScore?.score ?? null;
+  const reviewCount = show.criticScore?.reviewCount ?? 0;
+  const criticReviewsForBar = show.criticScore?.reviews ?? [];
+  const tier = score !== null ? getScoreTier(score, show.category) : null;
+  const isClosed = show.status === 'closed';
+  const isPreviews = show.status === 'previews' || show.status === 'upcoming';
+
+  // Average rating across user's viewings (multi-viewing card foot)
+  const userAvg = ratingCount > 0
+    ? showReviews.reduce((sum, r) => sum + r.rating, 0) / ratingCount
+    : 0;
+
+  // ─── Effects ───────────────────────────────────────────────────────────
+
+  // Load on auth
+  useEffect(() => {
+    if (isAuthenticated && user) {
+      getReviewsForShow(show.id);
+      getWatchlist();
+      getLists();
+    }
+  }, [isAuthenticated, user, show.id, getReviewsForShow, getWatchlist, getLists]);
+
+  // Consume pending action after deferred auth
+  useEffect(() => {
+    if (!isAuthenticated || !user || hasExecutedPending.current) return;
+    const pending = getPendingAction();
+    if (!pending || pending.showId !== show.id) return;
+    hasExecutedPending.current = true;
+    clearPendingAction();
+
+    if (pending.type === 'rating') {
+      setEditingReview(null);
+      setPendingRatingFromAuth(pending.rating ?? null);
+      setRatePanelOpen(true);
+    } else if (pending.type === 'watchlist') {
+      addToWatchlist(show.id)
+        .then(() => showToast?.(<>Added to <a href="/my-shows?tab=watchlist" className="underline hover:text-white/90">Watchlist</a></>, 'success'))
+        .catch(() => showToast?.('Failed to add to watchlist.', 'error'));
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated, user, show.id]);
+
+  // ?rate=1 — auto-open rate panel (deferred-auth target for inline-stars CTAs)
+  useEffect(() => {
+    if (!autoRate || ratePanelOpen) return;
+    if (!isAuthenticated && !authLoading) {
+      savePendingAction({
+        type: 'rating',
+        showId: show.id,
+        ...(autoRateStars != null ? { rating: autoRateStars } : {}),
+        returnUrl: window.location.pathname,
+        timestamp: Date.now(),
+      });
+      showSignIn('rating');
+    } else {
+      // Open with latest review pre-filled (edit) if rated, else fresh panel with stars hint
+      setEditingReview(latestReview);
+      setPendingRatingFromAuth(latestReview ? null : autoRateStars);
+      setRatePanelOpen(true);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoRate, isAuthenticated, authLoading]);
+
+  // ?edit=1 — auto-open edit on latest review (diary edit pencil entry point)
+  useEffect(() => {
+    if (autoEditLatest && latestReview && !ratePanelOpen) {
+      setEditingReview(latestReview);
+      setRatePanelOpen(true);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoEditLatest, latestReview]);
+
+  // ─── Handlers ──────────────────────────────────────────────────────────
+
+  const handleWantToSee = useCallback(async () => {
+    if (!isAuthenticated && !authLoading) {
+      savePendingAction({
+        type: 'watchlist',
+        showId: show.id,
+        returnUrl: window.location.pathname,
+        timestamp: Date.now(),
+      });
+      showSignIn('watchlist');
+      return;
+    }
+    try {
+      if (onWatchlist) {
+        await removeFromWatchlist(show.id);
+        showToast?.(<>Removed from <a href="/my-shows?tab=watchlist" className="underline hover:text-white/90">Watchlist</a></>, 'info');
+      } else {
+        await addToWatchlist(show.id);
+        showToast?.(<>Added to <a href="/my-shows?tab=watchlist" className="underline hover:text-white/90">Watchlist</a></>, 'success');
+      }
+    } catch {
+      showToast?.('Failed to update watchlist.', 'error');
+    }
+  }, [isAuthenticated, authLoading, onWatchlist, show.id, addToWatchlist, removeFromWatchlist, showSignIn, showToast]);
+
+  const handleRateIt = useCallback(() => {
+    if (!isAuthenticated && !authLoading) {
+      savePendingAction({
+        type: 'rating',
+        showId: show.id,
+        returnUrl: window.location.pathname,
+        timestamp: Date.now(),
+      });
+      showSignIn('rating');
+      return;
+    }
+    if (isMulti) {
+      // 2+ existing ratings → "Log another viewing": fresh panel, appends new entry.
+      setEditingReview(null);
+    } else if (hasRating) {
+      // Exactly 1 rating → "Rate it again": opens with latest pre-filled, replaces.
+      setEditingReview(latestReview);
+    } else {
+      // First rating → fresh panel.
+      setEditingReview(null);
+    }
+    setPendingRatingFromAuth(null);
+    setRatePanelOpen(true);
+  }, [isAuthenticated, authLoading, show.id, hasRating, isMulti, latestReview, showSignIn]);
+
+  const handleEditLatest = useCallback(() => {
+    if (!latestReview) return;
+    setEditingReview(latestReview);
+    setRatePanelOpen(true);
+  }, [latestReview]);
+
+  const handleSaveReview = useCallback(async (data: { rating: number; reviewText: string | null; dateSeen: string | null }) => {
+    if (!user) {
+      showToast?.('Please sign in to save ratings.', 'error');
+      return;
+    }
+    setSaving(true);
+    try {
+      if (editingReview) {
+        const filters = `id=eq.${editingReview.id}&user_id=eq.${user.id}`;
+        const { error } = await supabaseRestUpdate('reviews', filters, {
+          rating: data.rating,
+          review_text: data.reviewText || null,
+          date_seen: data.dateSeen || null,
+          updated_at: new Date().toISOString(),
+        });
+        if (error) throw new Error(error.message);
+        showToast?.(<>Updated in <a href="/my-shows" className="underline hover:text-white/90">My Ratings &amp; Reviews</a></>, 'success');
+      } else {
+        const { error } = await supabaseRestInsert('reviews', {
+          user_id: user.id,
+          show_id: show.id,
+          rating: data.rating,
+          review_text: data.reviewText || null,
+          date_seen: data.dateSeen || null,
+        });
+        if (error) throw new Error(error.message);
+        showToast?.(<>Added to <a href="/my-shows" className="underline hover:text-white/90">My Ratings &amp; Reviews</a></>, 'success');
+      }
+      await getReviewsForShow(show.id);
+    } catch (e) {
+      const detail = e instanceof Error ? e.message : 'Unknown error';
+      showToast?.(`Save failed: ${detail}`, 'error');
+    } finally {
+      setSaving(false);
+      setRatePanelOpen(false);
+      setEditingReview(null);
+      setPendingRatingFromAuth(null);
+    }
+  }, [user, editingReview, show.id, getReviewsForShow, showToast]);
+
+  const handleCancelRate = useCallback(() => {
+    setRatePanelOpen(false);
+    setEditingReview(null);
+    setPendingRatingFromAuth(null);
+  }, []);
+
+  const handleDeleteRating = useCallback(async () => {
+    if (!editingReview) return;
+    try {
+      await deleteReview(editingReview.id);
+      showToast?.('Rating deleted.', 'info');
+      await getReviewsForShow(show.id);
+    } catch (e) {
+      const detail = e instanceof Error ? e.message : 'Unknown error';
+      showToast?.(`Delete failed: ${detail}`, 'error');
+    } finally {
+      setRatePanelOpen(false);
+      setEditingReview(null);
+    }
+  }, [editingReview, deleteReview, getReviewsForShow, show.id, showToast]);
+
+  // ─── Render ────────────────────────────────────────────────────────────
+
+  const venueLink = isWestEnd
+    ? `/west-end/theater/${slugify(show.venue)}`
+    : isOffBroadway
+      ? null
+      : `/theater/${slugify(show.venue)}`;
+
+  // Hide rating section + watchlist controls if userAccounts flag off (keeps demo-only gate).
+  const userFeaturesEnabled = featureFlags.userAccounts;
+
+  return (
+    <div className="card p-4 sm:p-5 space-y-4" data-testid="show-hero-redesign">
+      {/* Header: poster left + title block right */}
+      <div className="flex gap-4">
+        <div className="flex-shrink-0 w-28 sm:w-36">
+          <div className="relative aspect-[2/3] rounded-xl overflow-visible shadow-2xl border border-white/10 bg-surface-raised">
+            {userFeaturesEnabled && <ShowPageBookmark showId={show.id} size="compact" />}
+            <div className="absolute inset-0 rounded-xl overflow-hidden">
+              <ShowImage
+                sources={[
+                  show.images?.poster ? getOptimizedImageUrl(show.images.poster, 'poster') : null,
+                  show.images?.thumbnail ? getOptimizedImageUrl(show.images.thumbnail, 'poster') : null,
+                  show.images?.hero ? getOptimizedImageUrl(show.images.hero, 'poster') : null,
+                ]}
+                alt={`${show.title} poster`}
+                width={176}
+                height={264}
+                decoding="async"
+                priority
+                sizes="144px"
+                className="w-full h-full object-cover"
+                fallback={
+                  <div className="w-full h-full flex items-center justify-center bg-surface-overlay">
+                    <span className="text-4xl text-gray-500">🎭</span>
+                  </div>
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div className="flex-1 min-w-0 space-y-1.5">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <FormatPill type={show.type} />
+            {show.isRevival && <ProductionPill isRevival />}
+            <CategoryBadge category={show.category} />
+            <StatusBadge status={show.status} />
+          </div>
+          <h1 className="text-2xl font-extrabold tracking-tight leading-tight text-white">
+            {show.title}
+          </h1>
+          <div className="text-sm text-gray-400 space-y-0.5 pt-0.5">
+            <p>
+              {venueLink ? (
+                <Link href={venueLink} className="text-gray-300 underline underline-offset-2 decoration-white/10 hover:text-brand transition-colors">
+                  {show.venue}
+                </Link>
+              ) : (
+                <span className="text-gray-300">{show.venue}</span>
+              )}
+              {show.runtime ? <span> · {show.runtime}</span> : null}
+            </p>
+            <DateLine show={show} />
+          </div>
+        </div>
+      </div>
+
+      {/* Score row OR awaiting card */}
+      {!hasEnoughCriticReviews ? (
+        <AwaitingCard show={show} reviewCount={reviewCount} />
+      ) : (
+        <div className={`grid gap-2.5 ${hasAudience && audienceGrade ? 'grid-cols-2' : 'grid-cols-1'}`}>
+          {/* Critic score box — taps anchor to #critic-reviews */}
+          <a href="#critic-reviews" className="card p-3 sm:p-4 flex items-center gap-3 hover:bg-surface-overlay transition-colors">
+            <ScoreBadge score={score} reviewCount={reviewCount} category={show.category} size="lg" showCrown />
+            <div className="min-w-0 flex-1">
+              {tier && (
+                <p className="text-sm font-bold leading-tight" style={{ color: tier.color }}>
+                  {tier.label}
+                </p>
+              )}
+              <p className="text-[11px] text-gray-500 mt-0.5 leading-snug">
+                {reviewCount} critic {reviewCount === 1 ? 'review' : 'reviews'}
+              </p>
+            </div>
+          </a>
+          {/* Audience grade box — taps anchor to #audience */}
+          {hasAudience && audienceGrade && (
+            <a href="#audience" className="card p-3 sm:p-4 flex items-center gap-3 hover:bg-surface-overlay transition-colors">
+              <div
+                className="w-16 h-16 sm:w-20 sm:h-20 rounded-xl flex items-center justify-center flex-shrink-0 text-3xl font-extrabold"
+                style={{ background: audienceGrade.color, color: audienceGrade.textColor }}
+              >
+                {audienceGrade.grade}
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-bold leading-tight" style={{ color: audienceGrade.color }}>
+                  {audienceGrade.label}
+                </p>
+                {audienceCount > 0 && (
+                  <p className="text-[11px] text-gray-500 mt-0.5 leading-snug">
+                    {audienceCount.toLocaleString('en-US')} audience reviews
+                  </p>
+                )}
+              </div>
+            </a>
+          )}
+        </div>
+      )}
+
+      {/* Distribution bar */}
+      {hasEnoughCriticReviews && criticReviewsForBar.length > 0 && (
+        <ScoreBreakdownBar reviews={criticReviewsForBar} category={show.category} />
+      )}
+
+      {/* Critics' Take — inlined; CriticsTakeCard component lives only on the v1
+          redesign branch and isn't merged to main. Styling matches the existing
+          consensus block on the desktop side of this same page. */}
+      {hasEnoughCriticReviews && consensusText && (
+        <div className="card p-4">
+          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-1.5">
+            Critics&apos; Take
+          </p>
+          <p className="text-gray-300 text-sm leading-relaxed">{consensusText}</p>
+        </div>
+      )}
+
+      {/* Your rating card (rated state, render only when not actively editing inline) */}
+      {userFeaturesEnabled && hasRating && latestReview && !ratePanelOpen && (
+        <YourRatingInline
+          latestReview={latestReview}
+          isMulti={isMulti}
+          totalRatings={ratingCount}
+          userAvg={userAvg}
+          onEdit={handleEditLatest}
+        />
+      )}
+
+      {/* Action buttons row — Want to See / Rate it (icon stacked vertical) */}
+      {userFeaturesEnabled && (
+        <div className="grid grid-cols-2 gap-2.5">
+          <button
+            type="button"
+            onClick={handleWantToSee}
+            className={`flex flex-col items-center gap-1.5 py-3 px-2 rounded-card border transition-all ${
+              onWatchlist
+                ? 'bg-surface-raised border-brand text-brand'
+                : 'bg-surface-raised border-white/10 text-gray-300 hover:text-white hover:border-white/20'
+            }`}
+          >
+            <svg className="w-5 h-5" fill={onWatchlist ? 'currentColor' : 'none'} viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+            </svg>
+            <span className="text-xs font-semibold">{onWatchlist ? 'On your list' : 'Want to See'}</span>
+          </button>
+          <button
+            type="button"
+            onClick={handleRateIt}
+            className="flex flex-col items-center gap-1.5 py-3 px-2 rounded-card border bg-surface-raised border-white/10 text-gray-300 hover:text-white hover:border-white/20 transition-all"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.196-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+            </svg>
+            <span className="text-xs font-semibold">
+              {!hasRating ? 'Rate it' : isMulti ? 'Log another viewing' : 'Rate it again'}
+            </span>
+          </button>
+        </div>
+      )}
+
+      {/* On-list caption — minor indicator (decision: show page stays simple, list mgmt in /my-shows) */}
+      {userFeaturesEnabled && firstListContainingShow && (
+        <p className="text-[11px] text-gray-500 flex items-center gap-1.5 -mt-2">
+          <svg className="w-3 h-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 10h16M4 14h16M4 18h10" />
+          </svg>
+          <span className="truncate">
+            Also on{' '}
+            {listsWithShow.length === 1 ? (
+              <Link
+                href={`/my-shows?tab=lists&list=${firstListContainingShow.id}`}
+                className="text-gray-400 hover:text-brand transition-colors border-b border-dotted border-white/10"
+              >
+                {firstListContainingShow.name}
+              </Link>
+            ) : (
+              <Link
+                href="/my-shows?tab=lists"
+                className="text-gray-400 hover:text-brand transition-colors border-b border-dotted border-white/10"
+              >
+                {listsWithShow.length} of your lists
+              </Link>
+            )}
+          </span>
+        </p>
+      )}
+
+      {/* Inline rate panel (web behavior) — delete-rating button rendered as a separate
+          row when editing an existing review (ReviewPanel itself has no delete slot) */}
+      {userFeaturesEnabled && ratePanelOpen && (
+        <div className="space-y-2">
+          <ReviewPanel
+            rating={editingReview?.rating ?? pendingRatingFromAuth ?? 5}
+            existingReviewText={editingReview?.review_text}
+            existingDateSeen={editingReview?.date_seen ?? (editingReview ? undefined : watchlistDate)}
+            showTitle={show.title}
+            latestDate={show.closingDate}
+            onSave={handleSaveReview}
+            onCancel={handleCancelRate}
+            saving={saving}
+          />
+          {editingReview && (
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={handleDeleteRating}
+                className="text-[11px] text-gray-500 hover:text-score-skip transition-colors px-2 py-1"
+              >
+                Delete this rating
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Tickets — split-variant: primary CTA + secondary pills row */}
+      {!isClosed && sortedTicketLinks.length > 0 && (
+        <TicketButtonsAB
+          showName={show.title}
+          showId={show.id}
+          showSlug={show.slug}
+          showStatus={show.status}
+          showCategory={show.category}
+          showScore={score}
+          ticketLinks={sortedTicketLinks}
+          officialUrl={show.officialUrl}
+          pageType="show"
+          splitVariant
+        />
+      )}
+
+      {/* Lottery / Rush — small inline link below tickets row */}
+      {!isClosed && featureFlags.discountTickets && lotteryRush && (
+        <a
+          href="#discount-tickets"
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-surface-overlay hover:bg-white/10 text-gray-500 hover:text-gray-300 text-xs leading-none font-medium transition-colors border border-white/5 whitespace-nowrap self-start"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z" />
+          </svg>
+          {lotteryRush.lottery
+            ? lotteryRush.lottery.price
+              ? `${getCurrencySymbol(show.category)}${lotteryRush.lottery.price} Lottery`
+              : 'Lottery Tickets'
+            : lotteryRush.rush
+              ? lotteryRush.rush.price
+                ? `${getCurrencySymbol(show.category)}${lotteryRush.rush.price} Rush`
+                : 'Rush Tickets'
+              : 'Discount Tickets'}
+        </a>
+      )}
+    </div>
+  );
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────
+
+function DateLine({ show }: { show: ComputedShow }) {
+  if (show.status === 'closed' && show.openingDate && show.closingDate) {
+    return (
+      <p>
+        {formatDate(show.openingDate)} → {formatDate(show.closingDate)}
+      </p>
+    );
+  }
+  if (show.status === 'previews' || show.status === 'upcoming') {
+    if (show.openingDate) {
+      return <p>Opens {formatDate(show.openingDate)}</p>;
+    }
+    return null;
+  }
+  // open
+  return (
+    <p>
+      {show.openingDate && <>Opened {formatDate(show.openingDate)}</>}
+      {show.closingDate && <> · Closes {formatDate(show.closingDate)}</>}
+    </p>
+  );
+}
+
+function AwaitingCard({ show, reviewCount }: { show: ComputedShow; reviewCount: number }) {
+  return (
+    <div className="card p-4 text-center bg-surface-overlay border-white/5">
+      <p className="text-sm font-semibold text-gray-300 mb-0.5">Awaiting reviews</p>
+      <p className="text-xs text-gray-500">
+        {show.status === 'previews' ? 'Show in previews' : show.status === 'upcoming' ? 'Show opens soon' : 'Not enough reviews yet'}
+        {reviewCount > 0 ? ` · ${reviewCount} ${reviewCount === 1 ? 'review' : 'reviews'} collected` : null}
+      </p>
+    </div>
+  );
+}
+
+function YourRatingInline({
+  latestReview,
+  isMulti,
+  totalRatings,
+  userAvg,
+  onEdit,
+}: {
+  latestReview: UserReview;
+  isMulti: boolean;
+  totalRatings: number;
+  userAvg: number;
+  onEdit: () => void;
+}) {
+  return (
+    <div className="card p-4 space-y-1.5">
+      <div className="flex items-center gap-3 min-w-0">
+        <div className="flex-shrink-0">
+          <StarRating rating={latestReview.rating} onRatingChange={() => {}} size="sm" readOnly hideLabel />
+        </div>
+        <div className="flex items-baseline gap-1.5 min-w-0 flex-1 text-xs">
+          <span className="font-bold text-gray-200 whitespace-nowrap">
+            {isMulti ? 'Latest viewing' : 'Your rating'}
+          </span>
+          {latestReview.date_seen && (
+            <span className="text-gray-500 whitespace-nowrap">· {formatDate(latestReview.date_seen)}</span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onEdit}
+          className="flex-shrink-0 w-7 h-7 rounded-full bg-surface-overlay border border-white/10 text-gray-300 hover:text-white hover:border-white/20 transition-colors flex items-center justify-center"
+          aria-label="Edit rating"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+          </svg>
+        </button>
+      </div>
+      {latestReview.review_text && (
+        <p className="text-sm text-gray-400 italic leading-snug line-clamp-3">
+          {`“${latestReview.review_text}”`}
+        </p>
+      )}
+      {isMulti && (
+        <div className="pt-2 mt-1 border-t border-white/5 text-[11px] text-gray-500 flex items-center justify-between">
+          <Link href="/my-shows" className="text-gray-400 hover:text-brand transition-colors">
+            All {totalRatings} ratings →
+          </Link>
+          <span>avg {formatStars(userAvg)}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+/** Format ISO date as "Apr 10, 2026" — matches existing /show convention. */
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso + (iso.length === 10 ? 'T00:00:00' : ''));
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+/** Render avg rating as Unicode stars, e.g. 4.5 → "★★★★½". */
+function formatStars(avg: number): string {
+  const full = Math.floor(avg);
+  const half = avg - full >= 0.5;
+  return '★'.repeat(full) + (half ? '½' : '');
+}


### PR DESCRIPTION
## Summary
- Replaces the existing `showPageRedesign` mobile block with the Broadway Radar–inspired layout user approved via mocks (`~/Documents/claude-outputs/bwsc-redesign-mocks/`, polished into real components on `/mock/show-redesign`).
- New `<ShowHeroRedesign>` component wires real Supabase hooks (`useUserReviews`, `useWatchlist`, `useUserLists`, `useAuth`) into the new layout. Deferred-auth flow matches `ShowPageRatingConnected`.
- `<TicketButtonsAB>` gains a `splitVariant` prop: first link becomes a full-width brand-gold primary CTA; rest render as inline dark pills below. PostHog tracking preserved (same `abVariantStr`, `linkPosition` ordering).

## What's in the hero (mobile, 390px)
1. Poster (left) + pills (Format / Production / Status) + title + venue/runtime + dates
2. Score row — two matched-size cards: critic `ScoreBadge` with gold metallic crown + tier label; audience grade solid colored block + label + count
3. `ScoreBreakdownBar` (Rave / Positive / Mixed / Negative)
4. Critics' Take card
5. Your-rating card (when rated): inline stars + "Your rating · Apr 10" + edit pencil + italic quote (+ "All N ratings →" foot link when multi)
6. Action buttons: Want to See / Rate it (gold-lit "On your list" / "Rate it again" / "Log another viewing" labels are state-aware)
7. Inline `<ReviewPanel>` (web behavior — iOS will use a native sheet)
8. "Also on X list" caption (minor on-list indicator linking to /my-shows lists tab)
9. Brand-gold "Get Tickets from \$77 →" primary CTA
10. Secondary tickets row (Telecharge / Official Site / etc.)
11. Lottery / Rush pill (when discountTickets flag on)

## Decisions baked in
Full snapshot in `memory/feedback_show_page_redesign_v2_decisions.md`. Highlights:
- Score boxes matched size (w-16 / sm:w-20); both anchor tappable to existing `#critic-reviews` / `#audience`
- "Rate it again" with 1 rating edits in place; "Log another viewing" with 2+ ratings appends
- Closed shows: rating card still renders if rated; tickets CTA + secondary row hidden; Want to See remains active
- Inline delete removed from rating card (moves into edit panel) — mock had no trash, can re-add if users complain
- Critics' Take inlined (CriticsTakeCard component exists only on v1 redesign branch, not merged)

## Out of scope
- Audience Grade detail card, Critic Reviews list, Box Office, Theater Scorecard, Other Productions, Discount Tickets, Showtimes — untouched
- iOS port — follows web approval (user direction: web first because faster)
- Reverting `worktree-my-shows-redesign` iOS commit `937b752` — separate task in this session

## Test plan
- [x] `npx tsc --noEmit` — no new errors in changed files
- [x] `npx next lint` — no new warnings/errors in changed files
- [x] Visual @ 390px on real /show/death-of-a-salesman — screenshots in `~/Documents/claude-outputs/show-page-redesign-mocks/v2-LIVE-*.png`
- [x] Visual @ 1440px desktop — Metacritic header unchanged
- [ ] User accept design before merge
- [ ] After merge: visit https://demo.broadwayscorecard.com/show/{slug} to verify in deployed env
- [ ] Spot-check rated / unrated / closed / awaiting states on real shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)