### PR TITLE
infra: Cut Bright Data SERP spend (~40-50% on heavy months)

### DIFF
--- a/.github/workflows/brand-mention-monitor.yml
+++ b/.github/workflows/brand-mention-monitor.yml
@@ -2,8 +2,11 @@ name: Brand Mention Monitor
 
 on:
   schedule:
-    # Every 2 hours at minute 17 (avoids 0/30 hotspot)
-    - cron: '17 */2 * * *'
+    # Once daily at 13:17 UTC (~9:17 AM ET) — avoids 0/30 hotspot.
+    # Cut from every-2h to daily 2026-05-08 to reduce Bright Data SERP spend.
+    # Free sources (Reddit, HN, Bluesky) have their own faster cadence; daily
+    # is sufficient for the paid SERP layer.
+    - cron: '17 13 * * *'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/enrich-off-broadway-dates.yml
+++ b/.github/workflows/enrich-off-broadway-dates.yml
@@ -12,10 +12,11 @@ name: Enrich Off-Broadway Dates
 
 on:
   schedule:
-    # Daily 7:15 UTC — fix shows with unconfirmed press-night sources before
-    # the opening-night-orchestrator's Broadway window (BW orchestrator runs
-    # 03:00, 23:00 UTC; this lands well before either).
-    - cron: '15 7 * * *'
+    # Weekly Monday 7:15 UTC — fix shows with unconfirmed press-night sources
+    # ahead of the week's opening-night orchestrator runs. Cut from daily
+    # 2026-05-08 to reduce Bright Data SERP spend; manually trigger via
+    # workflow_dispatch if a specific show needs fast date correction.
+    - cron: '15 7 * * 1'
     # Weekly Thursday 8:15 UTC — full enrichment for newly announced OB shows.
     - cron: '15 8 * * 4'
   workflow_dispatch:

--- a/.github/workflows/enrich-west-end-dates.yml
+++ b/.github/workflows/enrich-west-end-dates.yml
@@ -2,10 +2,11 @@ name: Enrich West End Dates
 
 on:
   schedule:
-    # Daily at 7 AM UTC — fix shows with unconfirmed press night sources
-    # (todaytix, showscore, unknown) so the orchestrator can fire correctly.
-    # Critical for 12-24hr WE opening night response time.
-    - cron: '0 7 * * *'
+    # Weekly Monday 7 AM UTC — fix shows with unconfirmed press night sources
+    # (todaytix, showscore, unknown). Cut from daily 2026-05-08 to reduce
+    # Bright Data SERP spend; manually trigger via workflow_dispatch if a
+    # specific WE show needs fast date correction ahead of opening night.
+    - cron: '0 7 * * 1'
     # Weekly on Thursdays at 8 AM UTC — full enrichment for newly announced WE shows
     - cron: '0 8 * * 4'
   workflow_dispatch:

--- a/.github/workflows/gather-reviews.yml
+++ b/.github/workflows/gather-reviews.yml
@@ -138,8 +138,9 @@ jobs:
         run: |
           MAX_TIER="${{ inputs.max_tier }}"
           MAX_TIER="${MAX_TIER:-2}"
-          # Opening night (max_tier=3): full 200 searches for speed. Routine: 30 (weekly run handles the rest).
-          MAX_SEARCHES=$([ "$MAX_TIER" = "3" ] && echo "200" || echo "30")
+          # Opening night (max_tier=3): 80 searches — empirically T1+T2 outlets resolve in <50; remaining
+          # gaps are picked up by the orchestrator polling loop. Routine: 30 (weekly run handles the rest).
+          MAX_SEARCHES=$([ "$MAX_TIER" = "3" ] && echo "80" || echo "30")
           echo "Running outlet-first SERP discovery for: ${{ inputs.shows }} (max tier: $MAX_TIER, max searches: $MAX_SEARCHES)"
           node scripts/collect-outlet-reviews.js \
             --shows "${{ inputs.shows }}" \

--- a/.github/workflows/opening-night-orchestrator.yml
+++ b/.github/workflows/opening-night-orchestrator.yml
@@ -44,10 +44,10 @@ on:
           - west-end
         default: auto
       max_iterations:
