### PR TITLE
infra(awards): cron-schedule the Tony Awards Wikipedia scraper for April-June

### DIFF
--- a/.github/workflows/update-tony-awards.yml
+++ b/.github/workflows/update-tony-awards.yml
@@ -1,8 +1,17 @@
 name: Update Tony Awards Data
 
 on:
-  # No cron — Tony Awards are an annual event (noms ~April, ceremony ~June).
-  # Trigger manually when nominations are announced or ceremony concludes.
+  # Tony Awards season: nominations announced ~early May, ceremony ~early June.
+  # Cron runs daily during April-June at 16:00 UTC (12 PM ET) to catch noms +
+  # winners as Wikipedia is updated. Wikipedia scraping is idempotent: when
+  # there's no new data the workflow exits without committing. Outside of
+  # awards season the cron doesn't fire, so no wasted runs.
+  #
+  # Previously workflow_dispatch only — the 2026 nominations announced May 5
+  # never made it into awards.json because nobody manually triggered it,
+  # leaving every 2025-26 show showing 0 Tony noms on the site.
+  schedule:
+    - cron: '0 16 * 4-6 *'  # 16:00 UTC daily, April-June
   workflow_dispatch:
     inputs:
       year:
@@ -76,7 +85,7 @@ jobs:
           bash scripts/lib/push-with-retry.sh
 
       - name: Create IBDB scraper reminder issue
-        if: steps.changes.outputs.has_changes == 'true'
+        if: steps.changes.outputs.has_changes == 'true' && github.event_name == 'workflow_dispatch'
         run: |
           YEAR="${{ inputs.year }}"
           if [ -z "$YEAR" ]; then


### PR DESCRIPTION
## Why

The Tony Awards scraper (`scripts/scrape-tony-awards.js`) exists and works — Wikipedia has structured tables for every Tony ceremony. But `update-tony-awards.yml` was `workflow_dispatch` only, meaning a human had to remember to run it after Tony nominations are announced. **Nobody triggered it after May 5, 2026.** So:

- `awards.json` has no Tony nomination data for the 2025-26 season
- Every 2025-26 show on the site shows 0 Tony noms in the Awards Scorecard
- Cats: The Jellicle Ball (9 noms including Best Revival of a Musical) appears "Eligible" — looks like a site bug
- Same for the other 23 nominated shows

## What

Add a cron schedule firing daily at 16:00 UTC during April-June (Tony nom + ceremony window). Wikipedia scraping is idempotent — runs with no new data exit cleanly without committing. Outside awards season the cron doesn't fire.

Also gates the post-scrape "run IBDB scraper" reminder issue to `workflow_dispatch` only, so the daily cron doesn't spam GitHub Issues with the same reminder every day.

## After this merges

1. Either wait for the next cron tick (~12 PM ET) — that should ingest 2026 noms automatically and trigger a deploy.
2. Or trigger the workflow manually right after merge: github.com → Actions → Update Tony Awards Data → Run workflow (year blank).

## Follow-up

Precursors (Drama League, OCC, DD, NYDCC, Pulitzer) still use hardcoded arrays in `scripts/enrich-awards-with-precursors.js`. Same pattern problem — someone has to manually paste each year's winners. Worth filing a Notion P1 to move those to scrapers too. Wikipedia has structured tables for all 5.

---
_Generated by [Claude Code](https://claude.ai/code/session_015fc7jqg4KSwryYqx447MxK)_