### PR TITLE
fix(gap-audit): kill orphan ingest processes + reject bare aggregator section roots

### DIFF
--- a/scripts/audit-show-review-gap.js
+++ b/scripts/audit-show-review-gap.js
@@ -158,8 +158,16 @@ function isReviewUrl(href) {
   const h = hostOf(href);
   if (!h) return false;
   if (NON_REVIEW_HOST_PATTERNS.some(rx => rx.test(h)) && !ALLOWED_ORG_HOSTS.has(h)) return false;
-  // Skip Playbill/BWW internal navigation (we WANT outlet URLs, not aggregator URLs)
-  if ((h === 'playbill.com' || h === 'broadwayworld.com') && !/\/(review|reviews|theater|theatre|news|stage|culture|arts)/i.test(href)) return false;
+  // Skip Playbill/BWW internal navigation (we WANT outlet URLs, not aggregator URLs).
+  // Require at least 2 path segments so bare section roots like playbill.com/news
+  // or broadwayworld.com/theater are rejected (they're category pages, not reviews).
+  if (h === 'playbill.com' || h === 'broadwayworld.com') {
+    if (!/\/(review|reviews|theater|theatre|news|stage|culture|arts)/i.test(href)) return false;
+    try {
+      const segments = new URL(href).pathname.split('/').filter(Boolean);
+      if (segments.length < 2) return false; // bare section root e.g. /news
+    } catch { return false; }
+  }
   try {
     const p = new URL(href).pathname;
     if (NON_REVIEW_PATH_PATTERNS.some(rx => rx.test(p))) return false;
@@ -593,7 +601,7 @@ function ingestMissingUrl(showId, url, knownOutletId) {
     provisional = true;
   }
   try {
-    execFileSync('node', args, { stdio: 'pipe', timeout: 120000 });
+    execFileSync('node', args, { stdio: 'pipe', timeout: 120000, killSignal: 'SIGKILL' });
     return { ok: true, reason: null, provisional };
   } catch (e) {
     return { ok: false, reason: e.message.split('\n')[0].slice(0, 100), provisional };


### PR DESCRIPTION
## Summary

- **SIGKILL orphan fix**: `ingestMissingUrl` used `execFileSync` with default SIGTERM. For shows like Beetlejuice (5 ingest calls all ETIMEDOUT at 120s), the child processes didn't die on timeout and lingered as orphans — holding the "Run gap audit" step open past the 40-min job cap. 5 of the last 14 runs showed `cancelled` despite the audit script having exited cleanly. Switching to `killSignal: 'SIGKILL'` force-kills the child on timeout.
- **Bad URL filter fix**: `isReviewUrl` accepted bare aggregator section roots (`playbill.com/news`, `broadwayworld.com/theater`) because the path regex matched `/news` as a substring. `playbill.com/news` was actually ingested as a review for MJ West End in the 2026-06-07T19:16 run. Fix: require ≥ 2 path segments for playbill.com / broadwayworld.com so `/news` → rejected but `/news/some-article` → accepted.

## Verification context

Checkpoint is growing (218 entries in 24h across the full catalogue). Recent 14 runs: 5 success, 5 cancelled, 3 failure (benign Playwright teardown). The cancelled runs were all caused by bug #1 — the Beetlejuice show has 6 BWW roundup articles × (30s Playwright timeout + 2min BD failure each) plus 5 ETIMEDOUT ingest calls = ~30min audit + 8min orphan delay. After this fix those runs will be sub-20min and end with `success`.

## Test plan
- [ ] Verify next hourly cron run concludes `success` (not `cancelled`) even for shows with many roundup articles
- [ ] Confirm `playbill.com/news` no longer appears in ingested reviews
- [ ] Checkpoint entry count continues growing

https://claude.ai/code/session_01LFQScgXmjzFnY5YKnSA7DH

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFQScgXmjzFnY5YKnSA7DH)_