### PR TITLE
audit-closing-dates: add triple-signal auto-fix

### DIFF
--- a/.github/workflows/audit-closing-dates.yml
+++ b/.github/workflows/audit-closing-dates.yml
@@ -59,6 +59,7 @@ jobs:
           SCRAPINGBEE_API_KEY: ${{ secrets.SCRAPINGBEE_API_KEY }}
           DISCORD_WEBHOOK_ALERTS: ${{ secrets.DISCORD_WEBHOOK_ALERTS }}
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
             node scripts/audit-closing-dates.js --dry-run

--- a/scripts/audit-closing-dates.js
+++ b/scripts/audit-closing-dates.js
@@ -45,6 +45,7 @@
 const fs = require('fs');
 const path = require('path');
 const { fetchPage, cleanup } = require('./lib/scraper');
+const { discoverAnnouncedClosingDate } = require('./lib/closing-date-discovery');
 
 const SHOWS_FILE = path.join(__dirname, '..', 'data', 'shows.json');
 const AUDIT_FILE = path.join(__dirname, '..', 'data', 'audit', 'closing-date-discrepancies.json');
@@ -62,6 +63,16 @@ const AMBIGUOUS_DELTA_THRESHOLD_DAYS = 30;
 // the 2027 Tony Awards date) than a real extension. Fall through to
 // ambiguous review instead of writing a fabricated date.
 const MAX_AUTO_EXTENSION_DAYS = 180;
+// Triple-signal auto-fix: when broadway.com schedule + press article + LLM
+// extraction agree within ±7 days, auto-apply the new closingDate. Bounds
+// hallucination risk: a single wrong article can't move the date unless the
+// schedule and a second source corroborate. See clusterDates() in
+// scripts/lib/closing-date-discovery.js.
+const TRIPLE_SIGNAL_TOLERANCE_DAYS = 7;
+// Cap auto-fix attempts per run. With ~$0.10 of SERP+SB+LLM per show, this
+// caps a runaway audit (e.g., 50 ambiguous after a broadway.com layout
+// change) at ~$1. Excess flows through to the Notion card path normally.
+const MAX_TRIPLE_SIGNAL_ATTEMPTS = 10;
 
 const CONFIG = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
 const SLUG_OVERRIDES = CONFIG.slugOverrides;
@@ -282,18 +293,93 @@ async function main() {
     }
   }
 
