### PR TITLE
feat(filters): time-period uses Tony season dates + multi-select

### DIFF
--- a/src/components/HomePageClient.tsx
+++ b/src/components/HomePageClient.tsx
@@ -657,8 +657,8 @@ function HomePageInner({ shows, archiveHash, upcomingShows, offBroadwayShows = [
         singleGroups={panelSingleGroups}
         singleValueByGroup={panel.singleValueByGroup}
         onSetSingleValue={panel.setSingleValue}
-        yearRange={panel.yearRange}
-        onYearRangeChange={panel.setYearRange}
+        dateRanges={panel.dateRanges}
+        onDateRangesChange={panel.setDateRanges}
         onClearAll={handlePanelClearAll}
         resultCount={panel.filteredShows.length}
       />

--- a/src/components/OffBroadwayPageClient.tsx
+++ b/src/components/OffBroadwayPageClient.tsx
@@ -441,8 +441,8 @@ function OffBroadwayPageInner({ shows, totalShows, totalReviews, marketOpenCount
         singleGroups={panelSingleGroups}
         singleValueByGroup={panel.singleValueByGroup}
         onSetSingleValue={panel.setSingleValue}
-        yearRange={panel.yearRange}
-        onYearRangeChange={panel.setYearRange}
+        dateRanges={panel.dateRanges}
+        onDateRangesChange={panel.setDateRanges}
         onClearAll={handlePanelClearAll}
         resultCount={panel.filteredShows.length}
       />

--- a/src/components/OffWestEndPageClient.tsx
+++ b/src/components/OffWestEndPageClient.tsx
@@ -441,8 +441,8 @@ function OffWestEndPageInner({ shows, totalShows, totalReviews, marketOpenCounts
         singleGroups={panelSingleGroups}
         singleValueByGroup={panel.singleValueByGroup}
         onSetSingleValue={panel.setSingleValue}
-        yearRange={panel.yearRange}
-        onYearRangeChange={panel.setYearRange}
+        dateRanges={panel.dateRanges}
+        onDateRangesChange={panel.setDateRanges}
         onClearAll={handlePanelClearAll}
         resultCount={panel.filteredShows.length}
       />

--- a/src/components/WestEndPageClient.tsx
+++ b/src/components/WestEndPageClient.tsx
@@ -529,8 +529,8 @@ function WestEndPageInner({ shows, totalShows, totalReviews, scoredShows, lotter
         singleGroups={panelSingleGroups}
         singleValueByGroup={panel.singleValueByGroup}
         onSetSingleValue={panel.setSingleValue}
-        yearRange={panel.yearRange}
-        onYearRangeChange={panel.setYearRange}
+        dateRanges={panel.dateRanges}
+        onDateRangesChange={panel.setDateRanges}
         onClearAll={handlePanelClearAll}
         resultCount={panel.filteredShows.length}
       />

--- a/src/components/filters/FilterPanel.tsx
+++ b/src/components/filters/FilterPanel.tsx
@@ -6,6 +6,7 @@ import { FILTER_GROUPS, type SingleGroupConfig } from './filter-ui-config';
 import { FilterPillGroup } from './FilterPillGroup';
 import { FilterSinglePillGroup } from './FilterSinglePillGroup';
 import { TimePeriodSection } from './TimePeriodSection';
+import type { DateRange } from '@/lib/tony-seasons';
 
 interface FilterPanelProps {
   isOpen: boolean;
@@ -16,8 +17,8 @@ interface FilterPanelProps {
   singleGroups?: SingleGroupConfig[];
   singleValueByGroup?: Record<string, string>;
   onSetSingleValue?: (paramKey: string, value: string) => void;
-  yearRange: { from: number; to: number } | null;
-  onYearRangeChange: (range: { from: number; to: number } | null) => void;
+  dateRanges: DateRange[];
+  onDateRangesChange: (ranges: DateRange[] | ((prev: DateRange[]) => DateRange[])) => void;
   onClearAll: () => void;
   resultCount: number;
 }
@@ -35,8 +36,8 @@ export function FilterPanel({
   singleGroups,
   singleValueByGroup,
   onSetSingleValue,
-  yearRange,
-  onYearRangeChange,
+  dateRanges,
+  onDateRangesChange,
   onClearAll,
   resultCount,
 }: FilterPanelProps) {
@@ -137,7 +138,7 @@ export function FilterPanel({
                   <h3 className="text-[11px] font-bold uppercase tracking-wider text-gray-500 mb-2.5">
                     Time period
                   </h3>
-                  <TimePeriodSection yearRange={yearRange} onChange={onYearRangeChange} />
+                  <TimePeriodSection dateRanges={dateRanges} onChange={onDateRangesChange} />
                 </div>
               )}
             </div>

--- a/src/components/filters/TimePeriodSection.tsx
+++ b/src/components/filters/TimePeriodSection.tsx
@@ -1,87 +1,116 @@
 'use client';
 
 import { YearRangeSlider } from './YearRangeSlider';
+import {
+  TONY_SEASONS,
+  DECADES,
+  SLIDER_MIN_YEAR,
+  SLIDER_MAX_YEAR,
+  type DateRange,
+  type RangeDef,
+  rangesEqual,
+  findSeason,
+  findDecade,
+  isAllSeasons,
+  yearsToDateRange,
+  dateRangeToYears,
+} from '@/lib/tony-seasons';
 
 interface TimePeriodSectionProps {
-  yearRange: { from: number; to: number } | null;
-  onChange: (range: { from: number; to: number } | null) => void;
+  dateRanges: DateRange[];
+  /**
+   * Accepts either a new array OR a function that receives the live URL
+   * state (not React state) and returns the next array. The function form
+   * is required for back-to-back season-pill toggles in the same tick —
+   * see feedback_react_searchparams_stale.md.
+   */
+  onChange: (ranges: DateRange[] | ((prev: DateRange[]) => DateRange[])) => void;
 }
 
-const MIN_YEAR = 1950;
-const CURRENT_YEAR = new Date().getFullYear();
-
-const RECENT_SEASONS: { year: number; label: string }[] = Array.from({ length: 8 }, (_, i) => {
-  const year = CURRENT_YEAR - i;
-  return { year, label: `${year}–${String((year + 1) % 100).padStart(2, '0')}` };
-});
-
-const DECADES: { id: string; label: string; from: number; to: number }[] = [
-  { id: '2010s', label: '2010s', from: 2010, to: 2019 },
-  { id: '2000s', label: '2000s', from: 2000, to: 2009 },
-  { id: '1990s', label: '1990s', from: 1990, to: 1999 },
-  { id: '1980s', label: '1980s', from: 1980, to: 1989 },
-  { id: '1970s', label: '1970s', from: 1970, to: 1979 },
-  { id: '1960s', label: '1960s', from: 1960, to: 1969 },
-  { id: 'pre-1960', label: 'Pre-1960', from: 1950, to: 1959 },
-];
-
 /**
- * Three views over a single {from, to} year range:
- *  - Recent season pills: selected if range covers that single year
- *  - Decade pills: selected if range fully spans the decade (or is exactly that decade)
- *  - Custom slider: directly edits the range
+ * Three views over a single dateRanges array:
+ *  - Recent season pills: MULTI-select, toggle in/out of array. Active when
+ *    the array contains an exact match for that season window.
+ *  - Decade pills: SINGLE-select, replace the array with one decade range.
+ *  - Custom slider: SINGLE-select, replaces the array with one calendar
+ *    range (Jan 1 → Dec 31).
  *
- * Tapping a pill SETS the range to that pill's bounds (not toggles within range).
- * This mirrors the simpler "pick one preset, then refine" mental model.
+ * Multi-mix rule: clicking a season while the current selection is all
+ * seasons (or empty) toggles within the multi-set. Clicking a season while
+ * a decade or slider range is active replaces the array with that one
+ * season. Predicate logic ORs every range — see TIME_PERIOD_RANGE.
  */
-export function TimePeriodSection({ yearRange, onChange }: TimePeriodSectionProps) {
-  const isYearActive = (year: number) =>
-    !!yearRange && yearRange.from === year && yearRange.to === year;
-  const isDecadeActive = (from: number, to: number) =>
-    !!yearRange && yearRange.from === from && yearRange.to === to;
+export function TimePeriodSection({ dateRanges, onChange }: TimePeriodSectionProps) {
+  const containsRange = (def: RangeDef) => dateRanges.some((r) => rangesEqual(r, def));
 
-  const onYearPill = (year: number) => {
-    if (isYearActive(year)) onChange(null);
-    else onChange({ from: year, to: year });
+  // Decade pill is "active" only when it's the SOLE selection
+  const isDecadeActive = (def: RangeDef) =>
+    dateRanges.length === 1 && rangesEqual(dateRanges[0], def);
+
+  // Functional form so rapid back-to-back toggles in the same tick all see
+  // the latest URL state (React state lags one render behind router.replace).
+  const onSeasonPill = (def: RangeDef) => {
+    onChange((prev) => {
+      const has = prev.some((r) => rangesEqual(r, def));
+      if (has) return prev.filter((r) => !rangesEqual(r, def));
+      if (prev.length === 0 || isAllSeasons(prev)) {
+        return [...prev, { from: def.from, to: def.to }];
+      }
+      return [{ from: def.from, to: def.to }];
+    });
   };
-  const onDecadePill = (from: number, to: number) => {
-    if (isDecadeActive(from, to)) onChange(null);
-    else onChange({ from, to });
+
+  const onDecadePill = (def: RangeDef) => {
+    if (isDecadeActive(def)) onChange([]);
+    else onChange([{ from: def.from, to: def.to }]);
+  };
+
+  // Slider works in integer years; map to/from a single calendar-range entry.
+  // Active slider range = the lone date-range when it's NOT a known season/decade.
+  const sliderRange: { from: number; to: number } | null = (() => {
+    if (dateRanges.length !== 1) return null;
+    const r = dateRanges[0];
+    if (findSeason(r) || findDecade(r)) return null;
+    return dateRangeToYears(r);
+  })();
+
+  const onSliderChange = (range: { from: number; to: number }) => {
+    onChange([yearsToDateRange(range.from, range.to)]);
   };
 
   return (
     <div className="space-y-3">
       <Sublabel>Recent seasons</Sublabel>
       <div className="flex flex-wrap items-center gap-2">
-        {RECENT_SEASONS.map(({ year, label }) => (
+        {TONY_SEASONS.map((def) => (
           <Pill
-            key={year}
-            label={label}
-            isSelected={isYearActive(year)}
-            onClick={() => onYearPill(year)}
+            key={def.id}
+            label={def.label}
+            isSelected={containsRange(def)}
+            onClick={() => onSeasonPill(def)}
           />
         ))}
       </div>
 
       <Sublabel>Decade</Sublabel>
       <div className="flex flex-wrap items-center gap-2">
-        {DECADES.map(({ id, label, from, to }) => (
+        {DECADES.map((def) => (
           <Pill
-            key={id}
-            label={label}
-            isSelected={isDecadeActive(from, to)}
-            onClick={() => onDecadePill(from, to)}
+            key={def.id}
+            label={def.label}
+            isSelected={isDecadeActive(def)}
+            onClick={() => onDecadePill(def)}
           />
         ))}
       </div>
 
       <Sublabel>Custom range</Sublabel>
       <YearRangeSlider
-        min={MIN_YEAR}
-        max={CURRENT_YEAR}
-        value={yearRange}
-        onChange={(r) => onChange(r)}
-        onClear={() => onChange(null)}
+        min={SLIDER_MIN_YEAR}
+        max={SLIDER_MAX_YEAR}
+        value={sliderRange}
+        onChange={onSliderChange}
+        onClear={() => onChange([])}
       />
     </div>
   );

--- a/src/components/filters/filter-ui-config.ts
+++ b/src/components/filters/filter-ui-config.ts
@@ -182,7 +182,7 @@ export const SINGLE_PARAM_KEYS: ReadonlySet<string> = new Set(SINGLE_PARAM_KEY_L
 export const PANEL_PARAM_KEYS: ReadonlySet<string> = new Set([
   ...FILTER_GROUPS.map((g) => g.paramKey),
   ...SINGLE_PARAM_KEY_LIST,
-  'years', // time-period range
+  'dates', // time-period date ranges (multi)
 ]);
 
 /** Look up a multi-select option by paramKey + id */

--- a/src/lib/hooks/usePanelFilters.ts
+++ b/src/lib/hooks/usePanelFilters.ts
@@ -6,6 +6,13 @@ import type { ShowCardShow } from '@/components/show-cards/types';
 import { type FilterPredicateCtx, TIME_PERIOD_RANGE } from '@/lib/show-filter-predicates';
 import type { AwardWinnerSets } from '@/lib/data-awards';
 import {
+  type DateRange,
+  parseDateRanges,
+  serializeDateRanges,
+  labelForRange,
+  rangesEqual,
+} from '@/lib/tony-seasons';
+import {
   FILTER_GROUPS,
   PANEL_PARAM_KEYS,
   SINGLE_PARAM_KEYS,
@@ -15,17 +22,6 @@ import {
   type SingleGroupConfig,
 } from '@/components/filters/filter-ui-config';
 import type { ActiveFilterChip } from '@/components/filters/ActiveFilterChips';
-
-/** Parse "FROM-TO" into {from, to}; returns null if malformed. */
-function parseYearRange(raw: string | null): { from: number; to: number } | null {
-  if (!raw) return null;
-  const m = raw.match(/^(\d{4})-(\d{4})$/);
-  if (!m) return null;
-  const from = parseInt(m[1], 10);
-  const to = parseInt(m[2], 10);
-  if (isNaN(from) || isNaN(to) || from > to) return null;
-  return { from, to };
-}
 
 interface UsePanelFiltersArgs<T extends ShowCardShow> {
   /** Pre-filtered shows from existing inline filters — panel applies on top */
@@ -56,20 +52,25 @@ interface UsePanelFiltersArgs<T extends ShowCardShow> {
 interface UsePanelFiltersReturn<T extends ShowCardShow> {
   /** Final shows after panel predicates */
   filteredShows: T[];
-  /** Number of selected panel filter options across all groups (multi + non-default single + year) */
+  /** Number of selected panel filter options across all groups (multi + non-default single + each date range) */
   activeCount: number;
   /** Per-group selected sets (multi-select), keyed by paramKey */
   selectedByGroup: Record<string, ReadonlySet<string>>;
   /** Per-group current value (single-select), keyed by paramKey */
   singleValueByGroup: Record<string, string>;
-  /** Year range tuple — null if no time-period filter */
-  yearRange: { from: number; to: number } | null;
+  /** Active time-period date ranges (ISO YYYY-MM-DD). Empty = no filter. */
+  dateRanges: DateRange[];
   /** Toggle a single option in a multi-select group */
   toggleOption: (paramKey: string, id: string) => void;
   /** Set the value of a single-select group (writes URL param; default value deletes it) */
   setSingleValue: (paramKey: string, value: string) => void;
-  /** Set the year range (or null to clear) */
-  setYearRange: (range: { from: number; to: number } | null) => void;
+  /**
+   * Set the active date ranges. Accepts an array (replace) OR a function
+   * that receives the LIVE URL state (read from window.location.search,
+   * not React state). The function form is required for back-to-back
+   * toggles in the same tick — see feedback_react_searchparams_stale.md.
+   */
+  setDateRanges: (ranges: DateRange[] | ((prev: DateRange[]) => DateRange[])) => void;
   /** Remove a single chip */
   removeChip: (chipKey: string) => void;
   /** Clear every panel filter */
@@ -104,8 +105,12 @@ export function usePanelFilters<T extends ShowCardShow>({
   // Stable reference for the optional singleGroups prop — empty array if omitted
   const singleGroupsList = useMemo<SingleGroupConfig[]>(() => singleGroups ?? [], [singleGroups]);
 
-  // Year range from URL — single source of truth for Time period
-  const yearRange = useMemo(() => parseYearRange(searchParams?.get('years') ?? null), [searchParams]);
+  // Active date ranges from URL — single source of truth for Time period.
+  // Format: ?dates=YYYY-MM-DD~YYYY-MM-DD,YYYY-MM-DD~YYYY-MM-DD
+  const dateRanges = useMemo(
+    () => parseDateRanges(searchParams?.get('dates') ?? null),
+    [searchParams],
+  );
 
   // Build predicate ctx from server-supplied award sets (rebuild Sets once)
   const ctx: FilterPredicateCtx = useMemo(() => {
@@ -117,10 +122,10 @@ export function usePanelFilters<T extends ShowCardShow>({
       olivierNomineeIds: new Set(ws?.olivierNomineeIds ?? []),
       dramaDeskWinnerIds: new Set(ws?.dramaDeskWinnerIds ?? []),
       pulitzerWinnerIds: new Set(ws?.pulitzerWinnerIds ?? []),
-      yearRange,
+      dateRanges,
       scoreMode,
     };
-  }, [awardWinnerSets, scoreMode, yearRange]);
+  }, [awardWinnerSets, scoreMode, dateRanges]);
 
   // Parse selected ids per paramKey from URL (multi-select)
   const selectedByGroup = useMemo(() => {
@@ -171,10 +176,10 @@ export function usePanelFilters<T extends ShowCardShow>({
 
   const filteredShows = useMemo(() => {
     const hasGroupFilters = activePredicatesByGroup.length > 0;
-    const hasYearFilter = yearRange !== null;
-    if (!hasGroupFilters && !hasYearFilter) return shows;
+    const hasDateFilter = dateRanges.length > 0;
+    if (!hasGroupFilters && !hasDateFilter) return shows;
     return shows.filter((show) => {
-      if (hasYearFilter && !TIME_PERIOD_RANGE(show, ctx)) return false;
+      if (hasDateFilter && !TIME_PERIOD_RANGE(show, ctx)) return false;
       for (const group of activePredicatesByGroup) {
         // Within a group: any-of (OR)
         const groupPasses = group.predicates.some((opt) => opt.predicate(show, ctx));
@@ -182,16 +187,16 @@ export function usePanelFilters<T extends ShowCardShow>({
       }
       return true;
     });
-  }, [shows, activePredicatesByGroup, ctx, yearRange]);
+  }, [shows, activePredicatesByGroup, ctx, dateRanges]);
 
   const activeCount = useMemo(() => {
     let count = Object.values(selectedByGroup).reduce((sum, s) => sum + s.size, 0);
-    if (yearRange) count += 1;
+    count += dateRanges.length;
     for (const group of singleGroupsList) {
       if (singleValueByGroup[group.paramKey] !== group.defaultValue) count += 1;
     }
     return count;
-  }, [selectedByGroup, yearRange, singleGroupsList, singleValueByGroup]);
+  }, [selectedByGroup, dateRanges, singleGroupsList, singleValueByGroup]);
 
   const chips: ActiveFilterChip[] = useMemo(() => {
     const out: ActiveFilterChip[] = [];
@@ -217,14 +222,14 @@ export function usePanelFilters<T extends ShowCardShow>({
         }
       }
     }
-    if (yearRange) {
-      const label = yearRange.from === yearRange.to
-        ? `${yearRange.from}–${String((yearRange.from + 1) % 100).padStart(2, '0')}`
-        : `${yearRange.from}–${yearRange.to}`;
-      out.push({ key: 'years:_range', label });
+    for (const range of dateRanges) {
+      out.push({
+        key: `dates:${range.from}~${range.to}`,
+        label: labelForRange(range),
+      });
     }
     return out;
-  }, [selectedByGroup, yearRange, singleGroupsList, singleValueByGroup]);
+  }, [selectedByGroup, dateRanges, singleGroupsList, singleValueByGroup]);
 
   const writeParams = useCallback(
     (mutate: (params: URLSearchParams) => void) => {
@@ -234,7 +239,18 @@ export function usePanelFilters<T extends ShowCardShow>({
       const params = new URLSearchParams(live);
       mutate(params);
       const qs = params.toString();
-      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+      const url = qs ? `${pathname}?${qs}` : pathname;
+      // Two writes to the SAME URL:
+      //   1. replaceState so subsequent in-tick reads of window.location see it
+      //      (router.replace is async — lets back-to-back toggles overwrite each
+      //      other; verified manually 2026-04-27 with 2-3 rapid season pills).
+      //   2. router.replace so Next.js's useSearchParams() updates and React
+      //      re-renders the panel.
+      // Same URL on both → no two-writer race (see feedback_clearall_two_writer_race.md).
+      if (typeof window !== 'undefined') {
+        window.history.replaceState(null, '', url);
+      }
+      router.replace(url, { scroll: false });
     },
     [searchParams, router, pathname],
   );
@@ -271,11 +287,13 @@ export function usePanelFilters<T extends ShowCardShow>({
     [writeParams, singleGroupsList, onSetSingleValueOverride],
   );
 
-  const setYearRange = useCallback(
-    (range: { from: number; to: number } | null) => {
+  const setDateRanges = useCallback(
+    (ranges: DateRange[] | ((prev: DateRange[]) => DateRange[])) => {
       writeParams((params) => {
-        if (range) params.set('years', `${range.from}-${range.to}`);
-        else params.delete('years');
+        const livePrev = parseDateRanges(params.get('dates'));
+        const next = typeof ranges === 'function' ? ranges(livePrev) : ranges;
+        if (next.length > 0) params.set('dates', serializeDateRanges(next));
+        else params.delete('dates');
       });
     },
     [writeParams],
@@ -283,8 +301,13 @@ export function usePanelFilters<T extends ShowCardShow>({
 
   const removeChip = useCallback(
     (chipKey: string) => {
-      if (chipKey === 'years:_range') {
-        setYearRange(null);
+      if (chipKey.startsWith('dates:')) {
+        const rangeStr = chipKey.slice('dates:'.length);
+        const [from, to] = rangeStr.split('~');
+        if (!from || !to) return;
+        // Use functional form — `dateRanges` from React state can be stale
+        // when chips are removed in rapid succession.
+        setDateRanges((prev) => prev.filter((r) => !rangesEqual(r, { from, to })));
         return;
       }
       const [paramKey, id] = chipKey.split(':');
@@ -298,7 +321,7 @@ export function usePanelFilters<T extends ShowCardShow>({
       // Multi-select chip → toggle off
       toggleOption(paramKey, id);
     },
-    [toggleOption, setSingleValue, setYearRange, singleGroupsList],
+    [toggleOption, setSingleValue, setDateRanges, singleGroupsList],
   );
 
   // Hook-internal clearAll for non-controlled mode (no override props). When
@@ -320,10 +343,10 @@ export function usePanelFilters<T extends ShowCardShow>({
     activeCount,
     selectedByGroup,
     singleValueByGroup,
-    yearRange,
+    dateRanges,
     toggleOption,
     setSingleValue,
-    setYearRange,
+    setDateRanges,
     removeChip,
     clearAll,
     chips,

--- a/src/lib/show-filter-predicates.ts
+++ b/src/lib/show-filter-predicates.ts
@@ -13,6 +13,7 @@
  * the panel state passes the right score into ctx.
  */
 import type { ShowCardShow } from '@/components/show-cards/types';
+import type { DateRange } from '@/lib/tony-seasons';
 
 export interface FilterPredicateCtx {
   /** Reconstructed Sets from AwardWinnerSets — O(1) lookup */
@@ -22,8 +23,8 @@ export interface FilterPredicateCtx {
   olivierNomineeIds: ReadonlySet<string>;
   dramaDeskWinnerIds: ReadonlySet<string>;
   pulitzerWinnerIds: ReadonlySet<string>;
-  /** Time-period range — inclusive on both ends; null = no time filter */
-  yearRange: { from: number; to: number } | null;
+  /** Time-period date ranges (ISO YYYY-MM-DD). Empty = no filter. Multiple = OR. */
+  dateRanges: DateRange[];
   /** Active score-mode — score-tier predicates evaluate against this score */
   scoreMode: 'critics' | 'audience';
 }
@@ -45,29 +46,18 @@ export const AWARD_DRAMA_DESK_WINNER: FilterPredicate = (s, ctx) => ctx.dramaDes
 export const AWARD_PULITZER: FilterPredicate = (s, ctx) => ctx.pulitzerWinnerIds.has(s.id);
 
 // ─────────────── Time period ───────────────
-
-/**
- * Extract the year a show "belongs to" for time-period filtering.
- * Prefers `season` (e.g., "2024-2025" → 2024), falls back to opening-year.
- * Returns null if neither field is usable.
- */
-export function getShowYear(show: ShowCardShow): number | null {
-  if (show.season) {
-    const match = show.season.match(/^(\d{4})/);
-    if (match) return parseInt(match[1], 10);
-  }
-  if (show.openingDate) {
-    const year = parseInt(show.openingDate.slice(0, 4), 10);
-    if (!isNaN(year)) return year;
-  }
-  return null;
-}
+//
+// Filters by `openingDate` (ISO YYYY-MM-DD) against any active date range.
+// Tony season pills set April 28 → April 27 windows; decade and slider pills
+// set calendar-year windows (Jan 1 → Dec 31). See src/lib/tony-seasons.ts.
+// Multiple ranges OR together — show passes if openingDate is in any.
+// String comparison is correct because ISO 8601 dates sort lexicographically.
 
 export const TIME_PERIOD_RANGE: FilterPredicate = (s, ctx) => {
-  if (!ctx.yearRange) return true;
-  const year = getShowYear(s);
-  if (year === null) return false;
-  return year >= ctx.yearRange.from && year <= ctx.yearRange.to;
+  if (ctx.dateRanges.length === 0) return true;
+  if (!s.openingDate) return false;
+  const opened = s.openingDate;
+  return ctx.dateRanges.some((r) => opened >= r.from && opened <= r.to);
 };
 
 // ─────────────── Score tier ───────────────

--- a/src/lib/tony-seasons.ts
+++ b/src/lib/tony-seasons.ts
@@ -1,0 +1,123 @@
+/**
+ * Tony season definitions and date-range helpers for the Time Period filter.
+ *
+ * A Tony season runs from April 28 of year N to April 27 of year N+1 — the
+ * day after the prior eligibility cutoff to the day of the next. Project
+ * convention (see src/lib/data-tony-predictions.ts:43-66). COVID-era seasons
+ * (2019-20, 2020-21) use the same uniform window for now.
+ *
+ * The Time Period filter compares show.openingDate (ISO YYYY-MM-DD) directly
+ * against these ranges — string comparison is correct because ISO 8601 dates
+ * sort lexicographically.
+ */
+
+export interface DateRange {
+  from: string;
+  to: string;
+}
+
+export interface RangeDef {
+  id: string;
+  label: string;
+  from: string;
+  to: string;
+}
+
+const CURRENT_YEAR = new Date().getFullYear();
+
+/** 8 most recent Tony seasons, newest first. */
+export const TONY_SEASONS: RangeDef[] = Array.from({ length: 8 }, (_, i) => {
+  const startYear = CURRENT_YEAR - i;
+  const endShort = String((startYear + 1) % 100).padStart(2, '0');
+  return {
+    id: `${startYear}-${endShort}`,
+    label: `${startYear}–${endShort}`,
+    from: `${startYear}-04-28`,
+    to: `${startYear + 1}-04-27`,
+  };
+});
+
+/** Decade pills — calendar-year ranges. */
+export const DECADES: RangeDef[] = [
+  { id: '2010s', label: '2010s', from: '2010-01-01', to: '2019-12-31' },
+  { id: '2000s', label: '2000s', from: '2000-01-01', to: '2009-12-31' },
+  { id: '1990s', label: '1990s', from: '1990-01-01', to: '1999-12-31' },
+  { id: '1980s', label: '1980s', from: '1980-01-01', to: '1989-12-31' },
+  { id: '1970s', label: '1970s', from: '1970-01-01', to: '1979-12-31' },
+  { id: '1960s', label: '1960s', from: '1960-01-01', to: '1969-12-31' },
+  { id: 'pre-1960', label: 'Pre-1960', from: '1950-01-01', to: '1959-12-31' },
+];
+
+export const SLIDER_MIN_YEAR = 1950;
+export const SLIDER_MAX_YEAR = CURRENT_YEAR;
+
+export function rangesEqual(a: DateRange, b: DateRange): boolean {
+  return a.from === b.from && a.to === b.to;
+}
+
+export function findSeason(range: DateRange): RangeDef | null {
+  return TONY_SEASONS.find((s) => rangesEqual(s, range)) ?? null;
+}
+
+export function findDecade(range: DateRange): RangeDef | null {
+  return DECADES.find((d) => rangesEqual(d, range)) ?? null;
+}
+
+/** True when every range in the array is one of the Tony season presets. */
+export function isAllSeasons(ranges: DateRange[]): boolean {
+  return ranges.length > 0 && ranges.every((r) => findSeason(r) !== null);
+}
+
+/** Calendar-year range as ISO date range (Jan 1 → Dec 31). */
+export function yearsToDateRange(from: number, to: number): DateRange {
+  return { from: `${from}-01-01`, to: `${to}-12-31` };
+}
+
+/** Inverse of yearsToDateRange — returns null if the range isn't a clean Jan-1/Dec-31 span. */
+export function dateRangeToYears(range: DateRange): { from: number; to: number } | null {
+  const fromY = parseInt(range.from.slice(0, 4), 10);
+  const toY = parseInt(range.to.slice(0, 4), 10);
+  if (isNaN(fromY) || isNaN(toY)) return null;
+  if (range.from !== `${fromY}-01-01` || range.to !== `${toY}-12-31`) return null;
+  return { from: fromY, to: toY };
+}
+
+/**
+ * Best human label for a range chip:
+ *   season match → "2024–25"
+ *   decade match → "2010s"
+ *   clean year span → "2015" / "2010–2015"
+ *   anything else → "2024-04-28 → 2025-04-27"
+ */
+export function labelForRange(range: DateRange): string {
+  const season = findSeason(range);
+  if (season) return season.label;
+  const decade = findDecade(range);
+  if (decade) return decade.label;
+  const years = dateRangeToYears(range);
+  if (years) {
+    return years.from === years.to ? String(years.from) : `${years.from}–${years.to}`;
+  }
+  return `${range.from} → ${range.to}`;
+}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Parse `?dates=YYYY-MM-DD~YYYY-MM-DD,YYYY-MM-DD~YYYY-MM-DD` */
+export function parseDateRanges(raw: string | null | undefined): DateRange[] {
+  if (!raw) return [];
+  const out: DateRange[] = [];
+  for (const part of raw.split(',')) {
+    const segs = part.split('~');
+    if (segs.length !== 2) continue;
+    const [from, to] = segs;
+    if (!ISO_DATE_RE.test(from) || !ISO_DATE_RE.test(to)) continue;
+    if (from > to) continue;
+    out.push({ from, to });
+  }
+  return out;
+}
+
+export function serializeDateRanges(ranges: DateRange[]): string {
+  return ranges.map((r) => `${r.from}~${r.to}`).join(',');
+}

--- a/src/lib/tony-seasons.ts
+++ b/src/lib/tony-seasons.ts
@@ -23,6 +23,11 @@ export interface RangeDef {
   to: string;
 }
 
+// Captured once at module load. Build-time on the server bundle, page-load
+// on the client bundle — both run in the same webpack pass so there's no
+// hydration mismatch. The list goes one year stale if no rebuild happens
+// between Dec 31 and Jan 1; static export deploys run daily so practical
+// exposure is the gap between the year-flip cron and the next deploy.
 const CURRENT_YEAR = new Date().getFullYear();
 
 /** 8 most recent Tony seasons, newest first. */


### PR DESCRIPTION
## Summary
- Recent Seasons pills now filter by Tony eligibility windows (April 28 → April 27 of next year) applied to `show.openingDate`, instead of by extracted-year integer compare. A show that opened March 2024 is now correctly classified as Tony season 2023-24, not calendar year 2024.
- Multi-select on season pills (multiple Tony seasons can be active at once); decade pills and the custom slider remain single-select and replace the array.
- Race fix in `writeParams`: `window.history.replaceState` now runs sync before `router.replace` so back-to-back toggles in the same tick read the prior click's URL update. This silently fixed awards multi-select too — it was overwriting on rapid clicks.

URL param: `?years=YYYY-YYYY` → `?dates=YYYY-MM-DD~YYYY-MM-DD,YYYY-MM-DD~YYYY-MM-DD` (no backward-compat shim — old bookmarks lose state).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint` — no warnings on changed files
- [x] Playwright at 1440px desktop — panel renders, multi-select pills accumulate ✓ checks
- [x] Playwright at 390px mobile — bottom-sheet renders, pills reflow correctly
- [x] Rapid 3-pill click — URL accumulates all 3 ranges (verified via `location.search` after each click)
- [x] Decade click while seasons active → REPLACE; season click while decade active → REPLACE
- [x] Toggle off behavior — clicking active season removes that range only
- [x] Lost Boys (`openingDate: 2026-04-26`) appears in 2025-26 season filter (Apr 27 cutoff boundary case)
- [x] Active filter chips render with season labels and remove via the × button

🤖 Generated with [Claude Code](https://claude.com/claude-code)