### PR TITLE
audit-closing-dates: self-cleaning ambiguousAllowlist

### DIFF
--- a/data/closing-date-audit-config.json
+++ b/data/closing-date-audit-config.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Config for scripts/audit-closing-dates.js. Edited by hand; not auto-generated. Established pattern (cf. data/dtli-slug-map.json).",
-  "_lastUpdated": "2026-05-14",
+  "_lastUpdated": "2026-05-24",
   "slugOverrides": {
     "_comment": "show.id → broadway.com slug, when stripping the year suffix from id doesn't produce the URL broadway.com actually uses. Probe via curl https://www.broadway.com/shows/{slug}/schedule/. Verified 2026-05-14.",
     "and-juliet-2022": "juliet",
@@ -24,5 +24,25 @@
       "maybe-happy-ending-2024",
       "the-lost-boys-2026"
     ]
+  },
+  "ambiguousAllowlist": {
+    "_comment": "Shows where stored closingDate is human-verified correct but broadway.com's ~5-month schedule window cuts off earlier. Audit treats these as MATCH (not AMBIGUOUS) as long as stored matches the verifiedStored value. If the show extends/retracts, stored diverges from verifiedStored → entry auto-bypassed → normal ambiguous path resumes. Add an entry after manually confirming via Variety/Playbill/Deadline that the stored date is the announced final performance.",
+    "entries": {
+      "operation-mincemeat-2025": {
+        "verifiedStored": "2027-02-14",
+        "verifiedAt": "2026-05-24",
+        "source": "Broadway.com Buzz 2026-05-12: 9th extension through Feb 14 2027 (https://www.broadway.com/buzz/207124/)"
+      },
+      "oh-mary-2024": {
+        "verifiedStored": "2027-01-03",
+        "verifiedAt": "2026-05-24",
+        "source": "Broadway.com / IBDB / Broadway League confirm Jan 3 2027 close at Lyceum"
+      },
+      "schmigadoon-2026": {
+        "verifiedStored": "2027-01-03",
+        "verifiedAt": "2026-05-24",
+        "source": "Deadline 2026-05: 17-week extension post-12-Tony-noms to Jan 3 2027 (https://deadline.com/2026/05/schmigadoon-broadway-closing-date-1236885280/)"
+      }
+    }
   }
 }

--- a/scripts/audit-closing-dates.js
+++ b/scripts/audit-closing-dates.js
@@ -77,6 +77,17 @@ const MAX_TRIPLE_SIGNAL_ATTEMPTS = 10;
 const CONFIG = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
 const SLUG_OVERRIDES = CONFIG.slugOverrides;
 const OPEN_RUN_SKIP = new Set(CONFIG.openRunSkip.ids);
+// Self-cleaning allowlist for known calendar-window-short false positives.
+// Entry honored only while stored closingDate still matches verifiedStored —
+// any drift (extension or retraction) bypasses the allowlist and the show
+// re-enters the normal ambiguous-flagging path.
+const AMBIGUOUS_ALLOWLIST = (CONFIG.ambiguousAllowlist && CONFIG.ambiguousAllowlist.entries) || {};
+
+function isAllowlisted(showId, storedClosingDate) {
+  const entry = AMBIGUOUS_ALLOWLIST[showId];
+  if (!entry || !storedClosingDate) return false;
+  return entry.verifiedStored === storedClosingDate;
+}
 
 function slugFor(s) {
   if (SLUG_OVERRIDES[s.id]) return SLUG_OVERRIDES[s.id];
@@ -284,7 +295,17 @@ async function main() {
         // window short, stored is the real future close; (b) show actually
         // closing earlier than announced. We can't tell from this signal
         // alone — flag for human review.
-        ambiguous.push({ ...verdict, delta, action: 'NEEDS_HUMAN_REVIEW' });
+        //
+        // Allowlist short-circuit: if the show is human-verified-correct in
+        // data/closing-date-audit-config.json AND stored still matches the
+        // verified value, treat as a silent match. Drift (extension or
+        // retraction) makes the stored date diverge from verifiedStored,
+        // which bypasses this branch and resumes ambiguous flagging.
+        if (isAllowlisted(show.id, stored)) {
+          matches.push({ ...verdict, delta, allowlistedFalsePositive: true });
+        } else {
+          ambiguous.push({ ...verdict, delta, action: 'NEEDS_HUMAN_REVIEW' });
+        }
       } else {
         matches.push({ ...verdict, delta });
       }


### PR DESCRIPTION
Suppresses repeat Notion cards for 3 human-verified-correct shows (Op Mincemeat / Oh Mary / Schmigadoon) where broadway.com's short calendar window made them flag ambiguous daily. Self-cleaning: any drift in stored closingDate bypasses the allowlist and resumes normal ambiguous flagging.

15/15 inline tests pass (9 unit + 5 integration + Beaches-style real retraction still catches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)