### PR TITLE
fix(lbo): catch Stuart King's missed reviews — numeric titles (1536) + individual-review discovery (Avenue Q)

### DIFF
--- a/scripts/lib/show-matching.js
+++ b/scripts/lib/show-matching.js
@@ -1130,7 +1130,17 @@ function _matchCleanedSlugAgainstShows(cleanedSlug, shows, options = {}) {
     // supporting token. The HOLIDAY INN regression that motivated the
     // title-token switch is fixed without lowering this gate because
     // "Holiday Inn" has 2 tokens [holiday, inn], not 1.
-    if (tokens.length === 1 && tokens[0].length < 5) continue;
+    //
+    // Numeric exception: a purely-numeric single token (≥3 digits) is exempt
+    // from the ≥5-char rule. The gate exists to reject common short English
+    // WORDS (home/cats/rent) that collide with unrelated slugs; a 3-4 digit
+    // NUMBER is not an English word and is highly distinctive, so it does not
+    // carry that false-positive risk. Without this, numeric-titled shows like
+    // "1536" (Ambassadors) and "1984" were silently unmatched — Stuart King's
+    // 1536 review (londonboxoffice.co.uk/news/post/1536-ambassadors-review)
+    // was dropped this way (2026-06-28 report). Mirrors the numeric exemption
+    // already used by matchTitleToShow's first-token gate (`/^\d+$/`).
+    if (tokens.length === 1 && tokens[0].length < 5 && !/^\d{3,}$/.test(tokens[0])) continue;
     let matchedTokens = 0;
     let score = 0;       // sum of matched-token-length squared
     let totalLen = 0;

--- a/scripts/lib/show-matching.js
+++ b/scripts/lib/show-matching.js
@@ -1140,6 +1140,15 @@ function _matchCleanedSlugAgainstShows(cleanedSlug, shows, options = {}) {
     // 1536 review (londonboxoffice.co.uk/news/post/1536-ambassadors-review)
     // was dropped this way (2026-06-28 report). Mirrors the numeric exemption
     // already used by matchTitleToShow's first-token gate (`/^\d+$/`).
+    //
+    // Blast radius: this helper backs matchSlugToShow (PV, LBO) AND
+    // matchBwwRoundupSlugToShow (BWW), so the exemption is intentionally global
+    // — a numeric-titled show (1536, 1776, 1984) should be matchable from every
+    // aggregator, not just LBO. Spurious matches on an incidental year token are
+    // contained by three existing gates: _tokenAppearsInSlug requires a hyphen
+    // boundary (so `1536` never bleeds into `21536`), ALL of a show's tokens
+    // must appear, and the squared-length sort lets any genuine multi-token
+    // candidate out-score a lone numeric token.
     if (tokens.length === 1 && tokens[0].length < 5 && !/^\d{3,}$/.test(tokens[0])) continue;
     let matchedTokens = 0;
     let score = 0;       // sum of matched-token-length squared

--- a/scripts/lib/show-matching.lbo-individual.test.mjs
+++ b/scripts/lib/show-matching.lbo-individual.test.mjs
@@ -23,6 +23,13 @@ const SHOWS = [
   { id: 'glengarry-glen-ross-west-end-2026', title: 'Glengarry Glen Ross', category: 'west-end', market: 'west-end' },
   { id: 'sinatra-the-musical-west-end-2026', title: 'Sinatra the Musical', category: 'west-end', market: 'west-end' },
   { id: 'the-truth-a-comedy-by-florian-zeller-west-end-2026', title: 'The Truth: A Comedy by Florian Zeller', category: 'west-end', market: 'west-end' },
+  // Numeric title — the single-token ≥5-char gate used to reject the 4-digit
+  // "1536" and silently drop its LBO review (Stuart King report 2026-06-28).
+  // The numeric exemption re-admits it.
+  { id: '1536-west-end-2026', title: '1536', category: 'west-end', market: 'west-end' },
+  // Single-letter second token ("Q") is dropped by the ≥3-char token filter;
+  // the match must still land on the surviving "avenue" token.
+  { id: 'avenue-q-west-end-2026', title: 'Avenue Q', category: 'west-end', market: 'west-end' },
   // Distractor with no token overlap — confirms the matcher does not reach for
   // an unrelated show. (matchSlugToShow ignores the market option; the sweep's
   // cross-market scoping comes from pre-filtering the candidate pool, not this
@@ -39,6 +46,10 @@ const CASES = [
   { url: 'https://www.londonboxoffice.co.uk/news/post/review-glengarry-glen-ross-old-vic', id: 'glengarry-glen-ross-west-end-2026' },
   { url: 'https://www.londonboxoffice.co.uk/news/post/sinatra-aldwych-theatre-review', id: 'sinatra-the-musical-west-end-2026' },
   { url: 'https://www.londonboxoffice.co.uk/news/post/review-the-truth-apollo-theatre', id: 'the-truth-a-comedy-by-florian-zeller-west-end-2026' },
+  // Numeric-titled show (4 digits) — must match despite the single-token gate.
+  { url: 'https://www.londonboxoffice.co.uk/news/post/1536-ambassadors-review', id: '1536-west-end-2026' },
+  // Single-letter token dropped; must still match on "avenue".
+  { url: 'https://www.londonboxoffice.co.uk/news/post/avenue-q-shaftesbury-review', id: 'avenue-q-west-end-2026' },
 ];
 
 test('LBO individual review URLs match their show at high confidence, venue-agnostically', () => {

--- a/scripts/scrape-london-box-office-roundups.js
+++ b/scripts/scrape-london-box-office-roundups.js
@@ -731,6 +731,66 @@ async function scrapeLBORoundups() {
     }
   }
 
+  // SERP fallback for INDIVIDUAL byline reviews (targeted mode only).
+  //
+  // LBO first-party reviews (Stuart King + colleagues) are only discoverable
+  // via news-sitemap.xml, which per the Google News sitemap protocol holds
+  // only ~48h of URLs. A byline review not swept within that window is
+  // otherwise LOST — the curated map is roundups-only, the roundup SERP above
+  // searches "review round up", and the opening-night poller feeds pages to
+  // the roundup extractor. So Stuart King reviews of shows we polled a few days
+  // late silently never appeared (Avenue Q + 1536, reported 2026-06-28).
+  //
+  // For a targeted show with no sitemap-matched individual review, ask SERP for
+  // the byline review directly and accept a result ONLY when its slug matches
+  // THIS show via matchSlugToShow (single-show pool) — the same guard the
+  // sitemap path uses — so a wrong-show URL can't contaminate (the Stuart King
+  // mis-attribution failure mode this file has hit before).
+  if (targetShowIds && SCRAPINGBEE_KEY) {
+    const matchedIndivIds = new Set(matchedIndividual.map(r => r.show.id));
+    const unmatchedIndivTargets = targetShowIds.filter(id => !matchedIndivIds.has(id));
+
+    for (const showId of unmatchedIndivTargets) {
+      const show = weShows.find(s => s.id === showId);
+      if (!show) continue;
+
+      console.log(`[SERP] Searching for ${show.title} individual LBO review...`);
+      try {
+        const query = `site:londonboxoffice.co.uk "${show.title}" review`;
+        const results = await serpQuery(query, { nbResults: 8 });
+        const candidateUrls = (results || [])
+          .map(r => r.url)
+          .filter(Boolean)
+          .map(u => u.split(/[?#]/)[0])
+          .filter(u => u.includes('londonboxoffice.co.uk') && /\/news\/post\//i.test(u))
+          // Individual-review shape only — never a roundup listing.
+          .filter(u => !/review-round-?up/i.test(u))
+          .filter(u => /\/news\/post\/review-.+/i.test(u) || /-review\/?$/i.test(u));
+
+        let picked = null;
+        for (const u of candidateUrls) {
+          const postSlug = u
+            .replace(/^https?:\/\/[^/]+/, '')
+            .replace(/^\/news\/post\//, '')
+            .replace(/\/$/, '');
+          const m = matchSlugToShow(postSlug, [show]);
+          if (m && m.show && m.confidence === 'high') { picked = u; break; }
+        }
+
+        if (picked) {
+          console.log(`  Found individual via SERP: ${picked}`);
+          matchedIndividual.push({ url: picked, show, extractedTitle: show.title, via: 'serp' });
+          stats.matchedIndividual = (stats.matchedIndividual || 0) + 1;
+        } else {
+          console.log(`  No LBO individual review found for ${show.title}`);
+        }
+        await sleep(2000);
+      } catch (err) {
+        console.log(`  SERP (individual) error: ${err.message}`);
+      }
+    }
+  }
+
   // Process each matched roundup
   for (const { url, show } of matchedRoundups) {
     const showId = show.id;

--- a/scripts/scrape-london-box-office-roundups.js
+++ b/scripts/scrape-london-box-office-roundups.js
@@ -743,9 +743,14 @@ async function scrapeLBORoundups() {
   //
   // For a targeted show with no sitemap-matched individual review, ask SERP for
   // the byline review directly and accept a result ONLY when its slug matches
-  // THIS show via matchSlugToShow (single-show pool) — the same guard the
-  // sitemap path uses — so a wrong-show URL can't contaminate (the Stuart King
-  // mis-attribution failure mode this file has hit before).
+  // THIS show as the WINNER against the full weShows pool — identical to the
+  // sitemap path (line ~630). Matching against a single-show pool would be a
+  // strictly weaker guard: it returns "high" whenever this show's tokens appear
+  // in the slug even if the URL is really about a different show that would
+  // out-score it across the pool (e.g. "avenue-verte" slug matching Avenue Q on
+  // the bare "avenue" token). The full-pool + id-equality check prevents that
+  // wrong-show contamination (the Stuart King mis-attribution failure mode this
+  // file has hit before).
   if (targetShowIds && SCRAPINGBEE_KEY) {
     const matchedIndivIds = new Set(matchedIndividual.map(r => r.show.id));
     const unmatchedIndivTargets = targetShowIds.filter(id => !matchedIndivIds.has(id));
@@ -773,8 +778,8 @@ async function scrapeLBORoundups() {
             .replace(/^https?:\/\/[^/]+/, '')
             .replace(/^\/news\/post\//, '')
             .replace(/\/$/, '');
-          const m = matchSlugToShow(postSlug, [show]);
-          if (m && m.show && m.confidence === 'high') { picked = u; break; }
+          const m = matchSlugToShow(postSlug, weShows);
+          if (m && m.show && m.show.id === show.id && m.confidence === 'high') { picked = u; break; }
         }
 
         if (picked) {


### PR DESCRIPTION
## Why

Stuart King emailed two more LBO reviews his coverage still missed:
- **1536** — https://www.londonboxoffice.co.uk/news/post/1536-ambassadors-review
- **Avenue Q** — https://www.londonboxoffice.co.uk/news/post/avenue-q-shaftesbury-review

They were missed for **two different reasons** — which is why prior sessions (bstars extraction, roundup regex, venue-agnostic slug matching) didn't close them. This PR fixes both.

### 1. `1536` — matcher bug
`_matchCleanedSlugAgainstShows` (`scripts/lib/show-matching.js`) rejects any show whose only distinctive title token is `<5` chars — a deliberate gate against common short words (`home`, `cats`, `rent`) that caused 241 misroutes in the 38K-file audit. But it also killed the **4-digit title `1536`**, so `matchSlugToShow('1536-ambassadors-review', …)` returned `null` and the review was dropped **even when the URL was discovered**. Reproduced: `1536` → tokens `["1536"]` → `NULL`.

**Fix:** exempt purely-numeric `/^\d{3,}$/` single tokens (a number isn't an English word, so it carries none of the false-positive risk the gate targets) — mirroring the numeric exemption `matchTitleToShow` already uses. Boundary-matching + the all-tokens gate + squared-length sort contain any incidental-year collisions; documented the (intentional) global blast radius across the PV/BWW/LBO callers.

### 2. `Avenue Q` — discovery-timing gap
Matching already works for Avenue Q; it was missed because LBO **individual byline reviews had no persistent discovery path**. Discovery is via `news-sitemap.xml`, which per the Google News sitemap protocol holds only **~48h** of URLs. `lbo-roundup-urls.json` is roundups-only, the SERP fallback searched `"review round up"` (roundups), and the opening-night poller feeds pages to the *roundup* extractor. So any byline review not swept within ~48h of publishing was lost — Avenue Q was only in the data because it was recovered **manually**. This is the real answer to "why does this keep happening after multiple sessions."

**Fix:** extend the targeted-mode SERP fallback in `scrape-london-box-office-roundups.js`. For a targeted show with no sitemap-matched individual review, query `site:londonboxoffice.co.uk "{title}" review`, filter to individual-review URL shapes (not roundups), and accept a result **only when its slug wins against the full `weShows` pool and `m.show.id === show.id`** — the same guard the sitemap path uses, so a wrong-show URL can't contaminate.

## Changes
- `scripts/lib/show-matching.js` — numeric single-token exemption + blast-radius note.
- `scripts/scrape-london-box-office-roundups.js` — SERP discovery for individual byline reviews, full-pool slug guard.
- `scripts/lib/show-matching.lbo-individual.test.mjs` — regression cases for `1536` (numeric) and `Avenue Q` (single-letter token dropped).

## Testing
- `node --test scripts/lib/show-matching.lbo-individual.test.mjs` → pass (both new cases).
- SERP pick logic simulated against real + adversarial URLs: picks `1536` and `Avenue Q` targets; rejects roundup URLs, non-review pages, and a wrong-show `avenue-verte` URL returned first (full-pool guard).
- Adversarial ship-check review run; its P1 (single-show pool was too weak) applied, P2 (numeric blast radius) documented, P0 (claimed revert) verified false — all commits intact on disk.
- Pre-existing CI failures (`validate-data-push-refusal-sentinel.test.mjs`, census/WET) are unrelated — confirmed byte-identical on `main` (run 28509108077) before this branch existed, and no slug/matching test regressed.

## Follow-up (not in this PR)
Merging the code enables *future* catches. To backfill the two reviews now, the LBO scraper must run with `SCRAPINGBEE_API_KEY` + private data (`gather-reviews.yml` / targeted `--shows=1536-west-end-2026`), which isn't available in this cloud session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)