### PR TITLE
Site Award Score — new module + Awards Scorecard UI behind awardScoreV2 flag

### DIFF
--- a/scripts/audit-award-scores.ts
+++ b/scripts/audit-award-scores.ts
@@ -1,0 +1,48 @@
+/**
+ * Audit Award Scores across every show with awards.json data.
+ * Surfaces the full sweeper roster + honor-roll counts per tier.
+ * Run: npx tsx scripts/audit-award-scores.ts
+ */
+
+import { computeSiteAwardScore, type TierBadge } from '../src/lib/awards-scoring';
+import awardsData from '../data/awards.json';
+
+const shows = (awardsData as { shows: Record<string, unknown> }).shows;
+
+const rows: Array<{ id: string; score: number; raw: number; badge: TierBadge }> = [];
+for (const id of Object.keys(shows)) {
+  const r = computeSiteAwardScore(id, 'broadway');
+  if (r.displayScore > 0) rows.push({ id, score: r.displayScore, raw: r.rawPoints, badge: r.badge });
+}
+
+rows.sort((a, b) => b.score - a.score || b.raw - a.raw);
+
+const counts: Record<TierBadge, number> = {
+  sweeper: 0, decorated: 0, honored: 0, nominated: 0, 'in-the-hunt': 0, eligible: 0,
+};
+for (const r of rows) counts[r.badge]++;
+
+console.log('Tier distribution (current thresholds):');
+for (const [tier, n] of Object.entries(counts)) {
+  if (n > 0) console.log(`  ${tier.padEnd(12)} ${n}`);
+}
+console.log(`  total scored: ${rows.length}\n`);
+
+console.log('═══ SWEEPER roster ═══');
+for (const r of rows.filter(x => x.badge === 'sweeper')) {
+  console.log(`  ${r.score.toString().padStart(3)}  (raw ${r.raw.toString().padStart(5)})  ${r.id}`);
+}
+
+console.log('\n═══ Top 30 DECORATED ═══');
+for (const r of rows.filter(x => x.badge === 'decorated').slice(0, 30)) {
+  console.log(`  ${r.score.toString().padStart(3)}  (raw ${r.raw.toString().padStart(5)})  ${r.id}`);
+}
+
+console.log('\n═══ Score distribution histogram ═══');
+const buckets = Array(11).fill(0);
+for (const r of rows) buckets[Math.min(10, Math.floor(r.score / 10))]++;
+for (let i = 0; i < buckets.length; i++) {
+  const lo = i * 10;
+  const hi = i === 10 ? '+' : `-${i * 10 + 9}`;
+  console.log(`  ${lo.toString().padStart(3)}${hi.toString().padEnd(3)}  ${'█'.repeat(Math.ceil(buckets[i] / 5))} ${buckets[i]}`);
+}

--- a/scripts/sanity-check-awards-scoring.ts
+++ b/scripts/sanity-check-awards-scoring.ts
@@ -1,0 +1,43 @@
+/**
+ * Sanity-check the new Site Award Score against canonical test cases.
+ * Run: npx tsx scripts/sanity-check-awards-scoring.ts
+ */
+
+import { computeSiteAwardScore } from '../src/lib/awards-scoring';
+
+const SHOWS: Array<{ id: string; label: string; expect?: string }> = [
+  { id: 'hamilton-2015',              label: 'Hamilton',              expect: 'sweeper, breaks 100' },
+  { id: 'next-to-normal-2009',        label: 'Next to Normal',        expect: 'honored — 3 Tonys + Pulitzer' },
+  { id: 'stereophonic-2024',          label: 'Stereophonic',          expect: 'decorated — Tony Best Play + Pulitzer finalist' },
+  { id: 'spring-awakening-2006',      label: 'Spring Awakening',      expect: 'decorated — 8 Tonys, no Pulitzer' },
+  { id: 'maybe-happy-ending-2024',    label: 'Maybe Happy Ending',    expect: '~sweeper — 2025 Best Musical' },
+  { id: 'purpose-2025',               label: 'Purpose',               expect: 'decorated — Pulitzer + Tony Best Play 2025' },
+  { id: 'sunday-in-the-park-1984',    label: 'Sunday in the Park...', expect: 'honored — Pulitzer, lost Best Musical' },
+  { id: 'wicked-2003',                label: 'Wicked',                expect: 'in-the-hunt — lots of noms, lost Best Musical to Avenue Q' },
+  { id: 'come-from-away-2017',        label: 'Come From Away',        expect: 'nominated/honored — Best Musical nom, Direction win' },
+];
+
+function fmt(n: number, w = 4): string {
+  return Math.round(n).toString().padStart(w);
+}
+
+for (const { id, label, expect } of SHOWS) {
+  const r = computeSiteAwardScore(id, 'broadway');
+  console.log('═'.repeat(70));
+  console.log(`${label.padEnd(28)} → score ${fmt(r.displayScore, 3)}  (raw ${fmt(r.rawPoints)}) · ${r.badge.toUpperCase()}`);
+  if (expect) console.log(`  expected: ${expect}`);
+  if (r.breakdown.length === 0) {
+    console.log('  (no awards data found)');
+    continue;
+  }
+  for (const c of r.breakdown) {
+    console.log(`  ${c.ceremony.padEnd(28)} +${fmt(c.subtotal, 5)}`);
+    for (const it of c.items.slice(0, 6)) {
+      const tag = it.result === 'win' ? 'WIN' : 'nom';
+      const tier = it.revival ? `${it.tier}r` : it.tier;
+      console.log(`     ${tier.padEnd(3)} ${tag.padEnd(3)} ${it.category.slice(0, 44).padEnd(44)} +${fmt(it.points, 4)}`);
+    }
+    if (c.items.length > 6) console.log(`     ... + ${c.items.length - 6} more line items`);
+  }
+}
+console.log('═'.repeat(70));

