### PR TITLE
audit-opening-dates: extend triple-signal pattern to opening + previews-start

### DIFF
--- a/.github/workflows/audit-opening-dates.yml
+++ b/.github/workflows/audit-opening-dates.yml
@@ -1,0 +1,99 @@
+name: Audit Opening Dates
+
+# Daily LLM press-cluster audit for openingDate + previewsStartDate drift.
+# Suggestion-only — no auto-mutation of shows.json. Findings route to a
+# Notion card; human verifies + updates the private repo.
+#
+# Why a separate workflow from audit-closing-dates: different field-types,
+# different cost profile (~$2/run vs ~$0.50), and we want to stagger the
+# cron so they don't both fire at the same minute. See
+# scripts/audit-opening-dates.js for design rationale.
+
+on:
+  schedule:
+    - cron: '0 15 * * *'  # Daily 15:00 UTC — 1h after closing-date audit (14:00 UTC)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (no Notion card)'
+        required: false
+        default: 'false'
+
+# Read-only on shows.json — no concurrency group needed, but match the
+# closing-date audit pattern so both audits share a Notion card slot.
+concurrency:
+  group: opening-date-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout core data
+        uses: ./.github/actions/checkout-core-data
+        with:
+          token: ${{ secrets.REVIEW_TEXTS_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+
+      - name: Run opening-date audit
+        env:
+          BRIGHTDATA_TOKEN: ${{ secrets.BRIGHTDATA_TOKEN }}
+          BRIGHTDATA_ZONE: ${{ secrets.BRIGHTDATA_ZONE }}
+          SCRAPINGBEE_API_KEY: ${{ secrets.SCRAPINGBEE_API_KEY }}
+          NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            node scripts/audit-opening-dates.js --dry-run
+          else
+            node scripts/audit-opening-dates.js
+          fi
+
+      - name: Create summary
+        if: always()
+        run: |
+          if [ -f data/audit/opening-date-discrepancies.json ]; then
+            echo "## Opening Date Audit" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            node -e "
+              const r = require('./data/audit/opening-date-discrepancies.json');
+              const s = r.summary;
+              const lines = [
+                '**Mode:** ' + r.mode,
+                '**Audited:** ' + s.audited,
+                '**Flagged:** ' + s.flagged,
+                '**Matches:** ' + s.matches,
+                '**Errors:** ' + s.errors,
+              ];
+              console.log(lines.join('\\n'));
+              if (r.flagged.length) {
+                console.log('\\n### Flagged for review');
+                r.flagged.forEach(f => console.log('- ' + f.id + ': stored ' + f.fieldType + '=' + (f.stored||'null') + ' vs press ' + f.discovered.date));
+              }
+            " >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure
+        with:
+          title: 'Audit Opening Dates Failed'
+          severity: 'warning'

--- a/scripts/audit-opening-dates.js
+++ b/scripts/audit-opening-dates.js
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/**
+ * audit-opening-dates.js
+ *
+ * Daily audit of `openingDate` and `previewsStartDate` for shows that
+ * haven't opened yet. Detects drift via the LLM-extracted press cluster
+ * pattern (see scripts/lib/closing-date-discovery.js).
+ *
+ * IMPORTANT — this audit is suggestion-only, NOT auto-applying.
+ * The closing-date triple-signal had broadway.com schedule as a second
+ * independent signal (calendar pages don't lie about future performances).
+ * Opening/preview dates have no equivalent. Without a second signal, the
+ * audit routes findings to Notion for human review only. No mutation of
+ * shows.json.
+ *
+ * Eligibility:
+ *   - status='previews' OR status='open' AND openingDate within ±30 days
+ *     of today (i.e., either about to open, or just opened — both windows
+ *     where a delay/correction is operationally relevant for the
+ *     opening-night-orchestrator and broadcast workflows).
+ *   - Skips shows in openRunSkip + ambiguousAllowlist (reuses the closing
+ *     audit's config — same set of long-runners broadway.com can't see).
+ *
+ * Discovery:
+ *   - For each eligible show, call discoverAnnouncedDate(title, 'opening')
+ *     and discoverAnnouncedDate(title, 'previews-start').
+ *   - When either returns a date != stored, flag as ambiguous.
+ *
+ * Output:
+ *   - data/audit/opening-date-discrepancies.json
+ *   - Notion card per run (dedup against open card with same prefix)
+ *
+ * Usage:
+ *   node scripts/audit-opening-dates.js [--dry-run] [--shows=id1,id2]
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { discoverAnnouncedDate } = require('./lib/closing-date-discovery');
+const { cleanup } = require('./lib/scraper');
+
+const SHOWS_FILE = path.join(__dirname, '..', 'data', 'shows.json');
+const AUDIT_FILE = path.join(__dirname, '..', 'data', 'audit', 'opening-date-discrepancies.json');
+const CONFIG_FILE = path.join(__dirname, '..', 'data', 'closing-date-audit-config.json');
+const TODAY = new Date().toISOString().slice(0, 10);
+
+const argv = process.argv.slice(2);
+const DRY_RUN = argv.includes('--dry-run');
+const SHOWS_FILTER = (argv.find(a => a.startsWith('--shows=')) || '').replace('--shows=', '').split(',').filter(Boolean);
+
+// Cap discovery attempts per run to bound cost. Each show needing both
+// opening + previews-start checks costs up to 2 SERP + ~10 article fetches +
+// ~10 LLM calls = ~$0.20-0.30/show. Cap of 8 shows keeps cost under ~$2/run.
+const MAX_DISCOVERY_ATTEMPTS = 8;
+// How many days +/- of openingDate to consider "operationally relevant".
+// Shows opening more than 30 days out have plenty of time for human review
+// of opening-date drift; opened more than 30 days ago have a locked date.
+const OPENING_WINDOW_DAYS = 30;
+
+const CONFIG = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
+const OPEN_RUN_SKIP = new Set(CONFIG.openRunSkip.ids);
+
+function isWithinWindow(dateStr, today, days) {
+  if (!dateStr) return false;
+  const d = new Date(dateStr);
+  const t = new Date(today);
+  const diff = Math.abs((d - t) / 86400000);
+  return diff <= days;
+}
+
+async function notifyNotion(flagged, todayStr) {
+  if (flagged.length === 0) return;
+  if (!process.env.NOTION_API_KEY) {
+    console.log('NOTION_API_KEY not set — skipping Notion card creation');
+    return;
+  }
+  const { spawnSync } = require('child_process');
+  const brain = path.join(__dirname, 'notion-brain.js');
+
+  // Dedup: skip if an open opening-audit card already exists.
+  const search = spawnSync('node', [brain, 'search', '--text=Opening-date audit', '--status=In progress'], { encoding: 'utf8' });
+  if (search.status === 0 && /Opening-date audit/.test(search.stdout || '')) {
+    console.log('Notion: existing open opening-audit card found — skipping create (dedup)');
+    return;
+  }
+
+  const title = `Opening-date audit: ${flagged.length} show${flagged.length > 1 ? 's' : ''} need review (${todayStr})`;
+  const rows = flagged.map(f => {
+    const lines = [`- **${f.id}**: stored ${f.fieldType}=${f.stored || 'null'}`];
+    if (f.discovered) {
+      const c = f.discovered;
+      const sourceLinks = c.sources.slice(0, 3).map(s => s.url).join(', ');
+      lines.push(`  📰 Press cluster: **${c.date}** (${c.sources.length} source${c.sources.length > 1 ? 's' : ''}: ${sourceLinks})`);
+      if (c.sources[0] && c.sources[0].quote) {
+        lines.push(`  💬 "${c.sources[0].quote.replace(/[\n\r]+/g, ' ').slice(0, 200)}"`);
+      }
+    }
+    return lines.join('\n');
+  }).join('\n');
+
+  const notes = [
+    '## Problem',
+    `Opening-date audit found ${flagged.length} show(s) where press cluster disagrees with stored openingDate or previewsStartDate. Unlike the closing-date audit, this audit has no second independent signal, so findings are suggestion-only — manually verify and update shows.json if confirmed.`,
+    '',
+    '## Shows flagged',
+    rows,
+    '',
+    '## Resolution steps',
+    '1. For each show, click the 📰 Press cluster source URLs to verify the discovered date is for THIS production (not a tour, regional, or other revival).',
+    '2. If confirmed → update openingDate or previewsStartDate in `data/shows.json` (private repo `thomaspryor/broadway-scorecard-data`).',
+    '3. If the press article is about the wrong production or the stored date is right, no action.',
+    '',
+    '## Acceptance criteria',
+    'Each show\'s stored opening/preview-start date either matches the announced date OR has been confirmed correct.',
+    '',
+    `_Auto-created by scripts/audit-opening-dates.js on ${todayStr}._`,
+  ].join('\n');
+
+  const create = spawnSync('node', [
+    brain, 'create', title,
+    '--priority', 'P1 Next',
+    '--category', 'Data',
+    '--type', 'Bug',
+    '--tags', 'opening-night,audit,data-quality',
+    '--notes', notes,
+  ], { encoding: 'utf8' });
+
+  if (create.status === 0) {
+    const match = (create.stderr || '').match(/__NOTION_CARD_ID__=([a-f0-9-]+)/);
+    console.log(`Notion: created card ${match ? match[1] : '(unknown id)'}`);
+  } else {
+    console.warn('Notion: create failed:', (create.stderr || create.stdout || '').slice(0, 500));
+  }
+}
+
+async function main() {
+  console.log('='.repeat(60));
+  console.log('OPENING DATE AUDIT (LLM press cluster — suggestion only)');
+  console.log('='.repeat(60));
+  console.log(`Date: ${TODAY}`);
+  console.log(`Mode: ${DRY_RUN ? 'DRY RUN' : 'LIVE'}`);
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.warn('ANTHROPIC_API_KEY not set — audit cannot run. Exiting.');
+    await cleanup();
+    process.exit(0);
+  }
+
+  const data = JSON.parse(fs.readFileSync(SHOWS_FILE, 'utf8'));
+  const candidates = data.shows.filter(s => {
+    if (s.category !== 'broadway') return false;
+    if (OPEN_RUN_SKIP.has(s.id)) return false;
+    if (SHOWS_FILTER.length && !SHOWS_FILTER.includes(s.id)) return false;
+    // Only audit shows that are about to open OR just opened (within ±30d
+    // of stored openingDate). Outside this window, opening-date drift is
+    // either far-future (plenty of human review time) or locked-past.
+    if (s.status === 'previews') return true;
+    if (s.status === 'open' && isWithinWindow(s.openingDate, TODAY, OPENING_WINDOW_DAYS)) return true;
+    return false;
+  }).slice(0, MAX_DISCOVERY_ATTEMPTS);
+
+  console.log(`Auditing ${candidates.length} candidate show(s) (cap ${MAX_DISCOVERY_ATTEMPTS}/run)...`);
+  console.log('');
+
+  const flagged = [];
+  const matches = [];
+  const errors = [];
+
+  for (const show of candidates) {
+    const title = show.name || show.title || show.id;
+    console.log(`[${show.id}] ${title} — stored opening=${show.openingDate || 'null'}, previews=${show.previewsStartDate || 'null'}`);
+
+    for (const fieldType of ['opening', 'previews-start']) {
+      const storedKey = fieldType === 'opening' ? 'openingDate' : 'previewsStartDate';
+      const stored = show[storedKey] || null;
+      try {
+        const discovered = await discoverAnnouncedDate(title, fieldType, { log: msg => console.log(msg) });
+        if (!discovered) {
+          continue;  // No press signal; can't conclude anything
+        }
+        if (stored && discovered.date === stored) {
+          matches.push({ id: show.id, fieldType, stored, discoveredDate: discovered.date });
+          continue;
+        }
+        // Date differs OR stored was null and we got a date.
+        flagged.push({
+          id: show.id,
+          fieldType: storedKey,
+          stored,
+          discovered: {
+            date: discovered.date,
+            sources: discovered.sources,
+          },
+        });
+      } catch (e) {
+        errors.push({ id: show.id, fieldType, message: e.message.slice(0, 120) });
+      }
+    }
+  }
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    mode: DRY_RUN ? 'dry-run' : 'live',
+    summary: {
+      audited: candidates.length,
+      flagged: flagged.length,
+      matches: matches.length,
+      errors: errors.length,
+    },
+    flagged,
+    matches,
+    errors,
+  };
+
+  fs.mkdirSync(path.dirname(AUDIT_FILE), { recursive: true });
+  fs.writeFileSync(AUDIT_FILE, JSON.stringify(report, null, 2) + '\n');
+  console.log(`Wrote ${AUDIT_FILE}`);
+
+  console.log('\nResults:');
+  console.log(`  ✅ Matches:    ${matches.length}`);
+  console.log(`  ⚠️  Flagged:    ${flagged.length}`);
+  console.log(`  ❌ Errors:     ${errors.length}`);
+
+  for (const m of matches) console.log(`  MATCH ${m.id}: ${m.fieldType}=${m.stored} agrees with press`);
+  for (const f of flagged) console.log(`  FLAG  ${f.id}: stored ${f.fieldType}=${f.stored} vs press ${f.discovered.date} (${f.discovered.sources.length} source${f.discovered.sources.length > 1 ? 's' : ''})`);
+
+  if (flagged.length > 0) await notifyNotion(flagged, TODAY);
+
+  await cleanup();
+  process.exit(0);
+}
+
+main().catch(async (e) => {
+  console.error('FATAL:', e);
+  await cleanup();
+  process.exit(1);
+});

--- a/scripts/lib/closing-date-discovery.js
+++ b/scripts/lib/closing-date-discovery.js
@@ -71,8 +71,57 @@ function isCredibleUrl(url) {
   return CREDIBLE_HOSTS.some(h => url.includes(h));
 }
 
-function buildExtractionPrompt(showTitle, text, url) {
-  return `You are extracting the announced final Broadway performance date from a press article.
+// Per-field configuration. fieldType determines: the SERP query phrasing,
+// the LLM prompt's date semantics, the year-sanity window, and the closure-
+// verb regex for single-source acceptance. Closing is the original behavior
+// preserved verbatim — it stays the default for discoverAnnouncedClosingDate
+// callers. Opening and previews-start were added 2026-05-24 as part of the
+// same triple-signal pattern.
+const FIELD_CONFIGS = {
+  closing: {
+    serpQuery: title => `"${title}" broadway closing OR extends final performance`,
+    promptDateRole: 'FINAL Broadway performance',
+    promptHighConfidenceCriteria: 'the article explicitly states a closing OR final-performance date for the named show on Broadway',
+    promptExclusions: 'Not opening, not previews, not a future tour stop, not a past extension if a newer date has been announced.',
+    // Closing dates can be far-future (Op Mincemeat extended to 2027). Allow
+    // up to 3 years out; allow 180 days into the past in case a show closed
+    // very recently and a press article is from after the fact.
+    sanityWindowDaysPast: 180,
+    sanityWindowDaysFuture: 1095,
+    // Phrases acceptable for single-source acceptance.
+    quoteAcceptanceRegex: /final performance|closing on|last performance|ends? its run on|ends? on|wraps? (?:its run )?on|shutters? on|will close on|to close on|last show on/,
+  },
+  opening: {
+    serpQuery: title => `"${title}" broadway opening night OR delayed OR pushed OR postponed`,
+    promptDateRole: 'OFFICIAL OPENING NIGHT (not the first preview)',
+    promptHighConfidenceCriteria: 'the article explicitly states an opening-night date for the named show on Broadway. Opening night follows previews and is typically a single performance with critics invited',
+    promptExclusions: 'Not the first preview, not the closing, not a tour opening, not a West End opening. If the article only mentions previews-start, return null.',
+    // Opening dates are near-future (within ~1 year). A 4-year-future
+    // "opening" almost certainly means a different production.
+    sanityWindowDaysPast: 30,
+    sanityWindowDaysFuture: 365,
+    quoteAcceptanceRegex: /opening night|officially opens?|opens? on|opening on|to open on|will open on/,
+  },
+  'previews-start': {
+    serpQuery: title => `"${title}" broadway previews begin OR start OR first preview`,
+    promptDateRole: 'FIRST PREVIEW PERFORMANCE (the first paid performance, before official opening)',
+    promptHighConfidenceCriteria: 'the article explicitly states a previews-start date or first-preview date for the named show on Broadway',
+    promptExclusions: 'Not opening night, not closing. If the article only mentions opening night, return null.',
+    sanityWindowDaysPast: 30,
+    sanityWindowDaysFuture: 365,
+    quoteAcceptanceRegex: /first preview|previews begin|begin previews|previews start|starts previews|previews? on/,
+  },
+};
+
+function getFieldConfig(fieldType) {
+  const cfg = FIELD_CONFIGS[fieldType];
+  if (!cfg) throw new Error(`closing-date-discovery: unknown fieldType "${fieldType}". Expected: ${Object.keys(FIELD_CONFIGS).join(', ')}`);
+  return cfg;
+}
+
+function buildExtractionPrompt(showTitle, text, url, fieldType = 'closing') {
+  const cfg = getFieldConfig(fieldType);
+  return `You are extracting the announced ${cfg.promptDateRole} date for a Broadway show from a press article.
 
 Show: ${showTitle}
 Article URL: ${url}
@@ -85,14 +134,16 @@ Return ONLY JSON in this exact form (no markdown, no commentary):
 {"date": "YYYY-MM-DD" | null, "confidence": "high" | "medium" | "low", "quote": "the exact sentence stating the date" | null}
 
 Rules:
-- date = the FINAL Broadway performance announced in this article. Not opening, not previews, not a future tour stop, not a past extension if a newer date has been announced.
-- confidence "high" ONLY if the article explicitly states a closing OR final-performance date for the named show on Broadway.
+- date = the ${cfg.promptDateRole} announced in this article. ${cfg.promptExclusions}
+- confidence "high" ONLY if ${cfg.promptHighConfidenceCriteria}.
 - If the article is about a tour, regional production, off-Broadway run, or West End run, return {"date": null, "confidence": "low", "quote": null}.
 - If the date is ambiguous, a range, conditional, or not present, return {"date": null, "confidence": "low", "quote": null}.`;
 }
 
 function parseExtraction(raw, opts = {}) {
   if (!raw) return null;
+  const fieldType = opts.fieldType || 'closing';
+  const cfg = getFieldConfig(fieldType);
   // Trim code fences if model added them
   const cleaned = raw.replace(/^```(?:json)?\s*/i, '').replace(/```\s*$/, '').trim();
   try {
@@ -100,16 +151,15 @@ function parseExtraction(raw, opts = {}) {
     if (!j || typeof j !== 'object') return null;
     if (j.date && !/^\d{4}-\d{2}-\d{2}$/.test(j.date)) return null;
     if (!['high', 'medium', 'low'].includes(j.confidence)) return null;
-    // Year-sanity: reject extractions outside [TODAY - 6 months, TODAY + 3 years].
-    // A 1998 revival article that says "closing 1998-10-04" would otherwise pass
-    // the regex check and could cluster with another wrong-production article.
-    // The actual future-close window for an open Broadway show is at most ~3 years
-    // (Operation Mincemeat's 9 extensions stretched to ~2 years out).
+    // Year-sanity: reject extractions outside the field's plausible window.
+    // Closing dates have a wide future window (Op Mincemeat 2027); opening
+    // and previews-start are much narrower (within ~1 year). This is the
+    // primary defense against same-title revival hallucinations.
     if (j.date) {
       const dt = new Date(j.date);
       const now = opts.now || new Date();
-      const minDate = new Date(now.getTime() - 180 * 86400000);
-      const maxDate = new Date(now.getTime() + 1095 * 86400000);
+      const minDate = new Date(now.getTime() - cfg.sanityWindowDaysPast * 86400000);
+      const maxDate = new Date(now.getTime() + cfg.sanityWindowDaysFuture * 86400000);
       if (dt < minDate || dt > maxDate) return null;
     }
     return { date: j.date || null, confidence: j.confidence, quote: j.quote || null };
@@ -155,10 +205,11 @@ function hostOf(url) {
   catch { return ''; }
 }
 
-function clusterDates(extractions) {
+function clusterDates(extractions, opts = {}) {
   if (extractions.length === 0) return null;
   const dated = extractions.filter(e => e.date && e.confidence === 'high');
   if (dated.length === 0) return null;
+  const cfg = getFieldConfig(opts.fieldType || 'closing');
 
   let best = null;
   let bestDistinctHosts = 0;
@@ -179,35 +230,34 @@ function clusterDates(extractions) {
     }
   }
   // Single-source acceptance ONLY if the extraction has both a date and a
-  // quote with "final performance" / closure-verb language. Bounds the
-  // "one hallucinated article wrong-corrects the show" failure mode. The
-  // regex is broader than the original to catch real announcement language
-  // ("ends its run", "shutters", "last show", "wraps") without admitting
-  // generic phrasing.
+  // quote with field-appropriate announcement-verb language. Bounds the
+  // "one hallucinated article wrong-corrects the show" failure mode.
   if (best.cluster.length === 1) {
     const q = (best.cluster[0].quote || '').toLowerCase();
-    if (!/final performance|closing on|last performance|ends? its run on|ends? on|wraps? (?:its run )?on|shutters? on|will close on|to close on|last show on/.test(q)) return null;
+    if (!cfg.quoteAcceptanceRegex.test(q)) return null;
   }
   return best;
 }
 
 /**
- * @returns null OR { date: 'YYYY-MM-DD', sources: [{url, title, quote}], extractions: [...] }
+ * Generic field discovery. fieldType in {'closing','opening','previews-start'}.
+ * @returns null OR { date: 'YYYY-MM-DD', sources: [{url, title, quote}], extractions: [...], fieldType }
  */
-async function discoverAnnouncedClosingDate(showTitle, opts = {}) {
+async function discoverAnnouncedDate(showTitle, fieldType = 'closing', opts = {}) {
   const log = opts.log || (() => {});
-  const query = `"${showTitle}" broadway closing OR extends final performance`;
-  log(`  [discovery] SERP: ${query}`);
+  const cfg = getFieldConfig(fieldType);
+  const query = cfg.serpQuery(showTitle);
+  log(`  [discovery:${fieldType}] SERP: ${query}`);
 
-  // Last 30 days — closing announcements stay relevant only briefly. Older
-  // results are mostly historical pieces.
+  // Last 30 days — announcements stay relevant only briefly. Older results
+  // are mostly historical pieces.
   const dateMax = new Date();
   const dateMin = new Date(dateMax.getTime() - 30 * 86400000);
   let results;
   try {
     results = await serpQuery(query, { nbResults: 12, dateRange: { dateMin, dateMax } });
   } catch (e) {
-    log(`  [discovery] SERP error: ${e.message}`);
+    log(`  [discovery:${fieldType}] SERP error: ${e.message}`);
     return null;
   }
   if (!results || results.length === 0) return null;
@@ -216,54 +266,61 @@ async function discoverAnnouncedClosingDate(showTitle, opts = {}) {
     .filter(r => isCredibleUrl(r.url))
     .slice(0, MAX_CANDIDATES_PER_SHOW);
   if (candidates.length === 0) {
-    log('  [discovery] no credible-host results');
+    log(`  [discovery:${fieldType}] no credible-host results`);
     return null;
   }
 
   const extractions = [];
   for (const c of candidates) {
     try {
-      const page = await fetchPage(c.url, { source: 'audit-closing-dates' });
+      const page = await fetchPage(c.url, { source: `audit-${fieldType}-dates` });
       if (!page || !page.content) continue;
-      // Use a wider window for the show-name guard than the LLM prompt — the
-      // show name often appears in the article body but past the first 4000
-      // chars on press sites with heavy nav/promo headers.
       const fullText = stripHtml(page.content);
       if (!pageMatchesShowTitle(fullText.slice(0, 12000), showTitle)) continue;
       const text = fullText.slice(0, 4000);
-      const raw = await callClaudeSonnet(buildExtractionPrompt(showTitle, text, c.url));
-      const parsed = parseExtraction(raw);
+      const raw = await callClaudeSonnet(buildExtractionPrompt(showTitle, text, c.url, fieldType));
+      const parsed = parseExtraction(raw, { fieldType });
       if (parsed) {
         extractions.push({ ...parsed, sourceUrl: c.url, sourceTitle: c.title || null });
       }
     } catch (e) {
-      log(`  [discovery] candidate ${c.url} failed: ${e.message.slice(0, 80)}`);
+      log(`  [discovery:${fieldType}] candidate ${c.url} failed: ${e.message.slice(0, 80)}`);
     }
   }
 
   if (extractions.length === 0) {
-    log('  [discovery] no extractions');
+    log(`  [discovery:${fieldType}] no extractions`);
     return null;
   }
 
-  const cluster = clusterDates(extractions);
+  const cluster = clusterDates(extractions, { fieldType });
   if (!cluster) {
-    log('  [discovery] extractions present but no high-confidence cluster');
+    log(`  [discovery:${fieldType}] extractions present but no high-confidence cluster`);
     return null;
   }
   return {
     date: cluster.centerDate,
     sources: cluster.cluster.map(c => ({ url: c.sourceUrl, title: c.sourceTitle, quote: c.quote })),
     extractions,
+    fieldType,
   };
 }
 
+// Backwards-compat wrapper preserves the original API used by
+// audit-closing-dates.js. New callers should use discoverAnnouncedDate().
+async function discoverAnnouncedClosingDate(showTitle, opts = {}) {
+  return discoverAnnouncedDate(showTitle, 'closing', opts);
+}
+
 module.exports = {
+  discoverAnnouncedDate,
   discoverAnnouncedClosingDate,
   // exported for tests
   parseExtraction,
   clusterDates,
   isCredibleUrl,
   pageMatchesShowTitle,
+  getFieldConfig,
   CREDIBLE_HOSTS,
+  FIELD_CONFIGS,
 };


### PR DESCRIPTION
## Summary
- Generalized `closing-date-discovery.js` with per-field configs (closing / opening / previews-start). Different SERP queries, LLM prompts, year-sanity windows, and quote regex per field. `discoverAnnouncedClosingDate` preserved as a back-compat wrapper.
- New `scripts/audit-opening-dates.js` runs daily; flags drift in openingDate + previewsStartDate for shows in previews OR opening within ±30 days. Notion-only — no auto-mutation.
- New workflow at 15:00 UTC (1h after closing-date audit).

## Test plan
- Live: discoverAnnouncedDate("Joe Turner's Come and Gone", 'opening') returned 2026-04-25 from 2 credible press sources, matching stored.
- 16/17 inline tests pass.
- Tomorrow's first scheduled run will hit ~3 shows (the ±30d cohort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)