### PR TITLE
Awards: demote Choreography A→B, fix Obie Best Design, surface Lyrics

### DIFF
--- a/scripts/lib/classify-category.js
+++ b/scripts/lib/classify-category.js
@@ -32,7 +32,6 @@ function classifyCategory(category) {
   if (/best (original )?score|outstanding (new )?score|outstanding music\b|outstanding lyrics|outstanding music in a play/.test(c)) return { tier: 'A+', revival: false };
   if (/best book|outstanding book/.test(c)) return { tier: 'A+', revival: false };
   if (/direction|director/.test(c)) return { tier: 'A', revival: false };
-  if (/choreograph/.test(c)) return { tier: 'A', revival: false };
   if (/distinguished performance/.test(c)) return { tier: 'A', revival: false };
   if (/best (actor|actress) in a (play|musical)|outstanding (actor|actress) in a (play|musical)/.test(c)) return { tier: 'A', revival: false };
   // Olivier "Best Actor" / "Best Actress" — Olivier play acting awards have no "in a play" qualifier
@@ -54,9 +53,10 @@ function classifyCategory(category) {
   if (/best (actor|actress) in a supporting role/.test(c)) return { tier: 'B', revival: false };
   // Featured Performance (DD 70th+) / Featured Performer (OCC) / Featured Actor|Actress (Lortel) variants
   if (/outstanding featured (performance|performer|actor|actress) in an? (broadway |off-broadway )?(play|musical)/.test(c)) return { tier: 'B', revival: false };
+  if (/choreograph/.test(c)) return { tier: 'B', revival: false };
   if (/orchestration/.test(c)) return { tier: 'B', revival: false };
   if (/ensemble/.test(c)) return { tier: 'B', revival: false };
-  if (/scenic|set design/.test(c)) return { tier: 'C', revival: false };
+  if (/scenic|set design|^best design$/.test(c)) return { tier: 'C', revival: false };
   if (/costume/.test(c)) return { tier: 'C', revival: false };
   if (/lighting/.test(c)) return { tier: 'C', revival: false };
   if (/sound/.test(c)) return { tier: 'C', revival: false };

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -568,17 +568,17 @@ export default function MethodologyPage() {
                 </tr>
                 <tr className="border-b border-white/5">
                   <td className="py-2 pr-3 font-semibold text-violet-300">A+</td>
-                  <td className="py-2 pr-3">Best Score, Best Book (×1.2 multiplier)</td>
+                  <td className="py-2 pr-3">Best Score, Best Book, Best Lyrics (×1.2 multiplier)</td>
                   <td className="py-2 tabular-nums">+90</td>
                 </tr>
                 <tr className="border-b border-white/5">
                   <td className="py-2 pr-3 font-semibold text-emerald-400">A</td>
-                  <td className="py-2 pr-3">Best Direction, Choreography, lead Actor / Actress</td>
+                  <td className="py-2 pr-3">Best Direction, Lead Actor / Actress</td>
                   <td className="py-2 tabular-nums">+75</td>
                 </tr>
                 <tr className="border-b border-white/5">
                   <td className="py-2 pr-3 font-semibold text-teal-400">B</td>
-                  <td className="py-2 pr-3">Featured Actor / Actress, Orchestrations, Ensemble</td>
+                  <td className="py-2 pr-3">Featured Actor / Actress, Choreography, Orchestrations, Ensemble</td>
                   <td className="py-2 tabular-nums">+35</td>
                 </tr>
                 <tr>

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -568,7 +568,7 @@ export default function MethodologyPage() {
                 </tr>
                 <tr className="border-b border-white/5">
                   <td className="py-2 pr-3 font-semibold text-violet-300">A+</td>
-                  <td className="py-2 pr-3">Best Score, Best Book, Best Lyrics (×1.2 multiplier)</td>
+                  <td className="py-2 pr-3">Best Score, Best Book, Outstanding Lyrics (×1.2 multiplier)</td>
                   <td className="py-2 tabular-nums">+90</td>
                 </tr>
                 <tr className="border-b border-white/5">

--- a/src/lib/awards-scoring.ts
+++ b/src/lib/awards-scoring.ts
@@ -100,7 +100,6 @@ export function classifyCategory(category: string): { tier: CategoryTier; reviva
   if (/best (original )?score|outstanding (new )?score|outstanding music\b|outstanding lyrics|outstanding music in a play/.test(c)) return { tier: 'A+', revival: false };
   if (/best book|outstanding book/.test(c)) return { tier: 'A+', revival: false };
   if (/direction|director/.test(c)) return { tier: 'A', revival: false };
-  if (/choreograph/.test(c)) return { tier: 'A', revival: false };
   if (/distinguished performance/.test(c)) return { tier: 'A', revival: false };
   if (/best (actor|actress) in a (play|musical)|outstanding (actor|actress) in a (play|musical)/.test(c)) return { tier: 'A', revival: false };
   // Olivier "Best Actor" / "Best Actress" — Olivier play acting awards have no "in a play" qualifier
@@ -122,9 +121,10 @@ export function classifyCategory(category: string): { tier: CategoryTier; reviva
   if (/best (actor|actress) in a supporting role/.test(c)) return { tier: 'B', revival: false };
   // Featured Performance (DD 70th+) / Featured Performer (OCC) / Featured Actor|Actress (Lortel) variants
   if (/outstanding featured (performance|performer|actor|actress) in an? (broadway |off-broadway )?(play|musical)/.test(c)) return { tier: 'B', revival: false };
+  if (/choreograph/.test(c)) return { tier: 'B', revival: false };
   if (/orchestration/.test(c)) return { tier: 'B', revival: false };
   if (/ensemble/.test(c)) return { tier: 'B', revival: false };
-  if (/scenic|set design/.test(c)) return { tier: 'C', revival: false };
+  if (/scenic|set design|^best design$/.test(c)) return { tier: 'C', revival: false };
   if (/costume/.test(c)) return { tier: 'C', revival: false };
   if (/lighting/.test(c)) return { tier: 'C', revival: false };
   if (/sound/.test(c)) return { tier: 'C', revival: false };

--- a/tests/fixtures/classify-category-baseline.json
+++ b/tests/fixtures/classify-category-baseline.json
@@ -40,7 +40,7 @@
     "revival": false
   },
   "Outstanding Choreography": {
-    "tier": "A",
+    "tier": "B",
     "revival": false
   },
   "Outstanding Costume Design": {
@@ -314,6 +314,26 @@
     "revival": false
   },
   "Most Promising Playwright": {
+    "tier": "C",
+    "revival": false
+  },
+  "Best Choreography": {
+    "tier": "B",
+    "revival": false
+  },
+  "Best Theatre Choreographer": {
+    "tier": "B",
+    "revival": false
+  },
+  "Outstanding Choreographer": {
+    "tier": "B",
+    "revival": false
+  },
+  "Best Choreographer": {
+    "tier": "B",
+    "revival": false
+  },
+  "Best Design": {
     "tier": "C",
     "revival": false
   }

--- a/tests/unit/classify-category-parity.test.mjs
+++ b/tests/unit/classify-category-parity.test.mjs
@@ -10,11 +10,12 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
-import { execSync } from 'node:child_process';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -22,27 +23,41 @@ const require = createRequire(import.meta.url);
 const fixture = JSON.parse(readFileSync(path.join(__dirname, '../fixtures/classify-category-baseline.json'), 'utf8'));
 const { classifyCategory: classifyJS } = require(path.join(__dirname, '../../scripts/lib/classify-category.js'));
 
-// TS version: compile via ts-node on demand, or use tsx
-function classifyTS(category) {
+// Classify every fixture category through the TS implementation in ONE tsx
+// process — avoids per-call shell escaping that previously silently swallowed
+// every iteration. If tsx isn't installed the test FAILS (no silent skip).
+function classifyAllTS(categories) {
   const root = path.join(__dirname, '../../');
-  const result = execSync(
-    `node -e "const {classifyCategory}=require('./src/lib/awards-scoring.ts');console.log(JSON.stringify(classifyCategory(${JSON.stringify(category)})))"`,
-    { cwd: root, env: { ...process.env, TS_NODE_PROJECT: 'tsconfig.json' } }
-  );
-  return JSON.parse(result.toString().trim());
+  const tmp = mkdtempSync(path.join(os.tmpdir(), 'classify-parity-'));
+  const catsPath = path.join(tmp, 'cats.json');
+  const runnerPath = path.join(tmp, 'runner.mjs');
+  writeFileSync(catsPath, JSON.stringify(categories));
+  writeFileSync(runnerPath, `
+    import { readFileSync } from 'node:fs';
+    import { classifyCategory } from '${path.join(root, 'src/lib/awards-scoring.ts').replace(/\\/g, '/')}';
+    const cats = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+    const out = {};
+    for (const c of cats) out[c] = classifyCategory(c) ?? null;
+    process.stdout.write(JSON.stringify(out));
+  `);
+  try {
+    const result = execFileSync('node', ['--import', 'tsx', runnerPath, catsPath], {
+      cwd: root,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return JSON.parse(result.toString().trim());
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
 }
 
 test('classifyCategory JS/TS parity — both produce identical outputs for all fixture inputs', () => {
+  const categories = Object.keys(fixture);
+  const tsResults = classifyAllTS(categories);
   const mismatches = [];
-  for (const [category] of Object.entries(fixture)) {
-    const jsResult = classifyJS(category);
-    let tsResult;
-    try {
-      tsResult = classifyTS(category);
-    } catch {
-      // TS runner not available in this environment — skip TS check
-      continue;
-    }
+  for (const category of categories) {
+    const jsResult = classifyJS(category) ?? null;
+    const tsResult = tsResults[category];
     if (JSON.stringify(jsResult) !== JSON.stringify(tsResult)) {
       mismatches.push({ category, js: jsResult, ts: tsResult });
     }


### PR DESCRIPTION
## Summary
- Demote choreography wins from tier A → B across all 12 ceremonies (Tony, Olivier, DD, OCC, Lortel, WOS). User judgement call: choreography is closer in prestige to featured/orchestrations than direction/lead acting.
- Obie "Best Design" was silently UNMAPPED (scoring 0 pts). Now maps to tier C alongside scenic/set design (regex anchored to `^best design$` to avoid overmatch).
- Methodology page: A+ row surfaces Outstanding Lyrics. A row drops choreography. B row gains choreography.
- Golden fixture extended with all choreography variants + Best Design.
- **Parity test was a false green** — codex caught it during ship-check. Previous version shelled per-category to `node -e` with shell-unescapable strings, catch/continue silently swallowed every failure. Rebuilt to use one tsx subprocess + tempfile.

## Score impact
- 169 of 1,652 shows shifted (all downward, max Δ-8). Dance-heavy: Bandstand, Illinoise, MJ WE, After Midnight, Fela, Dancin', Tap Dance Kid.
- Zero current shows affected by Best Design fix (forward-looking).
- Tony predictor backtest: 39/43 = 90.7% post-demotion (unchanged from baseline; verified via `audit-tony-all-seasons.ts`).

## Test plan
- [x] `npx tsc --noEmit` clean (only pre-existing data-symlink errors remain, unrelated)
- [x] `node --test tests/unit/classify-category-{golden,parity}.test.mjs` — both pass
- [x] `/visual-qa` at 5 widths (360/414/768/1024/1440); element crops verified
- [x] codex + Claude subagent adversarial ship-check; P0 (methodology referenced "Best Lyrics" which no ceremony uses — changed to "Outstanding Lyrics") and P1 (broken parity test) fixed
- [x] Notion: 36b637c5-416f-816a-b799-e4ae76799516

🤖 Generated with [Claude Code](https://claude.com/claude-code)