### PR TITLE
audit-closing-dates: fix ship-check P0/P1 findings

### DIFF
--- a/.github/workflows/audit-closing-dates.yml
+++ b/.github/workflows/audit-closing-dates.yml
@@ -52,6 +52,18 @@ jobs:
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
 
+      - name: Snapshot pre-audit closingDates (rollback baseline)
+        run: |
+          node -e "
+            const fs = require('fs');
+            const path = require('path');
+            const shows = JSON.parse(fs.readFileSync('data/shows.json','utf8')).shows;
+            const snap = Object.fromEntries(shows.map(s => [s.id, s.closingDate || null]));
+            fs.mkdirSync('data/audit', { recursive: true });
+            fs.writeFileSync('data/audit/closing-date-pre-audit.json', JSON.stringify({ takenAt: new Date().toISOString(), closingDates: snap }, null, 2));
+            console.log('Snapshot: ' + Object.keys(snap).length + ' shows');
+          "
+
       - name: Run closing-date audit
         env:
           BRIGHTDATA_TOKEN: ${{ secrets.BRIGHTDATA_TOKEN }}
@@ -67,15 +79,35 @@ jobs:
             node scripts/audit-closing-dates.js
           fi
 
+      - name: Validate shows.json before push (rollback on failure)
+        id: validate
+        run: |
+          # If the audit corrupted shows.json (bad JSON, missing required
+          # fields, duplicates), restore the unmodified core-data copy from
+          # /tmp/core-data-checkout/ and exit non-zero. push step is gated
+          # on this step succeeding (see `if: success()` below), so a failed
+          # validation skips the push entirely — the next run starts from a
+          # clean baseline.
+          if ! node scripts/validate-data.js 2>&1 | tail -30; then
+            echo "::error::validate-data.js failed after audit — reverting shows.json"
+            if [ -f /tmp/core-data-checkout/shows.json ]; then
+              cp -f /tmp/core-data-checkout/shows.json data/shows.json
+              echo "Restored data/shows.json from /tmp/core-data-checkout/"
+            fi
+            exit 1
+          fi
+
+      # Push runs only when validation passed. Was `if: always()` previously,
+      # which would have pushed bad data on validation failure.
       - name: Push core data to private repo
-        if: always()
+        if: success()
         uses: ./.github/actions/push-core-data
         with:
           token: ${{ secrets.REVIEW_TEXTS_TOKEN }}
           message: 'data: Update from audit-closing-dates'
 
       - name: Dispatch deploy
-        if: always()
+        if: success()
         uses: ./.github/actions/dispatch-deploy
 
       - name: Create summary