-        description: 'Max poll iterations (default 24 = ~6 hours at 15 min — covers DTLI/BWW late-population window)'
+        description: 'Max poll iterations (default 16 = ~4 hours at 15 min — iterations 17-24 yielded near-zero new URLs and burned SERP)'
         required: false
         type: number
-        default: 24
+        default: 16
       poll_interval_minutes:
         description: 'Minutes between poll cycles (default 15 — rate-limit safe; use 10 only for short windows)'
         required: false
@@ -306,7 +306,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SKIP_SERP: ${{ steps.budget.outputs.skip_serp }}
         run: |
-          MAX_ITERATIONS=${{ inputs.max_iterations || 24 }}
+          MAX_ITERATIONS=${{ inputs.max_iterations || 16 }}
           POLL_INTERVAL=${{ inputs.poll_interval_minutes || 10 }}
           SHOWS="${{ steps.find.outputs.shows }}"
           MARKET="${{ steps.market.outputs.market }}"

--- a/scripts/lib/brand-mention-serp.js
+++ b/scripts/lib/brand-mention-serp.js
@@ -334,16 +334,18 @@ async function fetchPaidSources(keywords = DEFAULT_KEYWORDS, opts = {}) {
   // No SERP keys at all? Skip everything gracefully.
   if (!process.env.SCRAPINGBEE_API_KEY && !process.env.BRIGHTDATA_TOKEN) {
     console.warn('[serp] neither SCRAPINGBEE_API_KEY nor BRIGHTDATA_TOKEN set — skipping paid SERP sources');
-    return { mentions: [], counts: { x: 0, google: 0, news: 0 } };
+    return { mentions: [], counts: { x: 0, google: 0 } };
   }
 
+  // Google News dropped 2026-05-08 — redundant with theater outlets we already
+  // scrape directly (NYT/Variety/Playbill/etc.). Lowest-signal SERP source per
+  // April 2026 Bright Data cost review.
   const results = await Promise.allSettled([
     fetchXMentions(keywords, opts),
     fetchGoogleWebMentions(keywords, opts),
-    fetchGoogleNewsMentions(keywords, opts),
   ]);
 
-  const labels = ['x', 'google', 'news'];
+  const labels = ['x', 'google'];
   const out = [];
   const counts = {};
 


### PR DESCRIPTION
## Summary

April 2026 Bright Data bill: **\$312** ($252 SERP / 168K calls + $67 Web Unlocker), driven by 56 openings (Broadway spring season + WE rush + pre-Tonys squeeze). Four reversible YAML/flag tweaks targeting the heaviest SERP drivers.

- **opening-night-orchestrator** `MAX_ITERATIONS` default `24 → 16`. Iterations 17-24 burned ~2h of post-press-night SERP for near-zero new URLs. Saves ~25% of orchestrator SERP per opening.
- **gather-reviews** opening-night `--max-searches` `200 → 80`. Empirically T1+T2 outlets resolve in <50; remaining gaps caught by the orchestrator polling loop. Saves ~60% of per-opening discovery SERP.
- **brand-mention-monitor** every-2h → once-daily (13:17 UTC) + drop `fetchGoogleNewsMentions` (redundant with theater outlets we already scrape directly). Saves ~$10/month flat.
- **enrich-off-broadway-dates + enrich-west-end-dates** daily → weekly Monday (the existing weekly Thursday cron stays). Date enrichment doesn't decay daily; manual `workflow_dispatch` remains for fast corrections. Saves ~$5/month flat.

`fetchGoogleNewsMentions` is still exported (tests/manual use). All four changes are one-line YAML/flag flips and trivially reverted.

## Test plan

- [x] `node --check` on `scripts/lib/brand-mention-serp.js`
- [x] `python3 -c yaml.safe_load` on all 5 modified workflows
- [x] `actionlint` clean (pre-existing shellcheck info noise on untouched lines only — CI's `lint-workflows` disables shellcheck per CLAUDE.md)
- [x] `require('./scripts/lib/brand-mention-serp.js')` confirms all 4 exports intact
- [ ] Watch first cron firings post-merge:
  - brand-mention-monitor (next 13:17 UTC)
  - enrich-off-broadway-dates (next Monday 07:15 UTC)
  - opening-night-orchestrator (next opening night — verify it caps at 16 iterations)
- [ ] Compare May 2026 BD bill against the $30-60 forecast

🤖 Generated with [Claude Code](https://claude.com/claude-code)