### PR TITLE
fix(llm-scoring): finish 2.5-flash migration in ensemble + index

### DIFF
--- a/scripts/llm-scoring/ensemble-scorer.ts
+++ b/scripts/llm-scoring/ensemble-scorer.ts
@@ -22,7 +22,7 @@ import { ensembleScore, toModelScore } from './ensemble';
 export interface EnsembleScoringOptions {
   claudeModel: 'claude-sonnet-4-20250514' | 'claude-3-5-haiku-20241022';
   openaiModel: 'gpt-4o-mini' | 'gpt-4o';
-  geminiModel: 'gemini-2.0-flash' | 'gemini-1.5-flash';
+  geminiModel: 'gemini-2.5-flash' | 'gemini-2.0-flash' | 'gemini-1.5-flash';
   kimiModel: string;
   maxDelta: number;  // Maximum acceptable difference between models
   verbose: boolean;
@@ -51,7 +51,7 @@ export class EnsembleReviewScorer {
     this.options = {
       claudeModel: options.claudeModel || 'claude-sonnet-4-20250514',
       openaiModel: options.openaiModel || 'gpt-4o',
-      geminiModel: options.geminiModel || 'gemini-2.0-flash',
+      geminiModel: options.geminiModel || 'gemini-2.5-flash',
       kimiModel: options.kimiModel || 'moonshotai/kimi-k2.5',
       maxDelta: options.maxDelta ?? 15,
       verbose: options.verbose ?? false,

--- a/scripts/llm-scoring/index.ts
+++ b/scripts/llm-scoring/index.ts
@@ -736,15 +736,15 @@ async function main(): Promise<void> {
     scorer = new EnsembleReviewScorer(claudeApiKey, openaiApiKey!, geminiApiKey, openrouterApiKey, {
       claudeModel: options.model,
       openaiModel: 'gpt-4o',
-      geminiModel: 'gemini-2.0-flash',
+      geminiModel: 'gemini-2.5-flash',
       kimiModel: 'moonshotai/kimi-k2.5',
       verbose: options.verbose
     });
     const modelCount = (scorer as EnsembleReviewScorer).getModelCount();
     if (modelCount === 4) {
-      console.log('Using 4-MODEL ensemble mode (Claude Sonnet + GPT-4o + Gemini 2.0 Flash + Kimi K2.5)\n');
+      console.log('Using 4-MODEL ensemble mode (Claude Sonnet + GPT-4o + Gemini 2.5 Flash + Kimi K2.5)\n');
     } else if (modelCount === 3) {
-      console.log('Using 3-MODEL ensemble mode (Claude Sonnet + GPT-4o + Gemini 2.0 Flash)\n');
+      console.log('Using 3-MODEL ensemble mode (Claude Sonnet + GPT-4o + Gemini 2.5 Flash)\n');
       if (!openrouterApiKey) {
         console.log('  (Set OPENROUTER_API_KEY to enable 4-model mode with Kimi K2.5)\n');
       }


### PR DESCRIPTION
## Summary
Companion to #301. That PR updated `GeminiScorer`'s default model to `gemini-2.5-flash` but two upstream overrides still pinned `gemini-2.0-flash`:

- `scripts/llm-scoring/ensemble-scorer.ts:54` — `EnsembleScoringOptions.geminiModel` default
- `scripts/llm-scoring/index.ts:739` — hard-coded option passed to `EnsembleReviewScorer`

Either upstream override silently put bulk rescores back on the exhausted 2.0-flash quota pool, demoting the ensemble to `two-model-fallback` at ~6 min/review.

## Changes
- Both upstream defaults → `'gemini-2.5-flash'`
- Type union widened to include `'gemini-2.5-flash'`
- Banner strings in 3/4-MODEL log lines updated for accuracy
- `scripts/llm-scoring/test-helen-shaw-fixture.ts` and `scripts/llm-scoring/test-prompt-structural-ab.ts` already pass `model: 'gemini-2.5-flash'` explicitly — unaffected

## Test plan
- [x] `npx tsc --noEmit` clean on all modified files (pre-existing errors in unrelated `scrape-grosses.ts` / `scrape-ibdb.ts`)
- [ ] Re-launch the targeted backfill on 3-model after merge; verify rate drops to ~15 sec/review and score lines show `[C:.. O:.. G:..]` (Gemini contributing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)