### PR TITLE
fix: unblock 1 Minute Critic discovery for off-Broadway shows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1665,6 +1665,7 @@ jobs:
             tests/unit/biz-data-functions.test.mjs \
             tests/unit/bww-roundup-extractor.test.mjs \
             tests/unit/bww-roundup-method2-fallthrough.test.mjs \
+            tests/unit/bww-roundup-parser-digit-outlet.test.mjs \
             tests/unit/btc-send-picks.test.mjs \
             tests/unit/commercial-changes.test.mjs \
             tests/unit/content-verifier.test.mjs \

--- a/scripts/lib/bww-roundup-parser.js
+++ b/scripts/lib/bww-roundup-parser.js
@@ -33,7 +33,12 @@ const NAME_CAPTURE = `${LEADING_INITIAL}${NAME_WORD}${MIDDLE_INITIAL}\\s+${NAME_
 // end before "Faith" and the next match would absorb "Faith Joe Dziemianowicz"
 // as one critic name. Mirrors the original two-word boundary pre-fix.
 const NAME_LOOKAHEAD = `${LEADING_INITIAL}${NAME_WORD}${MIDDLE_INITIAL}\\s+${NAME_WORD}`;
-const OUTLET = "[A-Za-z][A-Za-z\\s&'.]+";
+// Optional leading digit-group so digit-prefixed outlet names ("1 Minute
+// Critic", "5th Estate Theatre") parse. Without it the whole entry was
+// silently dropped AND its quote was absorbed into the previous outlet's quote
+// (the "Matthew Wexler, 1 Minute Critic:" miss). Body still requires
+// letters-only, so a stray number ending the prior quote can't be misread.
+const OUTLET = "(?:[0-9]+\\s+)?[A-Za-z][A-Za-z\\s&'.]+";
 
 const CRITIC_OUTLET_PATTERN = new RegExp(
   `(${NAME_CAPTURE}),\\s+(${OUTLET}):\\s*([^]+?)(?=(?:${NAME_LOOKAHEAD},\\s+${OUTLET}:)|Photo Credit:|$)`,

--- a/scripts/opening-night-poller.js
+++ b/scripts/opening-night-poller.js
@@ -44,6 +44,11 @@ const {
 const { checkRSSFeeds } = require('./lib/rss-discovery');
 const { searchOutletSites, SITE_SEARCH_ENDPOINTS } = require('./lib/site-search-discovery');
 const { discoverCorrectUrl, OUTLET_DOMAINS } = require('./lib/url-discovery');
+// 1 Minute Critic direct-discovery. Its RSS feed isn't in rss-discovery.js's
+// outlet list, and the T3 SERP fallback below is Broadway-only, so without
+// this per-show hook OMC coverage relies entirely on aggregator pickup —
+// which historically missed Giant/Cats/Fallen Angels/Proof at opening.
+const { discoverNewReviews: discoverOMCReviews, OUTLET_NAME: OMC_OUTLET_NAME } = require('./lib/omc-discovery');
 const { validatePageMatchesShow } = require('./lib/page-validator');
 const { isLondonMarket } = require('./lib/venue-classification');
 const { llmFallbackExtract, hasStructuralMarkers } = require('./lib/llm-extractor');
@@ -232,6 +237,7 @@ const FORCE_SERP = process.argv.includes('--force-serp');
 // Emergency kill-switch (rarely needed): gh variable set DISABLE_WE_SERP_BURST --body true
 const ENABLE_WE_SERP_BURST = process.env.DISABLE_WE_SERP_BURST !== 'true';
 const SKIP_SITE_SEARCH = process.argv.includes('--skip-site-search');
+const SKIP_OMC = process.argv.includes('--skip-omc');
 const VERBOSE = process.argv.includes('--verbose') || true; // Always verbose for CI logs
 // Escape hatches: bypass SERP discovery when discovery fails (wrong Google result, unindexed page)
 // CLI args take priority; falls back to shows.json fields (bwwRoundupUrl, tbReviewUrl)
@@ -1391,6 +1397,29 @@ async function runRSSFeeds(showTitle, knownUrls, openingDate = null, market = 'b
 }
 
 /**
+ * Run Layer 2b: 1 Minute Critic direct RSS discovery.
+ *
+ * Independent from Layer 2 (rss-discovery.js) — that module's feed list does
+ * not include the OMC feed, and adding it there would apply its market-gated
+ * broad matcher; OMC needs its own per-show matcher (title + date-window +
+ * `-review/`-slug guard). Runs for all markets.
+ *
+ * @param {string} showId
+ * @param {Object} show   Full show object (openingDate/previewsStartDate anchor discovery).
+ */
+async function runOMC(showId, show) {
+  console.log('\n[Layer 2b] 1 Minute Critic RSS...');
+  try {
+    const results = await discoverOMCReviews(showId, show, undefined, { verbose: VERBOSE });
+    console.log(`  [Layer 2b Total] ${results.length} reviews from ${OMC_OUTLET_NAME}`);
+    return results;
+  } catch (err) {
+    console.log(`  OMC error: ${err.message}`);
+    return [];
+  }
+}
+
+/**
  * Run Layer 3: Direct Site Search
  * @param {string} showTitle
  * @param {string[]} missingOutletIds
@@ -1679,6 +1708,7 @@ async function pollCycle() {
   // JS-rendered site-search (ScrapingBee cost) runs after, with missing-outlet filter,
   // to avoid burning SB credits on outlets already found by aggregators/RSS.
   if (SKIP_SITE_SEARCH) console.log('\n[Layer 3] Site Search... SKIPPED (--skip-site-search)');
+  if (SKIP_OMC) console.log('\n[Layer 2b] 1 Minute Critic RSS... SKIPPED (--skip-omc)');
 
   // SSR outlets are free (plain HTTP) — run unconditionally in parallel.
   // JS-rendered outlets cost SB credits — run only for still-missing outlets after parallel phase.
@@ -1694,23 +1724,25 @@ async function pollCycle() {
       })
     : [];
 
-  const [aggSettled, rssSettled, ssrSettled] = await Promise.allSettled([
+  const [aggSettled, rssSettled, ssrSettled, omcSettled] = await Promise.allSettled([
     runAggregators(show),
     runRSSFeeds(show.title, knownUrls, show.openingDate || null, market),
     ssrSiteSearchIds.length > 0
       ? runSiteSearch(show.title, ssrSiteSearchIds, knownUrls, market, show.openingDate || null, show)
       : Promise.resolve([]),
+    SKIP_OMC ? Promise.resolve([]) : runOMC(SHOW_ID, show),
   ]);
   const aggResults = aggSettled.status === 'fulfilled' ? aggSettled.value : (console.log(`  [Layer 1] ERROR: ${aggSettled.reason?.message}`), []);
   const rssResults = rssSettled.status === 'fulfilled' ? rssSettled.value : (console.log(`  [Layer 2] ERROR: ${rssSettled.reason?.message}`), []);
   const ssrSiteSearchResults = ssrSettled.status === 'fulfilled' ? ssrSettled.value : (console.log(`  [Layer 3 SSR] ERROR: ${ssrSettled.reason?.message}`), []);
+  const omcResults = omcSettled.status === 'fulfilled' ? omcSettled.value : (console.log(`  [Layer 2b] ERROR: ${omcSettled.reason?.message}`), []);
 
   // JS-rendered site-search: only for outlets still missing after parallel phase.
   // Prevents burning SB credits on outlets aggregators/RSS already found.
   let jsSiteSearchResults = [];
   if (!SKIP_SITE_SEARCH) {
     const foundAfterParallel = getFoundOutletIds(SHOW_ID);
-    for (const r of [...aggResults, ...rssResults, ...ssrSiteSearchResults]) {
+    for (const r of [...aggResults, ...rssResults, ...ssrSiteSearchResults, ...omcResults]) {
       if (r.outletId) foundAfterParallel.add(r.outletId.toLowerCase());
     }
     const missingJsIds = Object.keys(SITE_SEARCH_ENDPOINTS).filter(id => {
@@ -1793,7 +1825,7 @@ async function pollCycle() {
   let serpResults = [];
   if ((!SKIP_SERP && shouldRunSerp()) || serpBurstActive) {
     const foundOutletIds = getFoundOutletIds(SHOW_ID);
-    for (const r of [...aggResults, ...rssResults, ...siteSearchResults]) {
+    for (const r of [...aggResults, ...rssResults, ...siteSearchResults, ...omcResults]) {
       if (r.outletId) foundOutletIds.add(r.outletId.toLowerCase());
     }
     // Sort T1 before T2 so the 30-call SERP budget goes to highest-value outlets first
@@ -1935,7 +1967,7 @@ async function pollCycle() {
   // else: ENABLE_WE_SERP_BURST on but burst disallowed — the "burst not allowed" line above already logged it
 
   // ── Process discovered reviews ──
-  const allDiscovered = [...aggResults, ...rssResults, ...siteSearchResults, ...serpResults];
+  const allDiscovered = [...aggResults, ...rssResults, ...siteSearchResults, ...serpResults, ...omcResults];
   console.log(`\n━━━ Processing ${allDiscovered.length} discovered reviews ━━━`);
 
   const { created, skipped, rejected } = processDiscoveredReviews(
@@ -1980,7 +2012,7 @@ async function pollCycle() {
   console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
   console.log('  POLL CYCLE RESULTS');
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
-  console.log(`  Discovered: ${allDiscovered.length} (agg:${aggResults.length} rss:${rssResults.length} site:${siteSearchResults.length} serp:${serpResults.length}) [parallel: layers 1-3]`);
+  console.log(`  Discovered: ${allDiscovered.length} (agg:${aggResults.length} rss:${rssResults.length} site:${siteSearchResults.length} serp:${serpResults.length} omc:${omcResults.length}) [parallel: layers 1-3+2b]`);
   console.log(`  Files created: ${created} | Skipped: ${skipped} | Rejected: ${rejected}`);
   console.log(`  Scored reviews: ${preStatus.total} → ${postStatus.total} (+${newReviews})`);
   console.log(`  T1: ${postStatus.t1} | T2: ${postStatus.t2} | Hi-conf: ${postStatus.highConfidence}`);

--- a/tests/unit/bww-roundup-parser-digit-outlet.test.mjs
+++ b/tests/unit/bww-roundup-parser-digit-outlet.test.mjs
@@ -1,0 +1,80 @@
+/**
+ * Unit test for scripts/lib/bww-roundup-parser.js OUTLET regex.
+ *
+ * Regression: "Matthew Wexler, 1 Minute Critic: ..." was silently dropped
+ * because OUTLET required a leading letter. The digit-leading outlet failed
+ * to match, AND — because the parser scans for the NEXT match to bound the
+ * previous quote — the dropped entry's quote was absorbed into the preceding
+ * outlet's quote, corrupting THAT quote too.
+ *
+ * These tests lock: (a) digit-leading outlets parse, (b) letter-leading
+ * outlets still parse, (c) the preceding quote stays clean, (d) known
+ * BWW-Roundup shapes (initial-prefix critic name, punctuation between quotes)
+ * are unaffected.
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { parseArticleBodyReviews } = require('../../scripts/lib/bww-roundup-parser.js');
+
+describe('bww-roundup-parser: digit-leading outlet names', () => {
+  test('parses "1 Minute Critic" and does not contaminate previous quote', () => {
+    const body =
+      "Let's see what the critics had to say! " +
+      "Jesse Green, The New York Times: A triumph of staging. " +
+      "Matthew Wexler, 1 Minute Critic: Five stars, dazzling. " +
+      "Adam Feldman, Time Out: Wonderful.";
+
+    const out = parseArticleBodyReviews(body);
+    const outlets = out.map(r => r.outletRaw);
+    assert.deepStrictEqual(outlets, ['The New York Times', '1 Minute Critic', 'Time Out']);
+
+    const nyt = out.find(r => r.outletRaw === 'The New York Times');
+    assert.strictEqual(nyt.quote, 'A triumph of staging.', 'NYT quote must not absorb the dropped 1MC quote');
+
+    const omc = out.find(r => r.outletRaw === '1 Minute Critic');
+    assert.strictEqual(omc.criticName, 'Matthew Wexler');
+    assert.strictEqual(omc.quote, 'Five stars, dazzling.');
+  });
+
+  test('still parses letter-leading outlets (One Minute Critic variant)', () => {
+    const body =
+      "Let's see what the critics had to say! " +
+      "Sara Holdren, One Minute Critic: A must see. " +
+      "Adam Feldman, Time Out: Wonderful.";
+
+    const out = parseArticleBodyReviews(body);
+    assert.strictEqual(out.length, 2);
+    assert.strictEqual(out[0].outletRaw, 'One Minute Critic');
+  });
+
+  test('leading-initial critic name still parses ("J. Kelly Nestruck, The Globe and Mail:")', () => {
+    // Guards against the earlier feedback_critic_name_initial_truncation regression
+    const body =
+      "Let's see what the critics had to say! " +
+      "J. Kelly Nestruck, The Globe and Mail: A strong revival. " +
+      "Jesse Green, The New York Times: Excellent.";
+
+    const out = parseArticleBodyReviews(body);
+    assert.strictEqual(out.length, 2);
+    assert.strictEqual(out[0].criticName, 'J. Kelly Nestruck');
+    assert.strictEqual(out[0].outletRaw, 'The Globe and Mail');
+  });
+
+  test('OUTLET body still rejects mid-name digits (guard against runaway match)', () => {
+    // A stray "5 out of 5" fragment in a quote must not be misread as an outlet.
+    // The optional leading-digit prefix only permits digits BEFORE a letter — the
+    // body itself is still [A-Za-z\s&'.]+, so "5 out of 5" fails as an outlet.
+    const body =
+      "Let's see what the critics had to say! " +
+      "Jesse Green, The New York Times: Gave it 5 out of 5 in one line. " +
+      "Adam Feldman, Time Out: Wonderful.";
+
+    const out = parseArticleBodyReviews(body);
+    assert.strictEqual(out.length, 2);
+    assert.strictEqual(out[0].outletRaw, 'The New York Times');
+    assert.strictEqual(out[1].outletRaw, 'Time Out');
+  });
+});


### PR DESCRIPTION
## Why

Investigating why 1 Minute Critic reviews for **The Maids** (`the-maids-off-broadway-2026`) and **Heated Rivalry** (`heated-rivalry-the-unauthorized-musical-parody-off-broadway-2026`) were missing after ingesting the BWW Review Roundup + Playbill Verdict URLs surfaced two overlapping gaps in the discovery pipeline.

Both shows are off-Broadway, which turned out to matter — the T3 SERP safety net for `one-minute-critic` in `opening-night-poller.js:1636` (`BROADWAY_T3_SERP_OUTLETS`) is gated by `market === 'broadway'`, so off-Broadway shows had no SERP net for OMC at all. The purpose-built per-show OMC RSS module (`scripts/lib/omc-discovery.js`) was written to close that gap for all markets but was never wired in — a full-repo grep for `omc-discovery` / `omcDiscovery` returned zero external references. And `scripts/lib/rss-discovery.js` (the wired RSS layer) does not include the OMC feed.

Separately, the BWW roundup parser silently dropped the whole "Matthew Wexler, 1 Minute Critic:" entry because `OUTLET = "[A-Za-z]..."` requires the outlet to start with a letter. Worse, the dropped entry's quote got absorbed into the preceding outlet's quote via the boundary-scanning lookahead — corrupting a second review at the same time. Sibling fix `tests/unit/1minutecritic-extractor.test.mjs` (2026-05-28) shows the same two shows were the reason for the earlier text-extractor patch, so this has been a repeat gap.

## Changes

- `scripts/lib/bww-roundup-parser.js` — `OUTLET` gains an optional `(?:[0-9]+\s+)?` prefix. Body still requires letters only, so a stray "5 out of 5" in a quote can't be misread as an outlet.
- `scripts/opening-night-poller.js` — new **Layer 2b** (`runOMC`) runs `discoverNewReviews` from `scripts/lib/omc-discovery.js` in parallel with Layers 1–3, plus a `--skip-omc` flag for symmetry with `--skip-serp` / `--skip-site-search`. `omcResults` is merged into `allDiscovered`, `foundOutletIds` bookkeeping, and the discovery-count log.
- `tests/unit/bww-roundup-parser-digit-outlet.test.mjs` — locks the fix: `1 Minute Critic` parses, `One Minute Critic` still parses, previous quote stays clean, `J. Kelly Nestruck` (leading-initial guard) still parses, mid-name digits still rejected.

## Test plan

- [x] `node --test tests/unit/bww-roundup-parser-digit-outlet.test.mjs` — 4/4 pass
- [x] `node --check` on all three edited files
- [x] Adjacent non-cheerio BWW/audit tests pass (`audit-bww-rr-critic-mismatches`, `1minutecritic-extractor`)
- [x] `npx tsc --noEmit` — zero errors from my changed files (pre-existing errors are in `tests/unit/tier-config-consistency.test.ts`, untouched)
- [ ] CI: full test suite (cheerio-dependent BWW suites need CI's node_modules — cloud session doesn't have `cheerio` installed)
- [ ] Re-run `opening-night-poller` for `the-maids-off-broadway-2026` and `heated-rivalry-the-unauthorized-musical-parody-off-broadway-2026` (`--market=off-broadway`, no `--skip-omc`) — needs secrets not present in this cloud session
- [ ] Confirm 1MC reviews land in `data/review-texts/{show-id}/1minutecritic--*.json` and score via `node scripts/verify-review-recovery.js --show=<id> --production`

---
_Generated by [Claude Code](https://claude.ai/code/session_015DXGT8o36vDZXuAiigztPj)_