+  // ── Triple-signal auto-fix pass ────────────────────────────────────────
+  // For each ambiguous show, SERP credible theater press for closing
+  // announcements within the last month and LLM-extract dates. Auto-apply
+  // when the press cluster and broadway.com schedule agree within ±7 days.
+  // Cap attempts to bound cost; sort by stored-closing-date ascending so
+  // the most-urgent retractions (closing soonest) get the auto-fix budget.
+  const autoFixedTripleSignal = [];
+  if (process.env.ANTHROPIC_API_KEY && ambiguous.length > 0) {
+    const byUrgency = ambiguous
+      .filter(a => a.action === 'NEEDS_HUMAN_REVIEW')  // earlier-than-stored only; never the extension-cap path
+      .sort((a, b) => new Date(a.stored) - new Date(b.stored))
+      .slice(0, MAX_TRIPLE_SIGNAL_ATTEMPTS);
+    console.log(`\nTriple-signal auto-fix: attempting ${byUrgency.length} ambiguous show(s)`);
+    for (const a of byUrgency) {
+      const show = candidates.find(c => c.id === a.id);
+      if (!show) continue;
+      const showTitle = show.title || show.name || a.id;
+      let discovery;
+      try {
+        discovery = await discoverAnnouncedClosingDate(showTitle, { log: (msg) => console.log(msg) });
+      } catch (e) {
+        console.warn(`  [auto-fix] ${a.id}: discovery error: ${e.message.slice(0, 120)}`);
+        continue;
+      }
+      if (!discovery) continue;
+
+      const dayDelta = Math.abs((new Date(discovery.date) - new Date(a.latestScheduled)) / 86400000);
+      if (dayDelta > TRIPLE_SIGNAL_TOLERANCE_DAYS) {
+        // Press article disagrees with broadway.com schedule. Don't apply;
+        // log for human review (the Notion card will surface it).
+        a.tripleSignalConflict = {
+          pressDate: discovery.date,
+          scheduleDate: a.latestScheduled,
+          dayDelta,
+          sources: discovery.sources,
+        };
+        continue;
+      }
+
+      // All three signals agree (stored disagrees by definition since this
+      // is ambiguous). Auto-apply the press date — it's the authoritative
+      // announcement; broadway.com schedule is just the lower-bound proof.
+      const newDate = discovery.date;
+      if (!DRY_RUN) {
+        const targetShow = data.shows.find(s => s.id === a.id);
+        if (targetShow) {
+          targetShow.closingDate = newDate;
+          targetShow.closingDateSource = `triple-signal audit (${TODAY}): broadway.com + ${discovery.sources[0].url}`;
+          targetShow.closingDateUpdatedAt = TODAY;
+        }
+      }
+      autoFixedTripleSignal.push({
+        id: a.id,
+        previousStored: a.stored,
+        newClosingDate: newDate,
+        scheduleDate: a.latestScheduled,
+        pressDate: discovery.date,
+        dayDelta,
+        sources: discovery.sources,
+      });
+    }
+    // Remove auto-fixed shows from ambiguous so they don't double-flag
+    // in the Discord/Notion path.
+    if (autoFixedTripleSignal.length > 0) {
+      const fixedIds = new Set(autoFixedTripleSignal.map(x => x.id));
+      for (let i = ambiguous.length - 1; i >= 0; i--) {
+        if (fixedIds.has(ambiguous[i].id)) ambiguous.splice(i, 1);
+      }
+    }
+  } else if (ambiguous.length > 0 && !process.env.ANTHROPIC_API_KEY) {
+    console.log('\nTriple-signal auto-fix: skipped (ANTHROPIC_API_KEY not set)');
+  }
+
   const report = {
     generatedAt: new Date().toISOString(),
     mode: DRY_RUN ? 'dry-run' : 'live',
     summary: {
       audited: candidates.length,
       extensions: extensions.length,
+      autoFixedTripleSignal: autoFixedTripleSignal.length,
       newClosings: newClosings.length,
       ambiguous: ambiguous.length,
       matches: matches.length,
       errors: errors.length,
     },
     extensions,
+    autoFixedTripleSignal,
     newClosings,
     ambiguous,
     matches,
@@ -307,15 +393,17 @@ async function main() {
   console.log('\nResults:');
   console.log(`  ✅ Matches (within ${AMBIGUOUS_DELTA_THRESHOLD_DAYS}d): ${matches.length}`);
   console.log(`  📈 Extensions auto-applied:    ${extensions.length}`);
+  console.log(`  🤖 Triple-signal auto-fixed:   ${autoFixedTripleSignal.length}`);
   console.log(`  🆕 New-closing candidates (review only): ${newClosings.length}`);
   console.log(`  ⚠️  Ambiguous (>30d earlier):  ${ambiguous.length}`);
   console.log(`  ❌ Errors:                     ${errors.length}`);
 
   for (const e of extensions) console.log(`  EXT  ${e.id}: ${e.stored} → ${e.latestScheduled} (+${e.delta}d)`);
+  for (const f of autoFixedTripleSignal) console.log(`  AUTO ${f.id}: ${f.previousStored} → ${f.newClosingDate} (3-signal: broadway.com + ${f.sources.length} press source(s))`);
   for (const n of newClosings) console.log(`  NEW  ${n.id}: null → schedule ends ${n.latestScheduled} (review — may be open run)`);
   for (const a of ambiguous) console.log(`  AMB  ${a.id}: stored=${a.stored} schedule=${a.latestScheduled} (${a.delta}d)`);
 
-  const changed = extensions.length;
+  const changed = extensions.length + autoFixedTripleSignal.length;
   if (changed > 0 && !DRY_RUN) {
     fs.writeFileSync(SHOWS_FILE, JSON.stringify(data, null, 2) + '\n');
     console.log(`\n✅ Wrote ${changed} closingDate updates to shows.json`);

--- a/scripts/lib/closing-date-discovery.js
+++ b/scripts/lib/closing-date-discovery.js
@@ -1,0 +1,217 @@
+/**
+ * closing-date-discovery.js
+ *
+ * Discover the announced Broadway closing date for a show by SERP-searching
+ * credible theater press within the last 30 days and LLM-extracting the date
+ * from each candidate article. Returns null unless ≥2 high-confidence
+ * extractions agree within ±3 days (or 1 extraction names BOTH the show and
+ * an explicit "final performance" date).
+ *
+ * Used by scripts/audit-closing-dates.js as the second of three signals in
+ * the triple-signal auto-fix: only auto-apply a new closingDate when
+ * broadway.com schedule + press article + LLM extraction all agree within
+ * ±7 days of each other. Failures fall through to the human-review Notion
+ * card path.
+ */
+
+const https = require('https');
+const { serpQuery } = require('./url-discovery');
+const { fetchPage } = require('../lib/scraper');
+
+const CREDIBLE_HOSTS = [
+  'variety.com',
+  'playbill.com',
+  'deadline.com',
+  'broadwayworld.com',
+  'broadway.com',
+  'broadwaynews.com',
+  'theatermania.com',
+  'newyorktheatreguide.com',
+];
+
+const CLUSTER_TOLERANCE_DAYS = 3;
+const MAX_CANDIDATES_PER_SHOW = 5;
+
+function callClaudeSonnet(prompt) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY not set');
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 400,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const req = https.request('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+    }, (res) => {
+      let data = '';
+      res.on('data', c => data += c);
+      res.on('end', () => {
+        if (res.statusCode === 200) {
+          try { resolve(JSON.parse(data).content?.[0]?.text || ''); }
+          catch (e) { reject(new Error(`Anthropic parse: ${e.message}`)); }
+        } else {
+          reject(new Error(`Anthropic HTTP ${res.statusCode}: ${data.slice(0, 200)}`));
+        }
+      });
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function isCredibleUrl(url) {
+  if (!url) return false;
+  return CREDIBLE_HOSTS.some(h => url.includes(h));
+}
+
+function buildExtractionPrompt(showTitle, text, url) {
+  return `You are extracting the announced final Broadway performance date from a press article.
+
+Show: ${showTitle}
+Article URL: ${url}
+Article text (truncated):
+"""
+${text}
+"""
+
+Return ONLY JSON in this exact form (no markdown, no commentary):
+{"date": "YYYY-MM-DD" | null, "confidence": "high" | "medium" | "low", "quote": "the exact sentence stating the date" | null}
+
+Rules:
+- date = the FINAL Broadway performance announced in this article. Not opening, not previews, not a future tour stop, not a past extension if a newer date has been announced.
+- confidence "high" ONLY if the article explicitly states a closing OR final-performance date for the named show on Broadway.
+- If the article is about a tour, regional production, off-Broadway run, or West End run, return {"date": null, "confidence": "low", "quote": null}.
+- If the date is ambiguous, a range, conditional, or not present, return {"date": null, "confidence": "low", "quote": null}.`;
+}
+
+function parseExtraction(raw) {
+  if (!raw) return null;
+  // Trim code fences if model added them
+  const cleaned = raw.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/, '').trim();
+  try {
+    const j = JSON.parse(cleaned);
+    if (!j || typeof j !== 'object') return null;
+    if (j.date && !/^\d{4}-\d{2}-\d{2}$/.test(j.date)) return null;
+    if (!['high', 'medium', 'low'].includes(j.confidence)) return null;
+    return { date: j.date || null, confidence: j.confidence, quote: j.quote || null };
+  } catch {
+    return null;
+  }
+}
+
+function stripHtml(html) {
+  return html
+    .replace(/<script[^]*?<\/script>/g, ' ')
+    .replace(/<style[^]*?<\/style>/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// Cluster dates by proximity: returns the date with the most agreements
+// within ±CLUSTER_TOLERANCE_DAYS, plus the contributing sources.
+function clusterDates(extractions) {
+  if (extractions.length === 0) return null;
+  const dated = extractions.filter(e => e.date && e.confidence === 'high');
+  if (dated.length === 0) return null;
+
+  let best = null;
+  for (let i = 0; i < dated.length; i++) {
+    const center = new Date(dated[i].date);
+    const cluster = dated.filter(e => {
+      const d = new Date(e.date);
+      return Math.abs((d - center) / 86400000) <= CLUSTER_TOLERANCE_DAYS;
+    });
+    if (!best || cluster.length > best.cluster.length) {
+      best = { centerDate: dated[i].date, cluster };
+    }
+  }
+  // Single-source acceptance ONLY if the extraction has both a date and a
+  // quote with "final performance" language — bounds the
+  // "one hallucinated article wrong-corrects the show" failure mode.
+  if (best.cluster.length === 1) {
+    const q = (best.cluster[0].quote || '').toLowerCase();
+    if (!/final performance|closing on|last performance/.test(q)) return null;
+  }
+  return best;
+}
+
+/**
+ * @returns null OR { date: 'YYYY-MM-DD', sources: [{url, title, quote}], extractions: [...] }
+ */
+async function discoverAnnouncedClosingDate(showTitle, opts = {}) {
+  const log = opts.log || (() => {});
+  const query = `"${showTitle}" broadway closing OR extends final performance`;
+  log(`  [discovery] SERP: ${query}`);
+
+  // Last 30 days — closing announcements stay relevant only briefly. Older
+  // results are mostly historical pieces.
+  const dateMax = new Date();
+  const dateMin = new Date(dateMax.getTime() - 30 * 86400000);
+  let results;
+  try {
+    results = await serpQuery(query, { nbResults: 12, dateRange: { dateMin, dateMax } });
+  } catch (e) {
+    log(`  [discovery] SERP error: ${e.message}`);
+    return null;
+  }
+  if (!results || results.length === 0) return null;
+
+  const candidates = results
+    .filter(r => isCredibleUrl(r.url))
+    .slice(0, MAX_CANDIDATES_PER_SHOW);
+  if (candidates.length === 0) {
+    log('  [discovery] no credible-host results');
+    return null;
+  }
+
+  const extractions = [];
+  for (const c of candidates) {
+    try {
+      const page = await fetchPage(c.url, { source: 'audit-closing-dates' });
+      if (!page || !page.content) continue;
+      const text = stripHtml(page.content).slice(0, 4000);
+      // Reject if the body doesn't even mention the show name
+      if (!text.toLowerCase().includes(showTitle.toLowerCase().split(/[^a-z0-9]/i)[0])) continue;
+      const raw = await callClaudeSonnet(buildExtractionPrompt(showTitle, text, c.url));
+      const parsed = parseExtraction(raw);
+      if (parsed) {
+        extractions.push({ ...parsed, sourceUrl: c.url, sourceTitle: c.title || null });
+      }
+    } catch (e) {
+      log(`  [discovery] candidate ${c.url} failed: ${e.message.slice(0, 80)}`);
+    }
+  }
+
+  if (extractions.length === 0) {
+    log('  [discovery] no extractions');
+    return null;
+  }
+
+  const cluster = clusterDates(extractions);
+  if (!cluster) {
+    log('  [discovery] extractions present but no high-confidence cluster');
+    return null;
+  }
+  return {
+    date: cluster.centerDate,
+    sources: cluster.cluster.map(c => ({ url: c.sourceUrl, title: c.sourceTitle, quote: c.quote })),
+    extractions,
+  };
+}
+
+module.exports = {
+  discoverAnnouncedClosingDate,
+  // exported for tests
+  parseExtraction,
+  clusterDates,
+  isCredibleUrl,
+  CREDIBLE_HOSTS,
+};


### PR DESCRIPTION
## Summary
- New `scripts/lib/closing-date-discovery.js`: SERPs credible theater press, LLM-extracts dates via Claude Sonnet, requires ≥2 high-confidence agreements within ±3 days.
- `scripts/audit-closing-dates.js`: when broadway.com schedule + press cluster agree within ±7 days, auto-apply the new closingDate. Mismatches logged as tripleSignalConflict. Capped at 10 attempts/run.
- `ANTHROPIC_API_KEY` wired into workflow env.

## Verified live today
- Death Becomes Her: 4 credible sources agree on 2026-06-28 → would auto-apply (matches yesterday's manual fix).
- Operation Mincemeat: discovery returns 2027-02-14 vs broadway.com cutoff 2026-10-25 (112d delta) → would NOT auto-apply. False-positive shield holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)