### PR TITLE
closing-date-guard: protect humanCorrectedClosingDate

### DIFF
--- a/.github/actions/push-core-data/action.yml
+++ b/.github/actions/push-core-data/action.yml
@@ -180,6 +180,11 @@ runs:
           # date corrections (e.g. enrich-west-end-dates, the new OB equivalent)
           # silently lost their work on rebase races. See KENREX 2026-04-28 root
           # cause and memory/feedback_off_broadway_opening_date_gap.md.
+          # humanCorrectedClosingDate added 2026-05-24 — when a human manually
+          # fixes a closingDate via the private repo, the flag tells all auto-
+          # writers to skip. Reconciling it here means a concurrent push by an
+          # auto-writer can't drop the flag on rebase. See
+          # scripts/lib/closing-date-guard.js.
           if [ -f "/tmp/remote-shows.json" ] && [ -f "shows.json" ]; then
             node -e '
               const fs = require("fs");
@@ -188,6 +193,7 @@ runs:
                 "venue", "synopsis", "runtime", "intermissions", "ageRecommendation",
                 "officialUrl", "wikipediaUrl", "ibdbUrl",
                 "openingDate", "previewsStartDate", "openingDateSource",
+                "humanCorrectedClosingDate",
               ]);
               try {
                 const local = JSON.parse(fs.readFileSync("shows.json", "utf8"));

--- a/scripts/audit-closing-dates.js
+++ b/scripts/audit-closing-dates.js
@@ -46,6 +46,7 @@ const fs = require('fs');
 const path = require('path');
 const { fetchPage, cleanup } = require('./lib/scraper');
 const { discoverAnnouncedClosingDate } = require('./lib/closing-date-discovery');
+const { writeClosingDate, canWriteClosingDate } = require('./lib/closing-date-guard');
 
 const SHOWS_FILE = path.join(__dirname, '..', 'data', 'shows.json');
 const AUDIT_FILE = path.join(__dirname, '..', 'data', 'audit', 'closing-date-discrepancies.json');
@@ -273,11 +274,15 @@ async function main() {
         // (unrelated date on the page). Surface to human instead of auto-applying.
         ambiguous.push({ ...verdict, delta, action: 'EXTENSION_EXCEEDS_CAP_NEEDS_REVIEW' });
       } else if (delta > 0) {
-        extensions.push({ ...verdict, delta, action: 'EXTENSION' });
-        if (!DRY_RUN) {
-          show.closingDate = r.latest;
-          show.closingDateSource = `broadway.com schedule (audit ${TODAY})`;
-          show.closingDateUpdatedAt = TODAY;
+        if (!canWriteClosingDate(show)) {
+          // Human override in effect — log the extension finding but don't write.
+          // The audit report still records it for transparency.
+          extensions.push({ ...verdict, delta, action: 'EXTENSION_HUMAN_PROTECTED', skipped: true });
+        } else {
+          extensions.push({ ...verdict, delta, action: 'EXTENSION' });
+          if (!DRY_RUN) {
+            writeClosingDate(show, r.latest, `broadway.com schedule (audit ${TODAY})`, { todayStr: TODAY });
+          }
         }
       } else if (delta < 0 && Math.abs(delta) > AMBIGUOUS_DELTA_THRESHOLD_DAYS) {
         // Schedule ends earlier than stored. Could be: (a) calendar
@@ -353,14 +358,19 @@ async function main() {
         continue;
       }
       if (targetShow) {
-        targetShow.closingDate = newDate;
+        if (!canWriteClosingDate(targetShow)) {
+          console.warn(`  [auto-fix] ${a.id}: humanCorrectedClosingDate=true — skipping triple-signal write`);
+          a.tripleSignalWriteFailed = { reason: 'humanCorrectedClosingDate', newDate };
+          continue;
+        }
+        // Record what we replaced BEFORE overwriting — single field to roll back from.
+        targetShow.closingDatePrevious = a.stored;
         // Cite ALL corroborating sources, not just the first — preserves
         // the audit trail when reviewing a wrong auto-fix later.
         const sourceList = discovery.sources.map(s => s.url).join(', ');
-        targetShow.closingDateSource = `triple-signal audit (${TODAY}): broadway.com + ${sourceList}`;
-        targetShow.closingDateUpdatedAt = TODAY;
-        // Record what we replaced — single field to roll back from.
-        targetShow.closingDatePrevious = a.stored;
+        writeClosingDate(targetShow, newDate,
+          `triple-signal audit (${TODAY}): broadway.com + ${sourceList}`,
+          { todayStr: TODAY });
       }
       autoFixedTripleSignal.push({
         id: a.id,

--- a/scripts/enrich-ob-dates-from-showscore.js
+++ b/scripts/enrich-ob-dates-from-showscore.js
@@ -14,6 +14,7 @@ const fs = require('fs');
 const path = require('path');
 const { fetchPage, cleanup } = require('./lib/scraper');
 const { extractStatusFromHtml } = require('./lib/show-score-status');
+const { writeClosingDate, canWriteClosingDate } = require('./lib/closing-date-guard');
 
 const SHOWS_PATH = path.join(__dirname, '..', 'data', 'shows.json');
 const URLS_PATH = path.join(__dirname, '..', 'data', 'show-score-urls.json');
@@ -105,9 +106,9 @@ async function main() {
     }
 
     // Closing date
-    if (ssData.closingDate && !show.closingDate) {
+    if (ssData.closingDate && !show.closingDate && canWriteClosingDate(show)) {
       changes.push(`closingDate: null → ${ssData.closingDate}`);
-      if (!dryRun) show.closingDate = ssData.closingDate;
+      if (!dryRun) writeClosingDate(show, ssData.closingDate, 'ShowScore "Ends" date (OB enrichment)');
       dateCorrections++;
     }
 

--- a/scripts/enrich-wikipedia-runtimes.js
+++ b/scripts/enrich-wikipedia-runtimes.js
@@ -14,6 +14,7 @@ const fs = require('fs');
 const path = require('path');
 const https = require('https');
 const { cleanSearchTitle } = require('./lib/title-normalization');
+const { writeClosingDate, canWriteClosingDate } = require('./lib/closing-date-guard');
 
 const SHOWS_PATH = path.join(__dirname, '..', 'data', 'shows.json');
 const DRY_RUN = process.argv.includes('--dry-run');
@@ -320,8 +321,8 @@ async function main() {
       parts.push(`opening=${dates.openingDate}`);
       dateUpdated = true;
     }
-    if (dates.closingDate && !show.closingDate && isDatePlausible(dates.closingDate, show)) {
-      if (!DRY_RUN) show.closingDate = dates.closingDate;
+    if (dates.closingDate && !show.closingDate && isDatePlausible(dates.closingDate, show) && canWriteClosingDate(show)) {
+      if (!DRY_RUN) writeClosingDate(show, dates.closingDate, 'Wikipedia infobox');
       parts.push(`closing=${dates.closingDate}`);
       dateUpdated = true;
     }

--- a/scripts/lib/closing-date-guard.js
+++ b/scripts/lib/closing-date-guard.js
@@ -1,0 +1,65 @@
+/**
+ * closing-date-guard.js
+ *
+ * Centralized write-guard for `closingDate` on shows.json entries. Any script
+ * that programmatically updates a show's closingDate MUST call
+ * `writeClosingDate(show, newDate, source)` instead of mutating the field
+ * directly. The guard skips the write when `humanCorrectedClosingDate === true`
+ * is set on the show.
+ *
+ * Pattern mirrors review-text protection (humanReviewedWrongProduction,
+ * humanReviewScore, wrongProductionManualClear) — see
+ * memory/feedback_protected_fields_every_write.md for the original rule.
+ *
+ * Why this exists:
+ *   closingDate has 8+ writers (update-show-status, audit-closing-dates,
+ *   enrich-ob-dates, enrich-wikipedia-runtimes, fix-show-statuses,
+ *   discover-new-shows, discover-historical-shows, ibdb-dates). When a human
+ *   manually corrects a closingDate via the private repo (as we did for
+ *   Death Becomes Her and Beaches on 2026-05-23), any of the auto-writers
+ *   can overwrite it on the next run. This guard is the single chokepoint.
+ *
+ * Bypass: pass `{ force: true }` as the third arg. Reserved for explicitly-
+ * manual scripts like fix-show-statuses.js where the operator IS the human
+ * correcting the field.
+ */
+
+/**
+ * Returns true if it is safe to programmatically write closingDate on this
+ * show. False means a human-correction guard is set and the auto-write
+ * should be skipped (callers should log + continue).
+ */
+function canWriteClosingDate(show) {
+  if (!show) return false;
+  return show.humanCorrectedClosingDate !== true;
+}
+
+/**
+ * Write a new closingDate, respecting the human-correction guard.
+ *
+ * @param {object} show - shows.json entry (mutated in place if write occurs)
+ * @param {string|null} newDate - 'YYYY-MM-DD' or null to clear
+ * @param {string} source - audit trail string (e.g. 'broadway.com schedule (audit 2026-05-24)')
+ * @param {object} [opts]
+ * @param {boolean} [opts.force=false] - bypass the human-correction guard. ONLY for explicitly-manual scripts.
+ * @param {(msg: string) => void} [opts.log=console.log] - log function
+ * @param {string} [opts.todayStr] - YYYY-MM-DD for closingDateUpdatedAt; defaults to today
+ * @returns {boolean} - true if the write occurred, false if blocked by guard
+ */
+function writeClosingDate(show, newDate, source, opts = {}) {
+  const log = opts.log || console.log;
+  if (!show) return false;
+  if (!opts.force && !canWriteClosingDate(show)) {
+    log(`[closing-date-guard] skipping write to ${show.id || '(unknown)'}: humanCorrectedClosingDate=true (preserving ${show.closingDate})`);
+    return false;
+  }
+  show.closingDate = newDate;
+  if (source) show.closingDateSource = source;
+  show.closingDateUpdatedAt = opts.todayStr || new Date().toISOString().slice(0, 10);
+  return true;
+}
+
+module.exports = {
+  canWriteClosingDate,
+  writeClosingDate,
+};

--- a/scripts/update-show-status.js
+++ b/scripts/update-show-status.js
@@ -19,6 +19,7 @@ const fs = require('fs');
 const path = require('path');
 const https = require('https');
 const { extractStatusFromHtml } = require('./lib/show-score-status');
+const { writeClosingDate, canWriteClosingDate } = require('./lib/closing-date-guard');
 
 const SHOWS_FILE = path.join(__dirname, '..', 'data', 'shows.json');
 const URLS_FILE = path.join(__dirname, '..', 'data', 'show-score-urls.json');
@@ -209,8 +210,11 @@ async function refreshTodayTixDates(data, updates) {
               console.log(`  🔄 ${closedMatch.title}: TodayTix (id=${ttShow.id}) still lists this show — reopening (was closed with closingDate=${oldClosingDate})`);
               if (!dryRun) {
                 closedMatch.status = 'open';
-                if (ttEndDate) closedMatch.closingDate = ttEndDate;
-                else delete closedMatch.closingDate;
+                if (ttEndDate) {
+                  writeClosingDate(closedMatch, ttEndDate, `update-show-status reopen (${new Date().toISOString().slice(0,10)})`);
+                } else if (canWriteClosingDate(closedMatch)) {
+                  delete closedMatch.closingDate;
+                }
               }
               reopenedIds.add(closedMatch.id);
               updates.push({
@@ -240,36 +244,46 @@ async function refreshTodayTixDates(data, updates) {
         // Compare dates: only update if TodayTix date is LATER (extension)
         if (match.closingDate && ttEndDate > match.closingDate) {
           const oldDate = match.closingDate;
-          console.log(`  📅 ${match.title}: closing date extended ${oldDate} → ${ttEndDate}`);
-          if (!dryRun) {
-            match.closingDate = ttEndDate;
-          }
-          updates.push({
-            id: match.id,
-            title: match.title,
-            changes: {
-              closingDate: { from: oldDate, to: ttEndDate },
-              note: `Extension detected via TodayTix (${loc.label})`
+          if (!canWriteClosingDate(match)) {
+            console.log(`  🔒 ${match.title}: humanCorrectedClosingDate=true — skipping TodayTix extension ${oldDate} → ${ttEndDate}`);
+          } else {
+            console.log(`  📅 ${match.title}: closing date extended ${oldDate} → ${ttEndDate}`);
+            if (!dryRun) {
+              writeClosingDate(match, ttEndDate, `TodayTix (${loc.label})`);
             }
-          });
-          dateUpdates++;
+            updates.push({
+              id: match.id,
+              title: match.title,
+              changes: {
+                closingDate: { from: oldDate, to: ttEndDate },
+                note: `Extension detected via TodayTix (${loc.label})`
+              }
+            });
+            dateUpdates++;
+          }
         }
 
         // Also set closingDate if we had none and TodayTix has one
         if (!match.closingDate && ttEndDate) {
-          console.log(`  📅 ${match.title}: closing date added ${ttEndDate} (was unknown)`);
-          if (!dryRun) {
-            match.closingDate = ttEndDate;
-          }
-          updates.push({
-            id: match.id,
-            title: match.title,
-            changes: {
-              closingDate: { from: 'none', to: ttEndDate },
-              note: `Closing date discovered via TodayTix (${loc.label})`
+          if (!canWriteClosingDate(match)) {
+            // Show has humanCorrectedClosingDate=true but no closingDate — bizarre,
+            // but respect the human flag and don't write.
+            console.log(`  🔒 ${match.title}: humanCorrectedClosingDate=true but stored closingDate is empty — skipping`);
+          } else {
+            console.log(`  📅 ${match.title}: closing date added ${ttEndDate} (was unknown)`);
+            if (!dryRun) {
+              writeClosingDate(match, ttEndDate, `TodayTix (${loc.label}) — discovered`);
             }
-          });
-          dateUpdates++;
+            updates.push({
+              id: match.id,
+              title: match.title,
+              changes: {
+                closingDate: { from: 'none', to: ttEndDate },
+                note: `Closing date discovered via TodayTix (${loc.label})`
+              }
+            });
+            dateUpdates++;
+          }
         }
       }
     } catch (err) {
@@ -504,14 +518,18 @@ async function refreshShowScoreStatuses(data, updates, ttActiveIds) {
 
     // Fill closing date gap
     if (ssData.closingDate && !show.closingDate) {
-      changes.push({
-        field: 'closingDate',
-        from: 'null',
-        to: ssData.closingDate,
-        note: `ShowScore "Ends" date`
-      });
-      if (!dryRun) show.closingDate = ssData.closingDate;
-      dateUpdates++;
+      if (!canWriteClosingDate(show)) {
+        // Human-protected with no stored closingDate — respect the flag, don't fill.
+      } else {
+        changes.push({
+          field: 'closingDate',
+          from: 'null',
+          to: ssData.closingDate,
+          note: `ShowScore "Ends" date`
+        });
+        if (!dryRun) writeClosingDate(show, ssData.closingDate, 'ShowScore "Ends" date');
+        dateUpdates++;
+      }
     }
 
     // Fill venue gap


### PR DESCRIPTION
## Summary
- New `scripts/lib/closing-date-guard.js` (canWriteClosingDate, writeClosingDate)
- 4 auto-writers wired (update-show-status × 4 paths, audit-closing-dates × 2 paths, enrich-ob-dates, enrich-wikipedia-runtimes)
- push-core-data RECONCILABLE safelist gets humanCorrectedClosingDate so the flag survives rebase races
- DBH + Beaches backfilled with the flag in private repo (fb5d6f41)

## Test plan
- 12/12 inline guard tests pass (matrix of guard states + force-bypass)
- Will be live-verified by tomorrow's audit run — protected shows won't appear in EXTENSION/AUTO buckets

🤖 Generated with [Claude Code](https://claude.com/claude-code)