--- a/scripts/audit-closing-dates.js
+++ b/scripts/audit-closing-dates.js
@@ -301,15 +301,22 @@ async function main() {
   // the most-urgent retractions (closing soonest) get the auto-fix budget.
   const autoFixedTripleSignal = [];
   if (process.env.ANTHROPIC_API_KEY && ambiguous.length > 0) {
+    // Run discovery for BOTH earlier-than-stored (NEEDS_HUMAN_REVIEW) and
+    // suspicious-large-jump extensions (EXTENSION_EXCEEDS_CAP_NEEDS_REVIEW) —
+    // a real 200-day extension shouldn't be locked out of the LLM rescue path.
     const byUrgency = ambiguous
-      .filter(a => a.action === 'NEEDS_HUMAN_REVIEW')  // earlier-than-stored only; never the extension-cap path
+      .filter(a => a.action === 'NEEDS_HUMAN_REVIEW' || a.action === 'EXTENSION_EXCEEDS_CAP_NEEDS_REVIEW')
       .sort((a, b) => new Date(a.stored) - new Date(b.stored))
       .slice(0, MAX_TRIPLE_SIGNAL_ATTEMPTS);
     console.log(`\nTriple-signal auto-fix: attempting ${byUrgency.length} ambiguous show(s)`);
     for (const a of byUrgency) {
       const show = candidates.find(c => c.id === a.id);
       if (!show) continue;
-      const showTitle = show.title || show.name || a.id;
+      // Title-field consistency: rest of the file uses show.name, fall through
+      // to show.title only if name is missing. shows.json schema uses `title`,
+      // but the audit script normalized to `name` earlier — use both as a
+      // safety net.
+      const showTitle = show.name || show.title || a.id;
       let discovery;
       try {
         discovery = await discoverAnnouncedClosingDate(showTitle, { log: (msg) => console.log(msg) });
@@ -336,13 +343,24 @@ async function main() {
       // is ambiguous). Auto-apply the press date — it's the authoritative
       // announcement; broadway.com schedule is just the lower-bound proof.
       const newDate = discovery.date;
-      if (!DRY_RUN) {
-        const targetShow = data.shows.find(s => s.id === a.id);
-        if (targetShow) {
-          targetShow.closingDate = newDate;
-          targetShow.closingDateSource = `triple-signal audit (${TODAY}): broadway.com + ${discovery.sources[0].url}`;
-          targetShow.closingDateUpdatedAt = TODAY;
-        }
+      const targetShow = !DRY_RUN ? data.shows.find(s => s.id === a.id) : null;
+      if (!DRY_RUN && !targetShow) {
+        // Found in `candidates` but missing in `data.shows`: this means the
+        // arrays diverged (concurrent reformat, hot-rebuild). Don't claim
+        // we fixed it; log and surface to Notion review.
+        console.warn(`  [auto-fix] ${a.id}: in candidates but not data.shows — skipping write`);
+        a.tripleSignalWriteFailed = { reason: 'target_not_in_data_shows', newDate };
+        continue;
+      }
+      if (targetShow) {
+        targetShow.closingDate = newDate;
+        // Cite ALL corroborating sources, not just the first — preserves
+        // the audit trail when reviewing a wrong auto-fix later.
+        const sourceList = discovery.sources.map(s => s.url).join(', ');
+        targetShow.closingDateSource = `triple-signal audit (${TODAY}): broadway.com + ${sourceList}`;
+        targetShow.closingDateUpdatedAt = TODAY;
+        // Record what we replaced — single field to roll back from.
+        targetShow.closingDatePrevious = a.stored;
       }
       autoFixedTripleSignal.push({
         id: a.id,

--- a/scripts/lib/closing-date-discovery.js
+++ b/scripts/lib/closing-date-discovery.js
@@ -91,7 +91,7 @@ Rules:
 - If the date is ambiguous, a range, conditional, or not present, return {"date": null, "confidence": "low", "quote": null}.`;
 }
 
-function parseExtraction(raw) {
+function parseExtraction(raw, opts = {}) {
   if (!raw) return null;
   // Trim code fences if model added them
   const cleaned = raw.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/, '').trim();
@@ -100,10 +100,40 @@ function parseExtraction(raw) {
     if (!j || typeof j !== 'object') return null;
     if (j.date && !/^\d{4}-\d{2}-\d{2}$/.test(j.date)) return null;
     if (!['high', 'medium', 'low'].includes(j.confidence)) return null;
+    // Year-sanity: reject extractions outside [TODAY - 6 months, TODAY + 3 years].
+    // A 1998 revival article that says "closing 1998-10-04" would otherwise pass
+    // the regex check and could cluster with another wrong-production article.
+    // The actual future-close window for an open Broadway show is at most ~3 years
+    // (Operation Mincemeat's 9 extensions stretched to ~2 years out).
+    if (j.date) {
+      const dt = new Date(j.date);
+      const now = opts.now || new Date();
+      const minDate = new Date(now.getTime() - 180 * 86400000);
+      const maxDate = new Date(now.getTime() + 1095 * 86400000);
+      if (dt < minDate || dt > maxDate) return null;
+    }
     return { date: j.date || null, confidence: j.confidence, quote: j.quote || null };
   } catch {
     return null;
   }
+}
+
+// Stronger show-name guard against same-title revivals: the article body must
+// mention at least one ≥4-char word from the show title. Mirrors
+// pageMatchesShow() in scripts/audit-closing-dates.js. Without this, a 1998
+// "Cabaret" revival article could be matched to the 2024 production.
+function pageMatchesShowTitle(text, showTitle) {
+  if (!text || !showTitle) return false;
+  const haystack = text.toLowerCase();
+  const words = showTitle.toLowerCase().split(/[^a-z0-9]+/).filter(w => w.length >= 4);
+  if (words.length === 0) {
+    // Single-syllable / very short title (e.g., "Job"): fall back to any
+    // alphanumeric token match — but require it to be present as a whole word,
+    // not a substring (so "Job" doesn't match "Jobs" or "jobbers").
+    const tokens = showTitle.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+    return tokens.some(t => new RegExp(`\\b${t}\\b`).test(haystack));
+  }
+  return words.some(w => haystack.includes(w));
 }
 
 function stripHtml(html) {
@@ -116,29 +146,47 @@ function stripHtml(html) {
 }
 
 // Cluster dates by proximity: returns the date with the most agreements
-// within ±CLUSTER_TOLERANCE_DAYS, plus the contributing sources.
+// within ±CLUSTER_TOLERANCE_DAYS, plus the contributing sources. Tie-broken
+// by distinct-host count (more independent publishers > more agreeing
+// articles from one publisher) — without this, two stale republications
+// of one wire story would beat a single fresh primary report.
+function hostOf(url) {
+  try { return new URL(url).hostname.replace(/^www\./, ''); }
+  catch { return ''; }
+}
+
 function clusterDates(extractions) {
   if (extractions.length === 0) return null;
   const dated = extractions.filter(e => e.date && e.confidence === 'high');
   if (dated.length === 0) return null;
 
   let best = null;
+  let bestDistinctHosts = 0;
   for (let i = 0; i < dated.length; i++) {
     const center = new Date(dated[i].date);
     const cluster = dated.filter(e => {
       const d = new Date(e.date);
       return Math.abs((d - center) / 86400000) <= CLUSTER_TOLERANCE_DAYS;
     });
-    if (!best || cluster.length > best.cluster.length) {
+    const distinctHosts = new Set(cluster.map(c => hostOf(c.sourceUrl))).size;
+    // Prefer the cluster with more members; tie-break by more distinct hosts.
+    if (!best
+      || cluster.length > best.cluster.length
+      || (cluster.length === best.cluster.length && distinctHosts > bestDistinctHosts)
+    ) {
       best = { centerDate: dated[i].date, cluster };
+      bestDistinctHosts = distinctHosts;
     }
   }
   // Single-source acceptance ONLY if the extraction has both a date and a
-  // quote with "final performance" language — bounds the
-  // "one hallucinated article wrong-corrects the show" failure mode.
+  // quote with "final performance" / closure-verb language. Bounds the
+  // "one hallucinated article wrong-corrects the show" failure mode. The
+  // regex is broader than the original to catch real announcement language
+  // ("ends its run", "shutters", "last show", "wraps") without admitting
+  // generic phrasing.
   if (best.cluster.length === 1) {
     const q = (best.cluster[0].quote || '').toLowerCase();
-    if (!/final performance|closing on|last performance/.test(q)) return null;
+    if (!/final performance|closing on|last performance|ends? its run on|ends? on|wraps? (?:its run )?on|shutters? on|will close on|to close on|last show on/.test(q)) return null;
   }
   return best;
 }
@@ -177,9 +225,12 @@ async function discoverAnnouncedClosingDate(showTitle, opts = {}) {
     try {
       const page = await fetchPage(c.url, { source: 'audit-closing-dates' });
       if (!page || !page.content) continue;
-      const text = stripHtml(page.content).slice(0, 4000);
-      // Reject if the body doesn't even mention the show name
-      if (!text.toLowerCase().includes(showTitle.toLowerCase().split(/[^a-z0-9]/i)[0])) continue;
+      // Use a wider window for the show-name guard than the LLM prompt — the
+      // show name often appears in the article body but past the first 4000
+      // chars on press sites with heavy nav/promo headers.
+      const fullText = stripHtml(page.content);
+      if (!pageMatchesShowTitle(fullText.slice(0, 12000), showTitle)) continue;
+      const text = fullText.slice(0, 4000);
       const raw = await callClaudeSonnet(buildExtractionPrompt(showTitle, text, c.url));
       const parsed = parseExtraction(raw);
       if (parsed) {
@@ -213,5 +264,6 @@ module.exports = {
   parseExtraction,
   clusterDates,
   isCredibleUrl,
+  pageMatchesShowTitle,
   CREDIBLE_HOSTS,
 };


### PR DESCRIPTION
## Summary
- Stronger show-name guard (≥4-char-word match, mirrors `audit-closing-dates.js:104`) — closes the same-title-revival hole (Cabaret/Chicago/Gypsy)
- Year-sanity in `parseExtraction()` — rejects dates outside [TODAY-180d, TODAY+3y]
- `validate-data.js` gate + workspace rollback path; push gated on `if: success()`
- Multi-source `closingDateSource`; `closingDatePrevious` rollback anchor
- `clusterDates` tie-broken by distinct-host count; broader single-source quote regex
- `EXTENSION_EXCEEDS_CAP` now eligible for triple-signal rescue

## Test plan
- 18 unit cases covering year-sanity, pageMatchesShowTitle, clusterDates tie-break, broader quote regex — all passing locally
- Live verification of `discoverAnnouncedClosingDate('Death Becomes Her')` and `('Operation Mincemeat')` already proved triple-signal returns correct dates in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)