--- a/src/components/AwardScoreCard.tsx
+++ b/src/components/AwardScoreCard.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { computeSiteAwardScore, type CeremonyContribution } from '@/lib/awards-scoring';
+import type { ShowAwards } from '@/lib/data-types';
+import { TrophyIcon, StarIcon, ChevronIcon, PulitzerIcon } from '@/components/icons';
+import { sortByImportance, isMajorCategory } from '@/config/awards';
+import { AwardScoreBadge } from '@/components/show-cards';
+import { featureFlags } from '@/config/feature-flags';
+
+interface AwardScoreCardProps {
+  showId: string;
+  awards: ShowAwards | undefined;
+  openingDate?: string;
+}
+
+function toFullSeasonLabel(season: string): string {
+  const parts = season.split('-');
+  if (parts.length !== 2) return season;
+  const endPart = parseInt(parts[1], 10);
+  const fullEnd = endPart < 100 ? 2000 + endPart : endPart;
+  return `${parts[0]}-${fullEnd}`;
+}
+
+/** Plain-English headline lines for the "At a glance" section. */
+function buildHighlights(awards: ShowAwards | undefined): string[] {
+  if (!awards) return [];
+  const out: string[] = [];
+  const tonyWins = awards.tony?.wins ?? [];
+  const tonyTopWin = sortByImportance(tonyWins).find(isMajorCategory);
+  if (tonyTopWin) {
+    const others = tonyWins.length - 1;
+    out.push(others > 0 ? `Tony — ${tonyTopWin} + ${others} more win${others === 1 ? '' : 's'}` : `Tony — ${tonyTopWin}`);
+  } else if (tonyWins.length > 0) {
+    out.push(`Tony — ${tonyWins.length} win${tonyWins.length === 1 ? '' : 's'}`);
+  } else if ((awards.tony?.nominations ?? 0) > 0) {
+    out.push(`Tony — ${awards.tony!.nominations} nomination${awards.tony!.nominations === 1 ? '' : 's'}`);
+  }
+  if (awards.pulitzer?.wins?.includes('Drama')) out.push('Pulitzer Prize for Drama');
+  else if (awards.pulitzer?.finalist?.includes('Drama') || awards.pulitzerFinalist) out.push('Pulitzer Prize finalist');
+  if ((awards.nyDramaCritics?.wins?.length ?? 0) > 0) {
+    out.push(`NY Drama Critics' Circle — ${awards.nyDramaCritics!.wins!.join(', ')}`);
+  }
+  return out.slice(0, 5);
+}
+
+/** Tier-color class for category labels in the breakdown. */
+function tierColor(tier: string): string {
+  if (tier === 'S') return 'text-amber-300';
+  if (tier === 'A+') return 'text-violet-300';
+  if (tier === 'A') return 'text-violet-300';
+  if (tier === 'B') return 'text-emerald-300';
+  return 'text-gray-400';
+}
+
+function BreakdownSection({ breakdown }: { breakdown: CeremonyContribution[] }) {
+  return (
+    <div className="space-y-4 text-sm">
+      {breakdown.filter(c => c.subtotal > 0).map((c, ci) => (
+        <div key={ci}>
+          <div className="flex items-baseline justify-between mb-1.5">
+            <span className="text-xs uppercase tracking-wide text-gray-400 font-semibold">{c.ceremony}</span>
+            <span className="text-gray-300 tabular-nums">+{Math.round(c.subtotal)}</span>
+          </div>
+          <ul className="space-y-1 pl-2">
+            {c.items.map((it, ii) => (
+              <li key={ii} className="flex items-center gap-2 text-gray-400">
+                {it.result === 'win'
+                  ? <TrophyIcon className="w-3 h-3 text-amber-400 flex-shrink-0" />
+                  : <StarIcon className="w-3 h-3 text-gray-500 flex-shrink-0" />}
+                <span className={`flex-1 truncate ${it.result === 'win' ? tierColor(it.tier) : 'text-gray-500'}`}>
+                  {it.category}
+                </span>
+                <span className="text-[10px] uppercase tracking-wide text-gray-500 tabular-nums">
+                  +{Math.round(it.points)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function AwardScoreCard({ showId, awards, openingDate }: AwardScoreCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const result = computeSiteAwardScore(showId, 'broadway');
+
+  // Hide entirely if score is 0 and the show is long past its eligibility
+  // window — historical no-data shows shouldn't render an empty card.
+  if (result.displayScore === 0 && !result.inProgress) {
+    const openingMs = openingDate ? new Date(openingDate).getTime() : 0;
+    const monthsSinceOpening = openingMs ? (Date.now() - openingMs) / (30 * 24 * 60 * 60 * 1000) : Infinity;
+    if (monthsSinceOpening > 14) return null;
+  }
+
+  const highlights = buildHighlights(awards);
+  const isPulitzerWinner = !!awards?.pulitzer?.wins?.includes('Drama');
+  const isPulitzerFinalist = !!awards?.pulitzer?.finalist?.includes('Drama') || !!awards?.pulitzerFinalist;
+  const hasPulitzer = isPulitzerWinner || isPulitzerFinalist;
+  const pulitzerYear = awards?.pulitzer?.year;
+  const tonySeason = awards?.tony?.season;
+
+  return (
+    <div className="card p-5 sm:p-6 mb-8">
+      <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-4">Awards Scorecard</h2>
+
+      <AwardScoreBadge score={result.displayScore} badge={result.badge} inProgress={result.inProgress} />
+
+      {/* Pulitzer special callout — kept from the legacy card. Pulitzer is
+          culturally distinct (honors the script, not the production) and
+          warrants a visible call-out even though its points are in the score. */}
+      {hasPulitzer && (
+        <div
+          className={
+            isPulitzerWinner
+              ? 'bg-gradient-to-r from-amber-500/10 to-yellow-500/10 rounded-lg p-3 border border-amber-500/20 mt-4'
+              : 'bg-amber-500/5 rounded-lg p-3 border border-amber-500/15 mt-4'
+          }
+        >
+          <div className="flex items-center gap-2">
+            <PulitzerIcon className={isPulitzerWinner ? 'text-amber-400' : 'text-amber-400/70'} />
+            <span className={isPulitzerWinner ? 'text-amber-300 font-medium' : 'text-amber-200/80'}>
+              Pulitzer Prize for Drama{isPulitzerWinner ? ' Winner' : ' Finalist'}
+              {typeof pulitzerYear === 'number' ? ` (${pulitzerYear})` : ''}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* At a glance — plain-English highlights for users who don't expand */}
+      {highlights.length > 0 && (
+        <div className="mt-4">
+          <div className="text-xs uppercase tracking-wide text-gray-500 font-semibold mb-2">
+            {result.inProgress ? 'Recognition so far' : 'At a glance'}
+          </div>
+          <ul className="space-y-1.5 text-sm">
+            {highlights.map((h, i) => (
+              <li key={i} className="flex items-center gap-2 text-gray-300">
+                <TrophyIcon className="w-3.5 h-3.5 text-amber-400 flex-shrink-0" />
+                {h}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Empty-state copy when nothing has happened yet but show is current-season */}
+      {highlights.length === 0 && result.inProgress && (
+        <p className="mt-4 text-sm text-gray-400">
+          No awards recognition yet this season. First nominations land in late April.
+        </p>
+      )}
+
+      {/* Expandable line-item breakdown */}
+      {result.breakdown.length > 0 && result.displayScore > 0 && (
+        <div className="border-t border-white/5 mt-4 pt-3">
+          <button
+            type="button"
+            onClick={() => setExpanded(!expanded)}
+            className="w-full flex items-center justify-between text-left group"
+            aria-expanded={expanded}
+          >
+            <span className="text-sm font-medium text-gray-300">How the score is built</span>
+            <ChevronIcon expanded={expanded} className="text-gray-500 group-hover:text-gray-400" />
+          </button>
+          {expanded && (
+            <div className="mt-4">
+              <BreakdownSection breakdown={result.breakdown} />
+              <div className="mt-3 text-xs text-gray-500 tabular-nums border-t border-white/5 pt-2">
+                Raw points {Math.round(result.rawPoints)} · log-scaled to {result.displayScore}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Cross-link to Tony Predictions — kept from legacy card */}
+      {featureFlags.tonyPredictions && tonySeason && (
+        <div className="border-t border-white/5 pt-3 mt-4">
+          <Link
+            href={`/tony-awards/predictions/${toFullSeasonLabel(tonySeason)}`}
+            className="text-sm text-brand hover:text-brand-hover transition-colors"
+          >
+            See {tonySeason} Tony predictions &rarr;
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/AwardsCard.tsx
+++ b/src/components/AwardsCard.tsx
@@ -11,6 +11,7 @@ import type { ShowAwards, AwardsDesignation } from '@/lib/data-types';
 import { TrophyIcon, StarIcon, ChevronIcon, PulitzerIcon } from '@/components/icons';
 import { sortByImportance, isMajorCategory } from '@/config/awards';
 import { featureFlags } from '@/config/feature-flags';
+import AwardScoreCard from '@/components/AwardScoreCard';
 
 /** Convert short season "2025-26" to full label "2025-2026" for prediction URLs */
 function toFullSeasonLabel(season: string): string {
@@ -309,6 +310,12 @@ function OtherAwardsExpandableSection({ awards }: { awards: ShowAwards }) {
 }
 
 export default function AwardsCard({ showId, awards, openingDate }: AwardsCardProps) {
+  // v2 card behind feature flag — same props, completely different rendering.
+  // See src/components/AwardScoreCard.tsx and src/lib/awards-scoring.ts.
+  if (featureFlags.awardScoreV2) {
+    return <AwardScoreCard showId={showId} awards={awards} openingDate={openingDate} />;
+  }
+
   const designation = getAwardsDesignation(showId);
   const tonyWins = getTonyWinCount(showId);
   const tonyNoms = getTonyNominationCount(showId);

--- a/src/components/show-cards/AwardScoreBadge.tsx
+++ b/src/components/show-cards/AwardScoreBadge.tsx
@@ -1,0 +1,41 @@
+import type { TierBadge } from '@/lib/awards-scoring';
+
+interface AwardScoreBadgeProps {
+  score: number;
+  badge: TierBadge;
+  inProgress: boolean;
+  size?: 'md' | 'lg';
+}
+
+const BADGE_LABEL: Record<TierBadge, { label: string; inProgressLabel?: string; tone: string; ring: string }> = {
+  sweeper:        { label: 'Sweeper',        tone: 'text-amber-300',  ring: 'ring-amber-400/30 bg-gradient-to-br from-amber-500/20 to-yellow-500/10' },
+  decorated:      { label: 'Decorated',      tone: 'text-violet-300', ring: 'ring-violet-400/30 bg-violet-500/10' },
+  honored:        { label: 'Honored',        tone: 'text-emerald-300', ring: 'ring-emerald-400/25 bg-emerald-500/10' },
+  nominated:      { label: 'Nominated',      inProgressLabel: 'In the Hunt', tone: 'text-sky-300', ring: 'ring-sky-400/25 bg-sky-500/10' },
+  'in-the-hunt':  { label: 'In the Hunt',    tone: 'text-sky-300',     ring: 'ring-sky-400/25 bg-sky-500/10' },
+  eligible:       { label: 'Eligible',       tone: 'text-gray-400',    ring: 'ring-white/10 bg-surface-overlay' },
+};
+
+export function AwardScoreBadge({ score, badge, inProgress, size = 'md' }: AwardScoreBadgeProps) {
+  const cfg = BADGE_LABEL[badge];
+  const label = inProgress && cfg.inProgressLabel ? cfg.inProgressLabel : cfg.label;
+  const numClass = size === 'lg' ? 'text-5xl' : 'text-4xl';
+
+  return (
+    <div className="flex items-center gap-4">
+      <div className={`relative flex items-center justify-center rounded-2xl ring-1 px-5 py-3 ${cfg.ring}`}>
+        <span className={`font-bold tabular-nums ${numClass} ${cfg.tone}`}>{score}</span>
+        {inProgress && (
+          <span aria-hidden className={`absolute -top-1 -right-1 ${cfg.tone} text-xl font-bold`}>*</span>
+        )}
+      </div>
+      <div>
+        <div className={`text-lg font-bold uppercase tracking-wide ${cfg.tone}`}>{label}</div>
+        <div className="text-xs text-gray-400 uppercase tracking-wide">Award Score</div>
+        {inProgress && (
+          <div className="text-xs text-gray-500 mt-1">*Score so far — season in progress</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/show-cards/index.ts
+++ b/src/components/show-cards/index.ts
@@ -17,3 +17,4 @@ export { default as Modal, ModalCloseButton } from './Modal';
 export { default as ShowSearchDropdown } from './ShowSearchDropdown';
 export { BlendedTrioDisplay } from './BlendedTrioDisplay';
 export type { BlendedTrioDisplayProps } from './BlendedTrioDisplay';
+export { AwardScoreBadge } from './AwardScoreBadge';

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -16,7 +16,7 @@ const enabledFeatures = new Set(
 // Features auto-enabled on demo.broadwayscorecard.com (runtime check).
 // Uses getters so the check runs each time the flag is read (client-side).
 // CI: lint-feature-flags checks these are never referenced in server components.
-const DEMO_FEATURES = new Set(['userAccounts', 'showPageRedesign', 'showtimes']);
+const DEMO_FEATURES = new Set(['userAccounts', 'showPageRedesign', 'showtimes', 'awardScoreV2']);
 
 function isDemo(): boolean {
   if (typeof window === 'undefined') return false;
@@ -51,4 +51,5 @@ export const featureFlags = {
   get fantasyLeague() { return has('fantasyLeague'); },
   get videoReviews() { return has('videoReviews'); },
   get homepageExplainer() { return true; }, // launched — flag retained for cleanup
+  get awardScoreV2() { return has('awardScoreV2'); },
 };

--- a/src/config/feature-flags.ts
+++ b/src/config/feature-flags.ts
@@ -16,7 +16,7 @@ const enabledFeatures = new Set(
 // Features auto-enabled on demo.broadwayscorecard.com (runtime check).
 // Uses getters so the check runs each time the flag is read (client-side).
 // CI: lint-feature-flags checks these are never referenced in server components.
-const DEMO_FEATURES = new Set(['userAccounts', 'showPageRedesign', 'showtimes', 'awardScoreV2']);
+const DEMO_FEATURES = new Set(['userAccounts', 'showPageRedesign', 'showtimes', 'awards', 'awardScoreV2']);
 
 function isDemo(): boolean {
   if (typeof window === 'undefined') return false;

--- a/src/lib/awards-scoring.ts
+++ b/src/lib/awards-scoring.ts
@@ -247,14 +247,14 @@ export function computeSiteAwardScore(showId: string, market: Market = 'broadway
   const rawPoints = breakdown.reduce((s, b) => s + b.subtotal, 0);
   const displayScore = Math.max(0, Math.round(40 * Math.log10(1 + rawPoints / 4)));
 
-  // Thresholds tuned against test cases: Hamilton (raw 1322 → 101) is the
-  // only sweeper. Maybe Happy Ending (944 → 95) is right at the edge. Most
-  // decorated shows land 76-94. See scripts/sanity-check-awards-scoring.ts.
+  // Thresholds tuned against test cases + full-corpus audit (see
+  // scripts/audit-award-scores.ts). Sweeper at 85+ keeps the tier earned
+  // but not impossibly rare; decorated 70-84 captures the strong-winner band.
   let badge: TierBadge;
   if (displayScore === 0) badge = 'eligible';
   else if (displayScore <= 40) badge = 'nominated';
-  else if (displayScore <= 75) badge = 'honored';
-  else if (displayScore <= 94) badge = 'decorated';
+  else if (displayScore <= 69) badge = 'honored';
+  else if (displayScore <= 84) badge = 'decorated';
   else badge = 'sweeper';
 
   // TODO: inProgress derivation from season + Tony ceremony date. v1 stub.

--- a/src/lib/awards-scoring.ts
+++ b/src/lib/awards-scoring.ts
@@ -1,0 +1,276 @@
+/**
+ * Site Award Score — a stable prestige-weighted score per show.
+ *
+ * Distinct from src/lib/data-tony-predictions.ts: that module uses *predictive*
+ * weights tuned for forecasting a Tony winner. This module uses *prestige*
+ * weights — what a theater fan thinks a show's award legacy is worth.
+ * Both modules can read the same awards.json; only the weights differ.
+ *
+ * See memory/award-score-design.md for the full spec, including category-tier
+ * mapping, ceremony prestige ordering, and the log-display rationale.
+ */
+
+import awardsData from '../../data/awards.json';
+
+export type CategoryTier = 'S' | 'A+' | 'A' | 'B' | 'C';
+
+export type TierBadge =
+  | 'eligible'
+  | 'in-the-hunt'
+  | 'nominated'
+  | 'honored'
+  | 'decorated'
+  | 'sweeper';
+
+export type Market = 'broadway' | 'west-end';
+
+type CeremonyKey =
+  | 'tony'
+  | 'pulitzer'
+  | 'olivier_bway'
+  | 'olivier_we'
+  | 'nydcc'
+  | 'occ'
+  | 'dramaLeague'
+  | 'dramaDesk';
+
+interface TierPoints { win: number; nom: number }
+
+const POINTS: Record<CeremonyKey, Partial<Record<CategoryTier, TierPoints>>> = {
+  tony:         { S: { win: 150, nom: 38 }, A: { win: 75, nom: 18 }, B: { win: 35, nom: 9 }, C: { win: 25, nom: 6 } },
+  pulitzer:     { S: { win: 110, nom: 35 } },
+  olivier_bway: { S: { win: 50,  nom: 12 }, A: { win: 25, nom: 6 },  B: { win: 15, nom: 4 }, C: { win: 12, nom: 3 } },
+  olivier_we:   { S: { win: 110, nom: 28 }, A: { win: 55, nom: 14 }, B: { win: 32, nom: 8 }, C: { win: 24, nom: 6 } },
+  nydcc:        { S: { win: 75,  nom: 0 } },
+  occ:          { S: { win: 50,  nom: 13 }, A: { win: 28, nom: 7 },  B: { win: 16, nom: 4 }, C: { win: 10, nom: 2 } },
+  dramaLeague:  { S: { win: 35,  nom: 9 },  A: { win: 22, nom: 6 } },
+  dramaDesk:    { S: { win: 28,  nom: 7 },  A: { win: 18, nom: 4 },  B: { win: 12, nom: 3 }, C: { win: 8,  nom: 2 } },
+};
+
+const A_PLUS_MULTIPLIER = 1.2;
+const REVIVAL_DISCOUNT = 0.85;
+
+// Diminishing returns on C-tier (design) wins within a single ceremony.
+// Five design Tonys total ~67 pts, less than half of one Best Musical (150).
+const C_STACKING = [1.0, 0.7, 0.5, 0.4, 0.4, 0.4];
+
+/** Tier classification — returns null for unmappable categories. */
+function classifyCategory(category: string): { tier: CategoryTier; revival: boolean } | null {
+  const c = category.toLowerCase();
+
+  // S — top production awards
+  if (/revival of a musical|musical revival/.test(c)) return { tier: 'S', revival: true };
+  if (/revival of a play|play revival/.test(c)) return { tier: 'S', revival: true };
+  if (/best musical$|outstanding musical$|outstanding new (broadway|off-broadway) musical|outstanding production of a (broadway or off-broadway )?musical/.test(c)) return { tier: 'S', revival: false };
+  if (/best play$|outstanding play$|outstanding new broadway play|outstanding production of a play/.test(c)) return { tier: 'S', revival: false };
+  if (/^drama$/.test(c)) return { tier: 'S', revival: false }; // Pulitzer
+
+  // A+ — creative authorship
+  if (/best (original )?score|outstanding (new )?score|outstanding music\b|outstanding lyrics|outstanding music in a play/.test(c)) return { tier: 'A+', revival: false };
+  if (/best book|outstanding book/.test(c)) return { tier: 'A+', revival: false };
+
+  // A — direction, choreography, lead performances, DL Distinguished Performance
+  if (/direction|director/.test(c)) return { tier: 'A', revival: false };
+  if (/choreograph/.test(c)) return { tier: 'A', revival: false };
+  if (/distinguished performance/.test(c)) return { tier: 'A', revival: false };
+  if (/best (actor|actress) in a (play|musical)|outstanding (actor|actress) in a (play|musical)/.test(c)) return { tier: 'A', revival: false };
+
+  // B — featured performances, orchestrations, ensemble
+  if (/featured (actor|actress)/.test(c)) return { tier: 'B', revival: false };
+  if (/orchestration/.test(c)) return { tier: 'B', revival: false };
+  if (/ensemble/.test(c)) return { tier: 'B', revival: false };
+
+  // C — design
+  if (/scenic|set design/.test(c)) return { tier: 'C', revival: false };
+  if (/costume/.test(c)) return { tier: 'C', revival: false };
+  if (/lighting/.test(c)) return { tier: 'C', revival: false };
+  if (/sound/.test(c)) return { tier: 'C', revival: false };
+
+  return null;
+}
+
+export interface ContributionItem {
+  category: string;
+  tier: CategoryTier;
+  revival: boolean;
+  result: 'win' | 'nom';
+  points: number;
+}
+
+export interface CeremonyContribution {
+  ceremony: string;
+  items: ContributionItem[];
+  subtotal: number;
+}
+
+export interface ScoreResult {
+  rawPoints: number;
+  displayScore: number;
+  badge: TierBadge;
+  inProgress: boolean;
+  breakdown: CeremonyContribution[];
+}
+
+function applyMultipliers(points: number, tier: CategoryTier, isRevival: boolean): number {
+  let p = points;
+  if (tier === 'A+') p *= A_PLUS_MULTIPLIER;
+  if (isRevival) p *= REVIVAL_DISCOUNT;
+  return p;
+}
+
+function pointsForTier(table: Partial<Record<CategoryTier, TierPoints>>, tier: CategoryTier): TierPoints | null {
+  if (tier === 'A+') return table.A ?? null;
+  return table[tier] ?? null;
+}
+
+function scoreCeremony(
+  display: string,
+  key: CeremonyKey,
+  wins: string[],
+  noms: string[],
+  unknownNomCount = 0,
+): CeremonyContribution {
+  const table = POINTS[key];
+  const items: ContributionItem[] = [];
+
+  // Count duplicates — performance noms can appear N times when N people from
+  // the same show are nominated for the same award (e.g. Hamilton's 3 Featured
+  // Actor nominees). Each instance counts.
+  const winCount: Record<string, number> = {};
+  const nomCount: Record<string, number> = {};
+  for (const w of wins) winCount[w] = (winCount[w] || 0) + 1;
+  for (const n of noms) nomCount[n] = (nomCount[n] || 0) + 1;
+
+  let cWinsSeen = 0;
+
+  for (const [cat, count] of Object.entries(winCount)) {
+    const cls = classifyCategory(cat);
+    if (!cls) continue;
+    const pts = pointsForTier(table, cls.tier);
+    if (!pts) continue;
+    for (let i = 0; i < count; i++) {
+      let raw = pts.win;
+      if (cls.tier === 'C') {
+        raw *= C_STACKING[Math.min(cWinsSeen, C_STACKING.length - 1)];
+        cWinsSeen++;
+      }
+      items.push({ category: cat, tier: cls.tier, revival: cls.revival, result: 'win', points: applyMultipliers(raw, cls.tier, cls.revival) });
+    }
+  }
+
+  for (const [cat, count] of Object.entries(nomCount)) {
+    const cls = classifyCategory(cat);
+    if (!cls) continue;
+    const pts = pointsForTier(table, cls.tier);
+    if (!pts || pts.nom <= 0) continue;
+    // Subtract win instances: a category in both wins and noms with the same
+    // count was fully won. We only count the *losing* noms here.
+    const losing = Math.max(0, count - (winCount[cat] || 0));
+    for (let i = 0; i < losing; i++) {
+      items.push({ category: cat, tier: cls.tier, revival: cls.revival, result: 'nom', points: applyMultipliers(pts.nom, cls.tier, cls.revival) });
+    }
+  }
+
+  // Uncategorized noms — when the ceremony reports e.g. 13 total nominations
+  // but only enumerates a few. Credit at C-tier nom rate so breadth is captured
+  // without inventing categories. Mostly affects Drama Desk historical entries.
+  if (unknownNomCount > 0 && table.C && table.C.nom > 0) {
+    for (let i = 0; i < unknownNomCount; i++) {
+      items.push({ category: '(uncategorized)', tier: 'C', revival: false, result: 'nom', points: table.C.nom });
+    }
+  }
+
+  const subtotal = items.reduce((s, x) => s + x.points, 0);
+  return { ceremony: display, items, subtotal };
+}
+
+function unknownNoms(totalCount: number | undefined, enumeratedWins: string[], enumeratedNoms: string[]): number {
+  if (!totalCount) return 0;
+  // Tally is # of distinct nominations across the ceremony. wins ∪ noms is
+  // what we know about. The gap is uncategorized noms.
+  const enumerated = new Set([...enumeratedWins, ...enumeratedNoms]).size;
+  return Math.max(0, totalCount - enumerated);
+}
+
+export function computeSiteAwardScore(showId: string, market: Market = 'broadway'): ScoreResult {
+  const shows = (awardsData as { shows: Record<string, AwardsShowEntry> }).shows;
+  const entry = shows[showId];
+
+  if (!entry) {
+    return { rawPoints: 0, displayScore: 0, badge: 'eligible', inProgress: false, breakdown: [] };
+  }
+
+  const breakdown: CeremonyContribution[] = [];
+
+  if (entry.tony) {
+    const wins = entry.tony.wins ?? [];
+    const noms = entry.tony.nominatedFor ?? [];
+    breakdown.push(scoreCeremony('Tony Awards', 'tony', wins, noms, unknownNoms(entry.tony.nominations, wins, noms)));
+  }
+
+  if (entry.pulitzer || entry.pulitzerFinalist) {
+    const wins = entry.pulitzer?.wins ?? [];
+    const finalists = entry.pulitzer?.finalist ? [...entry.pulitzer.finalist] : [];
+    if (entry.pulitzerFinalist) finalists.push('Drama');
+    breakdown.push(scoreCeremony('Pulitzer Prize', 'pulitzer', wins, finalists));
+  }
+
+  if (entry.olivier) {
+    const key: CeremonyKey = market === 'broadway' ? 'olivier_bway' : 'olivier_we';
+    const wins = entry.olivier.wins ?? [];
+    const noms = entry.olivier.nominatedFor ?? [];
+    breakdown.push(scoreCeremony('Olivier Awards', key, wins, noms, unknownNoms(entry.olivier.nominations, wins, noms)));
+  }
+
+  if (entry.nyDramaCritics) {
+    breakdown.push(scoreCeremony("NY Drama Critics' Circle", 'nydcc', entry.nyDramaCritics.wins ?? [], []));
+  }
+
+  if (entry.outerCriticsCircle) {
+    const wins = entry.outerCriticsCircle.wins ?? [];
+    const noms = entry.outerCriticsCircle.nominatedFor ?? [];
+    breakdown.push(scoreCeremony('Outer Critics Circle', 'occ', wins, noms, unknownNoms(entry.outerCriticsCircle.nominations, wins, noms)));
+  }
+
+  if (entry.dramaLeague) {
+    const wins = entry.dramaLeague.wins ?? [];
+    const noms = entry.dramaLeague.nominatedFor ?? [];
+    breakdown.push(scoreCeremony('Drama League', 'dramaLeague', wins, noms));
+  }
+
+  if (entry.dramadesk) {
+    const wins = entry.dramadesk.wins ?? [];
+    const noms = entry.dramadesk.nominatedFor ?? [];
+    breakdown.push(scoreCeremony('Drama Desk', 'dramaDesk', wins, noms, unknownNoms(entry.dramadesk.nominations, wins, noms)));
+  }
+
+  const rawPoints = breakdown.reduce((s, b) => s + b.subtotal, 0);
+  const displayScore = Math.max(0, Math.round(40 * Math.log10(1 + rawPoints / 4)));
+
+  // Thresholds tuned against test cases: Hamilton (raw 1322 → 101) is the
+  // only sweeper. Maybe Happy Ending (944 → 95) is right at the edge. Most
+  // decorated shows land 76-94. See scripts/sanity-check-awards-scoring.ts.
+  let badge: TierBadge;
+  if (displayScore === 0) badge = 'eligible';
+  else if (displayScore <= 40) badge = 'nominated';
+  else if (displayScore <= 75) badge = 'honored';
+  else if (displayScore <= 94) badge = 'decorated';
+  else badge = 'sweeper';
+
+  // TODO: inProgress derivation from season + Tony ceremony date. v1 stub.
+  const inProgress = false;
+
+  return { rawPoints, displayScore, badge, inProgress, breakdown };
+}
+
+interface PrecursorNode { wins?: string[]; nominatedFor?: string[]; nominations?: number }
+interface AwardsShowEntry {
+  tony?: PrecursorNode & { season?: string; ceremony?: string };
+  dramadesk?: PrecursorNode & { season?: string };
+  outerCriticsCircle?: PrecursorNode & { season?: string };
+  dramaLeague?: PrecursorNode & { season?: string };
+  nyDramaCritics?: PrecursorNode & { season?: string };
+  pulitzer?: { wins?: string[]; finalist?: string[]; year?: number };
+  pulitzerFinalist?: { year?: number; note?: string };
+  olivier?: PrecursorNode & { season?: string };
+}

--- a/src/lib/awards-scoring.ts
+++ b/src/lib/awards-scoring.ts
@@ -11,6 +11,7 @@
  */
 
 import awardsData from '../../data/awards.json';
+import { currentTonySeason } from './tony-cutoffs';
 
 export type CategoryTier = 'S' | 'A+' | 'A' | 'B' | 'C';
 
@@ -257,8 +258,13 @@ export function computeSiteAwardScore(showId: string, market: Market = 'broadway
   else if (displayScore <= 84) badge = 'decorated';
   else badge = 'sweeper';
 
-  // TODO: inProgress derivation from season + Tony ceremony date. v1 stub.
-  const inProgress = false;
+  // In progress = show's Tony season is the current season AND the Tony
+  // ceremony hasn't happened yet (no wins recorded). Once ceremony passes,
+  // currentTonySeason() advances and this flips false naturally.
+  const currentSeason = currentTonySeason();
+  const showSeason = entry.tony?.season;
+  const tonyDone = (entry.tony?.wins?.length ?? 0) > 0;
+  const inProgress = !!showSeason && showSeason === currentSeason.label && !tonyDone;
 
   return { rawPoints, displayScore, badge, inProgress, breakdown };
 }

--- a/src/lib/data-types.ts
+++ b/src/lib/data-types.ts
@@ -274,6 +274,9 @@ export interface ShowAwards {
   dramaLeague?: DramaLeagueAwards;
   nyDramaCritics?: NyDramaCriticsAwards;
   pulitzer?: PulitzerPrize;
+  /** Legacy shape — newer entries fold finalists into pulitzer.finalist. Some
+   *  pre-migration entries (e.g. Stereophonic 2024) still use this. */
+  pulitzerFinalist?: { year?: number; note?: string };
   note?: string;
 }
 


### PR DESCRIPTION
## Summary

- New Site Award Score module (`src/lib/awards-scoring.ts`) producing a per-show 0-100+ prestige-weighted score across Tony, Pulitzer, Olivier (Broadway/West End split), NYDCC, Drama League, OCC, Drama Desk. Distinct from `data-tony-predictions.ts` — predictive vs prestige weights on the same award data.
- Category tiers within each ceremony: **S** (Best Musical/Play/Revival), **A+** (Score/Book), **A** (Director/Choreo/Lead), **B** (Featured/Orch/Ensemble), **C** (Design). C-tier wins have diminishing returns within a ceremony so design sweeps don't outweigh a Best Musical win.
- Display is log-compressed but **uncapped** — Hamilton breaks 100, typical shows land 0-95. Tier thresholds: **SWEEPER 85+**, **DECORATED 70-84**, **HONORED 41-69**, **IN THE HUNT / NOMINATED 1-40**, **ELIGIBLE 0**.
- New `AwardScoreCard` component replaces the legacy categorical Awards Scorecard when `awardScoreV2` flag is on (auto-enabled on demo).
- New `AwardScoreBadge` primitive added to `show-cards/` design-system exports.
- The `awards` outer flag also auto-enables on demo so the card is actually reachable there.

## Calibration

Full-corpus audit (`scripts/audit-award-scores.ts`) produces 37 sweepers across ~50 years — one every ~1.4 years. Hamilton is the only show breaking 100. Spring Awakening and Stereophonic correctly land as sweepers; Wicked correctly stays decorated.

Sanity-check (`scripts/sanity-check-awards-scoring.ts`):

| Show | Score | Badge |
|---|---|---|
| Hamilton | 101 | SWEEPER |
| Maybe Happy Ending | 95 | SWEEPER |
| Stereophonic | 92 | SWEEPER |
| Spring Awakening | 87 | SWEEPER |
| Purpose | 84 | DECORATED |
| Wicked | 81 | DECORATED |
| Next to Normal | 76 | DECORATED (would be sweeper after backfilling missing Pulitzer data — see linked Notion card) |
| Come From Away | 76 | DECORATED |

## Test plan

- [ ] Demo deploy completes after merge (~5 min)
- [ ] Visit `/show/hamilton-2015` on demo → SWEEPER 101 badge, Pulitzer winner callout, breakdown expandable
- [ ] Visit `/show/stereophonic-2024` on demo → SWEEPER 92, Pulitzer finalist callout
- [ ] Visit `/show/wicked-2003` on demo → DECORATED 81, no Pulitzer callout
- [ ] Visit `/show/come-from-away-2017` on demo → DECORATED 76
- [ ] Visit a current 2025-26 show with precursor noms → IN THE HUNT, asterisk visible, "*Score so far — season in progress" copy
- [ ] Mobile (390px) + desktop (1440px) for at least one of each tier
- [ ] Confirm "See {season} Tony predictions →" cross-link still works
- [ ] Confirm production (broadwayscorecard.com) still shows legacy card (flag off in prod)

## Follow-ups (tracked in Notion)

- [Backfill historic Pulitzer + precursor data for pre-2014 shows](https://www.notion.so/361637c5416f816c98c5c3855e5e7171) — Next to Normal, Sunday in the Park, Angels in America etc. score lower than they should because awards.json lacks pre-2014 Pulitzer/NYDCC data.
- [P0: Skills don't work in cloud Claude Code sessions](https://www.notion.so/361637c5416f81fc9416e9a3a420ba67) — unrelated infra gap surfaced during this work.

---
_Generated by [Claude Code](https://claude.ai/code/session_015fc7jqg4KSwryYqx447MxK)_