### PR TITLE
Finance tracker: receipt ingestion, P&L engine, /admin/finances dashboard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1185,6 +1185,18 @@ jobs:
           fi
           echo "✓ Zero aggregator-archive files in public repo"
 
+          # Fail immediately if ANY finances files are tracked in the public repo.
+          # data/finances/ holds billing receipts + P&L ledgers (PII) — lives in the
+          # private repo thomaspryor/broadway-scorecard-data under data/finances/,
+          # accessed only via the GitHub API. It must NEVER be committed here.
+          FIN_COUNT=$(git ls-tree -r HEAD --name-only -- 'data/finances/' 2>/dev/null | wc -l | tr -d ' ')
+          if [ "$FIN_COUNT" -gt "0" ]; then
+            echo "::error::CRITICAL: $FIN_COUNT finances files found in public repo! These contain billing PII and MUST be removed."
+            git ls-tree -r HEAD --name-only -- 'data/finances/' | head -20
+            exit 1
+          fi
+          echo "✓ Zero finances files in public repo"
+
       - name: Guard — public show JSONs not stripped of reviews
         run: |
           # Detect when a commit strips reviews from public show JSONs.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,14 @@ on:
       - 'scripts/validate-market-expansion.js'
       - 'scripts/validate-mobile-shows.js'
       - 'scripts/audit-review-contamination.js'
+      # Finance tracker: pure matchers + P&L rollup + ingestion. Colocated
+      # *.test.mjs run in the lib-test glob; path-listed so a solo edit triggers CI.
+      - 'scripts/lib/finance-matchers.js'
+      - 'scripts/lib/finance-matchers.test.mjs'
+      - 'scripts/lib/finance-stats.js'
+      - 'scripts/lib/finance-stats.test.mjs'
+      - 'scripts/lib/finance-vendors.json'
+      - 'scripts/ingest-finances.js'
       # Contamination --gate catastrophe-floor decision (colocated test runs in the
       # lib-test glob; path-listed so an edit triggers CI per feedback_test_yml_push_path_allowlist).
       - 'scripts/lib/contamination-gate.js'

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ data/review-texts/
 
 # Aggregator archive (copyrighted scraped HTML — stored in private repo thomaspryor/broadway-review-texts)
 data/aggregator-archive/
+# Finances (billing PII: receipts + P&L ledgers — stored in private repo thomaspryor/broadway-scorecard-data under data/finances/, GitHub-API access only, never checked into the public build)
+data/finances/
 # Audit HTML caches (copyrighted source HTML — used by audit-opening-night-extraction.js)
 data/review-sources/
 # Live HTML test fixtures (copyrighted aggregator snapshots used to reproduce

--- a/scripts/ingest-finances.js
+++ b/scripts/ingest-finances.js
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * ingest-finances.js — turn vendor receipt emails into the BWSC expense ledger.
+ *
+ * Sources (pick one):
+ *   --from-file=PATH   Ingest pre-fetched receipts (JSON array of
+ *                      { gmailMessageId, date, from, subject, body }). Used by the
+ *                      MCP bootstrap and by tests — no Gmail creds needed.
+ *   (default)          Gmail API (read-only) via a stored OAuth refresh token
+ *                      (GMAIL_CLIENT_ID / GMAIL_CLIENT_SECRET / GMAIL_REFRESH_TOKEN).
+ *                      This is the production cron path.
+ *
+ * Flags:
+ *   --dry-run          Classify + summarize, write nothing.
+ *   --days=N           Gmail lookback window (default 45; --backfill widens to 400).
+ *   --backfill         One-time historical pull.
+ *   --out=DIR          Ledger dir (default data/finances). Gitignored — in CI the
+ *                      caller syncs it to the private repo via the GitHub API.
+ *
+ * Idempotent: a receipt already in the ledger (by Gmail id OR dedupHash) is skipped,
+ * so re-runs and the MCP→Gmail-API handoff never double-book.
+ */
+const fs = require('fs');
+const path = require('path');
+const { toLedgerRow, loadVendorConfig } = require('./lib/finance-matchers');
+const { computeFinanceStats } = require('./lib/finance-stats');
+
+function parseArgs(argv) {
+  const a = { dryRun: false, days: 45, backfill: false, out: 'data/finances', fromFile: null };
+  for (const arg of argv.slice(2)) {
+    if (arg === '--dry-run') a.dryRun = true;
+    else if (arg === '--backfill') { a.backfill = true; a.days = 400; }
+    else if (arg.startsWith('--days=')) a.days = parseInt(arg.slice(7), 10);
+    else if (arg.startsWith('--out=')) a.out = arg.slice(6);
+    else if (arg.startsWith('--from-file=')) a.fromFile = arg.slice(12);
+  }
+  return a;
+}
+
+function readJson(p, fallback) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return fallback; }
+}
+
+// --- Gmail API source (lazy-required so --from-file needs no googleapis dep) ---
+async function fetchGmailReceipts(days) {
+  const { google } = require('googleapis'); // eslint-disable-line
+  const { GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REFRESH_TOKEN } = process.env;
+  if (!GMAIL_CLIENT_ID || !GMAIL_CLIENT_SECRET || !GMAIL_REFRESH_TOKEN) {
+    throw new Error('Gmail source needs GMAIL_CLIENT_ID / GMAIL_CLIENT_SECRET / GMAIL_REFRESH_TOKEN (or use --from-file).');
+  }
+  const auth = new google.auth.OAuth2(GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET);
+  auth.setCredentials({ refresh_token: GMAIL_REFRESH_TOKEN });
+  const gmail = google.gmail({ version: 'v1', auth });
+  const q = `newer_than:${days}d (subject:(receipt OR invoice OR payment OR subscription OR recharged) OR from:(brightdata.com OR openrouter.ai OR anthropic.com))`;
+  const out = [];
+  let pageToken;
+  do {
+    const list = await gmail.users.messages.list({ userId: 'me', q, maxResults: 100, pageToken });
+    for (const { id } of list.data.messages || []) {
+      const msg = await gmail.users.messages.get({ userId: 'me', id, format: 'full' });
+      out.push(normalizeGmailMessage(msg.data));
+    }
+    pageToken = list.data.nextPageToken;
+  } while (pageToken);
+  return out;
+}
+
+function normalizeGmailMessage(m) {
+  const headers = Object.fromEntries((m.payload?.headers || []).map((h) => [h.name.toLowerCase(), h.value]));
+  return {
+    gmailMessageId: m.id,
+    date: new Date(Number(m.internalDate)).toISOString(),
+    from: headers.from || '',
+    subject: headers.subject || '',
+    body: decodeBody(m.payload),
+  };
+}
+
+function decodeBody(payload) {
+  if (!payload) return '';
+  const parts = [];
+  const walk = (p) => {
+    if (p.body?.data) parts.push(Buffer.from(p.body.data, 'base64').toString('utf8'));
+    (p.parts || []).forEach(walk);
+  };
+  walk(payload);
+  return parts.join(' ').replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ');
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const config = loadVendorConfig();
+
+  const receipts = args.fromFile
+    ? readJson(args.fromFile, [])
+    : await fetchGmailReceipts(args.days);
+
+  const ledgerPath = path.join(args.out, 'expense-ledger.json');
+  const queuePath = path.join(args.out, 'review-queue.json');
+  const ledger = readJson(ledgerPath, []);
+  const queue = readJson(queuePath, []);
+
+  const seenIds = new Set(ledger.map((r) => r.id).filter(Boolean));
+  const seenHashes = new Set(ledger.map((r) => r.dedupHash).filter(Boolean));
+  const seenQueue = new Set(queue.map((q) => q.gmailMessageId).filter(Boolean));
+
+  const stats = { booked: 0, duplicate: 0, personal: 0, ignore: 0, needsReview: 0, unparsed: 0 };
+
+  for (const receipt of receipts) {
+    const { row, disposition } = toLedgerRow(receipt, config);
+    if (disposition === 'booked') {
+      if ((row.id && seenIds.has(row.id)) || seenHashes.has(row.dedupHash)) { stats.duplicate++; continue; }
+      ledger.push(row);
+      if (row.id) seenIds.add(row.id);
+      seenHashes.add(row.dedupHash);
+      stats.booked++;
+    } else if (disposition === 'personal') stats.personal++;
+    else if (disposition === 'ignore') stats.ignore++;
+    else { // needs-review | amount-unparsed
+      disposition === 'amount-unparsed' ? stats.unparsed++ : stats.needsReview++;
+      if (receipt.gmailMessageId && !seenQueue.has(receipt.gmailMessageId)) {
+        queue.push({ gmailMessageId: receipt.gmailMessageId, date: receipt.date, from: receipt.from, subject: receipt.subject, reason: disposition });
+        seenQueue.add(receipt.gmailMessageId);
+      }
+    }
+  }
+
+  ledger.sort((a, b) => String(a.date).localeCompare(String(b.date)));
+
+  console.log(`Receipts in: ${receipts.length}`);
+  console.log(`  booked ${stats.booked} · duplicate ${stats.duplicate} · personal ${stats.personal} · ignored ${stats.ignore} · needs-review ${stats.needsReview} · amount-unparsed ${stats.unparsed}`);
+
+  const revenue = readJson(path.join(args.out, 'revenue-ledger.json'), []);
+  const pnl = computeFinanceStats({ expenses: ledger, revenue, monthsBack: 6 });
+  if (pnl.current) {
+    console.log(`\nCurrent month ${pnl.current.month}: expense $${pnl.current.expense} · revenue $${pnl.current.revenue} · net $${pnl.current.net}`);
+    console.log('By category:', pnl.byCategory.map((c) => `${c.category} $${c.amount}`).join(' · '));
+  }
+
+  if (args.dryRun) { console.log('\n[dry-run] nothing written.'); return; }
+  fs.mkdirSync(args.out, { recursive: true });
+  fs.writeFileSync(ledgerPath, JSON.stringify(ledger, null, 2));
+  fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2));
+  console.log(`\nWrote ${ledger.length} ledger rows → ${ledgerPath}; ${queue.length} review-queue items.`);
+}
+
+if (require.main === module) main().catch((e) => { console.error(e.message); process.exit(1); });
+module.exports = { parseArgs, normalizeGmailMessage, decodeBody };

--- a/scripts/ingest-finances.js
+++ b/scripts/ingest-finances.js
@@ -22,7 +22,7 @@
  */
 const fs = require('fs');
 const path = require('path');
-const { toLedgerRow, loadVendorConfig } = require('./lib/finance-matchers');
+const { toLedgerRow, loadVendorConfig, reclassifyMonthlyDupes, applyExternallyPaid } = require('./lib/finance-matchers');
 const { computeFinanceStats } = require('./lib/finance-stats');
 
 function parseArgs(argv) {
@@ -127,8 +127,14 @@ async function main() {
 
   ledger.sort((a, b) => String(a.date).localeCompare(String(b.date)));
 
+  // Whole-ledger post-passes (both idempotent): split same-month duplicate
+  // subscription charges into 'extra-topup', then re-mark externally-paid rows.
+  const retyped = reclassifyMonthlyDupes(ledger);
+  const ext = applyExternallyPaid(ledger, config);
+
   console.log(`Receipts in: ${receipts.length}`);
   console.log(`  booked ${stats.booked} · duplicate ${stats.duplicate} · personal ${stats.personal} · ignored ${stats.ignore} · needs-review ${stats.needsReview} · amount-unparsed ${stats.unparsed}`);
+  console.log(`  extra-topup retyped ${retyped} · externally-paid marked ${ext.excluded} / cleared ${ext.cleared} (total excluded ${ledger.filter((r) => r.excluded).length})`);
 
   const revenue = readJson(path.join(args.out, 'revenue-ledger.json'), []);
   const pnl = computeFinanceStats({ expenses: ledger, revenue, monthsBack: 6 });

--- a/scripts/lib/finance-matchers.js
+++ b/scripts/lib/finance-matchers.js
@@ -176,8 +176,70 @@ function toLedgerRow(receipt, config = loadVendorConfig(), fx = DEFAULT_FX_TO_US
   return { row, disposition: 'booked' };
 }
 
+/**
+ * A vendor billed as 'subscription' should charge once per calendar month; the
+ * 2nd+ charge in the same month is a credit top-up / early renewal (ScrapingBee
+ * did this 5x in Feb 2026). Reclassify those rows to kind 'extra-topup' so
+ * exclusion rules and the recurring-vs-usage split can tell them apart.
+ * Operates on the WHOLE ledger and is idempotent + self-healing: each run the
+ * earliest subscription-family charge of a vendor-month is 'subscription', the
+ * rest are 'extra-topup', regardless of what a prior run wrote.
+ * Returns the number of rows whose kind changed.
+ */
+function reclassifyMonthlyDupes(rows) {
+  const groups = new Map();
+  for (const r of rows) {
+    if (r.kind !== 'subscription' && r.kind !== 'extra-topup') continue;
+    const k = `${r.vendorKey}|${String(r.date).slice(0, 7)}`;
+    if (!groups.has(k)) groups.set(k, []);
+    groups.get(k).push(r);
+  }
+  let changed = 0;
+  for (const group of groups.values()) {
+    group.sort((a, b) => String(a.date).localeCompare(String(b.date)) || String(a.id).localeCompare(String(b.id)));
+    group.forEach((r, i) => {
+      const want = i === 0 ? 'subscription' : 'extra-topup';
+      if (r.kind !== want) { r.kind = want; changed++; }
+    });
+  }
+  return changed;
+}
+
+/**
+ * Mark rows matching config.externallyPaid.rules as excluded (paid by someone
+ * other than the business). Recomputes the flag on EVERY row each run so a
+ * config edit retroactively updates the whole ledger. finance-stats skips
+ * excluded rows; they stay in the ledger for audit.
+ * Returns { excluded, cleared } counts.
+ */
+function applyExternallyPaid(rows, config = loadVendorConfig()) {
+  const rules = (config.externallyPaid && config.externallyPaid.rules) || [];
+  const matches = (r, rule) =>
+    r.vendorKey === rule.vendorKey &&
+    (!rule.kinds || rule.kinds.includes(r.kind)) &&
+    (!rule.before || String(r.date) < rule.before) &&
+    (!rule.after || String(r.date) >= rule.after);
+  let excluded = 0;
+  let cleared = 0;
+  for (const r of rows) {
+    const rule = rules.find((rl) => matches(r, rl));
+    if (rule) {
+      if (!r.excluded) excluded++;
+      r.excluded = true;
+      r.excludedReason = rule.reason || 'paid-externally';
+    } else if (r.excluded) {
+      delete r.excluded;
+      delete r.excludedReason;
+      cleared++;
+    }
+  }
+  return { excluded, cleared };
+}
+
 module.exports = {
   loadVendorConfig,
+  reclassifyMonthlyDupes,
+  applyExternallyPaid,
   classifyReceipt,
   matchesRule,
   isPersonal,

--- a/scripts/lib/finance-matchers.js
+++ b/scripts/lib/finance-matchers.js
@@ -1,0 +1,191 @@
+/**
+ * finance-matchers.js — pure classification + amount-extraction for the BWSC
+ * finance tracker. NO network, NO Gmail SDK — takes a normalized receipt
+ * `{ from, subject, body, gmailMessageId, date }` and returns a ledger row or a
+ * disposition. Kept pure so the real matchers are `require()`d by the unit test
+ * (CLAUDE.md Rule 15) — a production match-rule change fails the test.
+ *
+ * Used by scripts/ingest-finances.js (the Gmail fetch layer lives there).
+ */
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_PATH = path.join(__dirname, 'finance-vendors.json');
+
+function loadVendorConfig(configPath = CONFIG_PATH) {
+  return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+}
+
+// Default FX → USD. Overridable per call so ingest can inject live rates.
+// Only currencies we actually see in receipts need entries.
+const DEFAULT_FX_TO_USD = { USD: 1, GBP: 1.27, EUR: 1.08 };
+
+const CURRENCY_BY_SYMBOL = { '$': 'USD', 'US$': 'USD', '£': 'GBP', '€': 'EUR' };
+
+function extractStripeAcct(from = '') {
+  const m = String(from).match(/acct_[A-Za-z0-9]+/);
+  return m ? m[0] : null;
+}
+
+function lc(s) { return String(s || '').toLowerCase(); }
+
+function condContains(haystack, needle) {
+  return lc(haystack).includes(lc(needle));
+}
+
+/**
+ * Does a receipt satisfy a vendor's `match` block? ALL present conditions must
+ * hold (AND). Absent conditions are ignored.
+ */
+function matchesRule(receipt, match) {
+  if (!match) return false;
+  const from = receipt.from || '';
+  const subject = receipt.subject || '';
+  const body = receipt.body || '';
+
+  if (match.from && lc(from) !== lc(match.from)) return false;
+  if (match.fromContains && !condContains(from, match.fromContains)) return false;
+  if (match.stripeAcct && extractStripeAcct(from) !== match.stripeAcct) return false;
+  if (match.subjectContains && !condContains(subject, match.subjectContains)) return false;
+  if (match.bodyContains && !condContains(body, match.bodyContains)) return false;
+  if (match.subjectContainsAny &&
+      !match.subjectContainsAny.some((s) => condContains(subject, s))) return false;
+  return true;
+}
+
+function isPersonal(receipt, config) {
+  const pe = config.personalExclude || {};
+  const from = receipt.from || '';
+  if ((pe.fromExact || []).some((f) => lc(from) === lc(f))) return true;
+  if ((pe.fromContains || []).some((f) => condContains(from, f))) return true;
+  return false;
+}
+
+/**
+ * Classify a receipt against the allowlist.
+ * Returns one of:
+ *   { disposition: 'personal' }
+ *   { disposition: 'ignore', vendorKey }        // e.g. Bright Data summary invoice
+ *   { disposition: 'booked', vendorKey, vendor, category, kind, businessPct }
+ *   { disposition: 'needs-review' }              // no confident match
+ */
+function classifyReceipt(receipt, config = loadVendorConfig()) {
+  if (isPersonal(receipt, config)) return { disposition: 'personal' };
+
+  for (const v of config.expenseVendors || []) {
+    if (matchesRule(receipt, v.match)) {
+      if (v.kind === 'ignore') return { disposition: 'ignore', vendorKey: v.key };
+      return {
+        disposition: 'booked',
+        vendorKey: v.key,
+        vendor: v.vendor,
+        category: v.category,
+        kind: v.kind,
+        businessPct: v.businessPct,
+      };
+    }
+  }
+  return { disposition: 'needs-review' };
+}
+
+// Currency token: symbol + amount, cents optional (Bright Data recharges are whole-dollar).
+const MONEY = '(US\\$|[$£€])\\s?([0-9][0-9,]*(?:\\.[0-9]{2})?)';
+
+function escapeRe(s) { return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+
+/**
+ * Extract the charged amount from receipt text. Tries, in order: vendor-specific
+ * anchors (opts.anchors), then "Amount paid", then "Total", then the last
+ * currency token (receipts put the total near the end). Returns
+ * { amount, currency } or null.
+ */
+function extractAmount(text = '', opts = {}) {
+  const phrases = [...(opts.anchors || []).map(escapeRe), 'amount\\s*paid', 'total'];
+  for (const phrase of phrases) {
+    const re = new RegExp(phrase + '[^0-9$£€]{0,20}' + MONEY, 'i');
+    const m = String(text).match(re);
+    if (m) return toMoney(m[1], m[2]);
+  }
+  const all = [...String(text).matchAll(new RegExp(MONEY, 'gi'))];
+  if (all.length) {
+    const last = all[all.length - 1];
+    return toMoney(last[1], last[2]);
+  }
+  return null;
+}
+
+function toMoney(symbol, digits) {
+  const currency = CURRENCY_BY_SYMBOL[symbol] || CURRENCY_BY_SYMBOL[symbol.replace(/\s/g, '')] || 'USD';
+  return { amount: parseFloat(digits.replace(/,/g, '')), currency };
+}
+
+function toUsd(amount, currency, fx = DEFAULT_FX_TO_USD) {
+  const rate = fx[currency];
+  if (rate == null) throw new Error(`No FX rate for currency ${currency}`);
+  return Math.round(amount * rate * 100) / 100;
+}
+
+function extractReceiptNo(text = '') {
+  const m = String(text).match(/#\s?([0-9]{3,4}-[0-9]{3,4}(?:-[0-9]{3,4})?)/);
+  return m ? m[1] : null;
+}
+
+function computeDedupHash({ vendorKey, date, amountUsd, receiptNo }) {
+  const basis = `${vendorKey}|${date}|${Number(amountUsd).toFixed(2)}|${receiptNo || ''}`;
+  return crypto.createHash('sha256').update(basis).digest('hex').slice(0, 16);
+}
+
+/**
+ * Turn a raw receipt into a ledger row, or null if it should not be booked
+ * (personal / ignore / needs-review / unparseable amount). Idempotency key is
+ * the Gmail canonical messageId; dedupHash is the fallback across the
+ * MCP→Gmail-API switch.
+ */
+function toLedgerRow(receipt, config = loadVendorConfig(), fx = DEFAULT_FX_TO_USD) {
+  const cls = classifyReceipt(receipt, config);
+  if (cls.disposition !== 'booked') return { row: null, disposition: cls.disposition };
+
+  const vcfg = (config.expenseVendors || []).find((v) => v.key === cls.vendorKey) || {};
+  const anchors = vcfg.amountAnchor ? [vcfg.amountAnchor] : [];
+  const money = extractAmount(receipt.body || receipt.subject || '', { anchors });
+  if (!money) return { row: null, disposition: 'amount-unparsed' };
+
+  const amountUsd = toUsd(money.amount, money.currency, fx);
+  const receiptNo = extractReceiptNo(receipt.body || receipt.subject || '');
+  const businessPct = cls.businessPct == null ? 100 : cls.businessPct;
+  const date = (receipt.date || '').slice(0, 10);
+
+  const row = {
+    id: receipt.gmailMessageId ? `gmail-${receipt.gmailMessageId}` : null,
+    dedupHash: computeDedupHash({ vendorKey: cls.vendorKey, date, amountUsd, receiptNo }),
+    date,
+    vendorKey: cls.vendorKey,
+    vendor: cls.vendor,
+    category: cls.category,
+    kind: cls.kind,
+    amount: money.amount,
+    currency: money.currency,
+    amountUsd,
+    businessPct,
+    amountBusiness: Math.round(amountUsd * (businessPct / 100) * 100) / 100,
+    source: 'gmail',
+    raw: { subject: receipt.subject || '', from: receipt.from || '', receiptNo },
+    confidence: 'high',
+  };
+  return { row, disposition: 'booked' };
+}
+
+module.exports = {
+  loadVendorConfig,
+  classifyReceipt,
+  matchesRule,
+  isPersonal,
+  extractStripeAcct,
+  extractAmount,
+  extractReceiptNo,
+  toUsd,
+  computeDedupHash,
+  toLedgerRow,
+  DEFAULT_FX_TO_USD,
+};

--- a/scripts/lib/finance-matchers.test.mjs
+++ b/scripts/lib/finance-matchers.test.mjs
@@ -1,0 +1,151 @@
+// Unit test for the real finance matchers (CLAUDE.md Rule 15 — require the
+// production module, don't reimplement). Fixtures are minimal synthetic
+// receipts that mirror the real vendor formats; NO real billing PII is committed.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const M = require('./finance-matchers.js');
+
+const config = M.loadVendorConfig();
+
+// --- Fixtures (shape matches scripts/ingest-finances.js normalized receipt) ---
+const fx = {
+  anthropic: {
+    gmailMessageId: 'aaa1', date: '2026-06-27T08:27:57Z',
+    from: 'invoice+statements@mail.anthropic.com',
+    subject: 'Your receipt from Anthropic, PBC #2034-6542-7006',
+    body: 'Receipt from Anthropic, PBC $504.70 Paid June 27, 2026 Recharge credits Qty 1 $490.00 Subtotal $490.00 Total excluding tax $490.00 Sales Tax - Colorado (3%) $14.70 Total $504.70 Amount paid $504.70',
+  },
+  bdRecharge: {
+    gmailMessageId: 'bbb1', date: '2026-07-01T06:52:59Z',
+    from: 'noreply@brightdata.com',
+    subject: 'Your Bright Data account hl_9b2d5c61 was recharged',
+    body: 'This notification is to inform you that your account balance just reached $12.97 and was recharged for $50, per your auto-recharge settings.',
+  },
+  bdMonthly: {
+    gmailMessageId: 'bbb2', date: '2026-07-03T13:13:05Z',
+    from: 'noreply@brightdata.com',
+    subject: 'Bright Data monthly bill - June 2026 (paid)',
+    body: 'Your June 2026 tax invoice for Bright Data is now available. Total $312.40',
+  },
+  googleCloud: {
+    gmailMessageId: 'ggg1', date: '2026-07-01T21:15:03Z',
+    from: 'payments-noreply@google.com',
+    subject: "Google: We've received your payment for 6158-9060-6605",
+    body: 'Google Cloud Platform & APIs Payment received Your payment amount of US$192.97 to Google was received on 1 Jul 2026.',
+  },
+  googlePlay: {
+    gmailMessageId: 'ggg2', date: '2026-04-19T22:07:34Z',
+    from: 'googleplay-noreply@google.com',
+    subject: 'Your Google Play Order Receipt from 19 Apr 2026',
+    body: 'Google Play Thank you for your payment You bought a book on Google Play. $9.99',
+  },
+  googleAmbiguous: {
+    gmailMessageId: 'ggg3', date: '2026-06-01T00:00:00Z',
+    from: 'payments-noreply@google.com',
+    subject: "Google: We've received your payment for 0000",
+    body: 'Nest Aware subscription payment received US$8.00',
+  },
+  openrouter: {
+    gmailMessageId: 'ooo1', date: '2026-02-22T20:36:17Z',
+    from: 'receipts@openrouter.ai',
+    subject: 'Your OpenRouter, Inc receipt [#1618-6690]',
+    body: 'Receipt from OpenRouter, Inc [#1618-6690] Amount paid $34.46 Date paid Feb 22, 2026',
+  },
+  xPremium: {
+    gmailMessageId: 'xxx1', date: '2026-06-08T22:46:06Z',
+    from: 'invoice+statements+acct_1Ika5JA3KZ32dPo1@stripe.com',
+    subject: 'Your receipt from X #2936-6638-0841',
+    body: 'Receipt from X $8.00 Paid June 8, 2026 X Premium (per Period) Qty 1 $8.00 Total $8.00 Amount paid $8.00',
+  },
+  xDeveloper: {
+    gmailMessageId: 'xxx2', date: '2026-04-13T02:36:25Z',
+    from: 'invoice+statements+acct_1S46seBJoSOSGwEl@stripe.com',
+    subject: 'Your receipt from X Developer Platform #2539-7100',
+    body: 'Receipt from X Developer Platform $25.00 Paid April 13, 2026 Credits Qty 1 $25.00 Total $25.00 Amount paid $25.00',
+  },
+  scrapingdog: {
+    gmailMessageId: 'sss1', date: '2026-06-22T00:00:00Z',
+    from: 'invoice+statements+acct_1GXTgWLsPRCYo9Br@stripe.com',
+    subject: 'Your receipt from OPENDATA LABS PRIVATE LIMITED #2117-6371',
+    body: 'Receipt from OPENDATA LABS PRIVATE LIMITED $90.00 Scrapingdog (per 1) Qty 1 $90.00 Total $90.00 Amount paid $90.00',
+  },
+};
+
+test('Anthropic receipt → booked at the CHARGED total, not the subtotal', () => {
+  const { row, disposition } = M.toLedgerRow(fx.anthropic, config);
+  assert.equal(disposition, 'booked');
+  assert.equal(row.vendorKey, 'anthropic');
+  assert.equal(row.category, 'llm');
+  assert.equal(row.amount, 504.70); // NOT 490.00
+  assert.equal(row.amountUsd, 504.70);
+  assert.equal(row.businessPct, 100);
+  assert.equal(row.id, 'gmail-aaa1');
+});
+
+test('Bright Data: recharge is booked, monthly summary is ignored (no double-count)', () => {
+  const recharge = M.toLedgerRow(fx.bdRecharge, config);
+  assert.equal(recharge.disposition, 'booked');
+  assert.equal(recharge.row.vendorKey, 'brightdata');
+  assert.equal(recharge.row.amount, 50);
+
+  const monthly = M.toLedgerRow(fx.bdMonthly, config);
+  assert.equal(monthly.disposition, 'ignore');
+  assert.equal(monthly.row, null);
+});
+
+test('Google Cloud (Gemini) → booked; personal Google Play → rejected; ambiguous google → not booked', () => {
+  const cloud = M.toLedgerRow(fx.googleCloud, config);
+  assert.equal(cloud.disposition, 'booked');
+  assert.equal(cloud.row.vendorKey, 'google-cloud');
+  assert.equal(cloud.row.amountUsd, 192.97);
+
+  const play = M.classifyReceipt(fx.googlePlay, config);
+  assert.equal(play.disposition, 'personal');
+
+  // Same billing sender as Cloud but no "Google Cloud Platform" body → must NOT book.
+  const ambiguous = M.classifyReceipt(fx.googleAmbiguous, config);
+  assert.equal(ambiguous.disposition, 'needs-review');
+});
+
+test('OpenRouter → booked $34.46', () => {
+  const { row, disposition } = M.toLedgerRow(fx.openrouter, config);
+  assert.equal(disposition, 'booked');
+  assert.equal(row.vendorKey, 'openrouter');
+  assert.equal(row.amount, 34.46);
+  assert.equal(row.raw.receiptNo, '1618-6690');
+});
+
+test('Stripe-fronted vendors resolve by acct_ id: X Premium vs X Developer vs Scrapingdog', () => {
+  const prem = M.classifyReceipt(fx.xPremium, config);
+  assert.equal(prem.vendorKey, 'x-premium');
+  assert.equal(prem.businessPct, 100);
+
+  const dev = M.classifyReceipt(fx.xDeveloper, config);
+  assert.equal(dev.vendorKey, 'x-developer');
+
+  const dog = M.toLedgerRow(fx.scrapingdog, config);
+  assert.equal(dog.row.vendorKey, 'scrapingdog');
+  assert.equal(dog.row.amount, 90);
+});
+
+test('FX normalizes non-USD to USD', () => {
+  assert.equal(M.toUsd(10, 'GBP', { USD: 1, GBP: 1.27 }), 12.7);
+  assert.equal(M.toUsd(100, 'USD'), 100);
+  assert.throws(() => M.toUsd(5, 'JPY', { USD: 1 }), /No FX rate/);
+});
+
+test('dedupHash is stable across differing Gmail ids (survives MCP→API switch)', () => {
+  const a = M.toLedgerRow({ ...fx.anthropic, gmailMessageId: 'mcp-form' }, config).row;
+  const b = M.toLedgerRow({ ...fx.anthropic, gmailMessageId: 'api-form' }, config).row;
+  assert.notEqual(a.id, b.id);        // different message-id source
+  assert.equal(a.dedupHash, b.dedupHash); // same charge → same fallback key
+});
+
+test('unknown vendor → needs-review, never auto-booked', () => {
+  const r = M.classifyReceipt({
+    from: 'billing@somenewtool.com', subject: 'Your receipt', body: 'Total $12.00',
+  }, config);
+  assert.equal(r.disposition, 'needs-review');
+});

--- a/scripts/lib/finance-matchers.test.mjs
+++ b/scripts/lib/finance-matchers.test.mjs
@@ -149,3 +149,36 @@ test('unknown vendor → needs-review, never auto-booked', () => {
   }, config);
   assert.equal(r.disposition, 'needs-review');
 });
+
+test('reclassifyMonthlyDupes: 2nd+ same-month subscription charge → extra-topup, idempotent', () => {
+  const rows = [
+    { id: 'a', vendorKey: 'scrapingbee', kind: 'subscription', date: '2026-02-02' },
+    { id: 'b', vendorKey: 'scrapingbee', kind: 'subscription', date: '2026-02-09' },
+    { id: 'c', vendorKey: 'scrapingbee', kind: 'subscription', date: '2026-02-19' },
+    { id: 'd', vendorKey: 'scrapingbee', kind: 'subscription', date: '2026-03-11' }, // new month resets
+    { id: 'e', vendorKey: 'resend', kind: 'subscription', date: '2026-02-15' },      // other vendor untouched
+    { id: 'f', vendorKey: 'anthropic', kind: 'usage-recharge', date: '2026-02-15' }, // non-subscription untouched
+  ];
+  assert.equal(M.reclassifyMonthlyDupes(rows), 2);
+  assert.deepEqual(rows.map((r) => r.kind), ['subscription', 'extra-topup', 'extra-topup', 'subscription', 'subscription', 'usage-recharge']);
+  assert.equal(M.reclassifyMonthlyDupes(rows), 0); // second run: no changes
+});
+
+test('applyExternallyPaid: early anthropic recharges + scrapingbee topups excluded, boundary respected', () => {
+  const rows = [
+    { vendorKey: 'anthropic', kind: 'usage-recharge', date: '2026-04-10' }, // < before → excluded
+    { vendorKey: 'anthropic', kind: 'usage-recharge', date: '2026-05-10' }, // ≥ before → kept
+    { vendorKey: 'scrapingbee', kind: 'extra-topup', date: '2026-02-09' },  // excluded
+    { vendorKey: 'scrapingbee', kind: 'subscription', date: '2026-02-02' }, // base sub kept
+  ];
+  const res = M.applyExternallyPaid(rows, config);
+  assert.equal(res.excluded, 2);
+  assert.deepEqual(rows.map((r) => !!r.excluded), [true, false, true, false]);
+  assert.equal(rows[0].excludedReason, 'paid-by-family');
+
+  // Config edit retroactively clears flags (self-healing).
+  const noRules = { ...config, externallyPaid: { rules: [] } };
+  const res2 = M.applyExternallyPaid(rows, noRules);
+  assert.equal(res2.cleared, 2);
+  assert.ok(rows.every((r) => !r.excluded && !r.excludedReason));
+});

--- a/scripts/lib/finance-stats.js
+++ b/scripts/lib/finance-stats.js
@@ -54,7 +54,12 @@ function sumBy(rows, keyFn, valFn) {
  * @param {number} opts.monthsBack how many months of trend (default 12)
  * @param {number|null} opts.cashOnHand optional, enables runway
  */
-function computeFinanceStats({ expenses = [], revenue = [], asOfMonth, monthsBack = 12, cashOnHand = null } = {}) {
+function computeFinanceStats({ expenses: rawExpenses = [], revenue = [], asOfMonth, monthsBack = 12, cashOnHand = null } = {}) {
+  // Rows marked excluded (externally paid — see finance-vendors.json
+  // externallyPaid) never count toward any total; surfaced separately below.
+  const expenses = rawExpenses.filter((e) => !e.excluded);
+  const excludedRows = rawExpenses.filter((e) => e.excluded);
+
   const allMonths = [
     ...expenses.map((e) => monthKey(e.date)),
     ...revenue.map((r) => r.month || monthKey(r.date)),
@@ -136,6 +141,10 @@ function computeFinanceStats({ expenses = [], revenue = [], asOfMonth, monthsBac
     recurringVsUsage: { recurring, usage },
     burnRate,
     runwayMonths,
+    excluded: {
+      count: excludedRows.length,
+      totalUsd: round2(excludedRows.reduce((s, e) => s + ((e.amountBusiness != null ? e.amountBusiness : e.amountUsd) || 0), 0)),
+    },
     totals: {
       expense: round2(trend.reduce((s, t) => s + t.expense, 0)),
       revenue: round2(trend.reduce((s, t) => s + t.revenue, 0)),

--- a/scripts/lib/finance-stats.js
+++ b/scripts/lib/finance-stats.js
@@ -1,0 +1,147 @@
+/**
+ * finance-stats.js — pure P&L rollup for the BWSC finance tracker. Single source
+ * of truth shared by the admin API route (src/app/api/admin/finance-stats) and
+ * the monthly report, mirroring the scripts/lib/affiliate-stats.js pattern.
+ *
+ * Takes already-loaded ledger arrays (the Gmail/GitHub fetch layer lives in
+ * scripts/ingest-finances.js and the API route), so this stays network-free and
+ * unit-testable.
+ *
+ * Expense row shape (see finance-matchers.toLedgerRow): { date, vendorKey,
+ *   vendor, category, kind, amountUsd, businessPct, amountBusiness }.
+ * Revenue row shape (see accrue-revenue): { month, sourceKey, source,
+ *   amountUsd, status: 'realized'|'pending' }.
+ */
+
+function monthKey(dateStr) {
+  return String(dateStr || '').slice(0, 7); // YYYY-MM
+}
+
+function round2(n) {
+  return Math.round(n * 100) / 100;
+}
+
+function pct(part, whole) {
+  if (!whole) return null;
+  return round2((part / whole) * 100);
+}
+
+// Enumerate the N most recent YYYY-MM keys ending at asOfMonth (inclusive).
+function recentMonths(asOfMonth, monthsBack) {
+  const [y, m] = asOfMonth.split('-').map(Number);
+  const out = [];
+  for (let i = monthsBack - 1; i >= 0; i--) {
+    const d = new Date(Date.UTC(y, m - 1 - i, 1));
+    out.push(`${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`);
+  }
+  return out;
+}
+
+function sumBy(rows, keyFn, valFn) {
+  const acc = new Map();
+  for (const r of rows) {
+    const k = keyFn(r);
+    acc.set(k, round2((acc.get(k) || 0) + valFn(r)));
+  }
+  return acc;
+}
+
+/**
+ * @param {object} opts
+ * @param {Array} opts.expenses  expense ledger rows
+ * @param {Array} opts.revenue   revenue ledger rows
+ * @param {string} opts.asOfMonth 'YYYY-MM' (defaults to latest month present)
+ * @param {number} opts.monthsBack how many months of trend (default 12)
+ * @param {number|null} opts.cashOnHand optional, enables runway
+ */
+function computeFinanceStats({ expenses = [], revenue = [], asOfMonth, monthsBack = 12, cashOnHand = null } = {}) {
+  const allMonths = [
+    ...expenses.map((e) => monthKey(e.date)),
+    ...revenue.map((r) => r.month || monthKey(r.date)),
+  ].filter(Boolean).sort();
+  const latest = asOfMonth || allMonths[allMonths.length - 1] || monthKey(new Date().toISOString());
+  const months = recentMonths(latest, monthsBack);
+  const monthSet = new Set(months);
+
+  // Business-booked expense per month (amountBusiness respects businessPct).
+  const expByMonth = sumBy(
+    expenses.filter((e) => monthSet.has(monthKey(e.date))),
+    (e) => monthKey(e.date),
+    (e) => (e.amountBusiness != null ? e.amountBusiness : e.amountUsd) || 0,
+  );
+  // Realized revenue per month (pending excluded from net).
+  const realizedRev = revenue.filter((r) => (r.status || 'realized') === 'realized');
+  const revByMonth = sumBy(
+    realizedRev.filter((r) => monthSet.has(r.month || monthKey(r.date))),
+    (r) => r.month || monthKey(r.date),
+    (r) => r.amountUsd || 0,
+  );
+  const pendingByMonth = sumBy(
+    revenue.filter((r) => r.status === 'pending' && monthSet.has(r.month || monthKey(r.date))),
+    (r) => r.month || monthKey(r.date),
+    (r) => r.amountUsd || 0,
+  );
+
+  const trend = months.map((month) => {
+    const expense = expByMonth.get(month) || 0;
+    const rev = revByMonth.get(month) || 0;
+    const net = round2(rev - expense);
+    return {
+      month,
+      expense,
+      revenue: rev,
+      revenuePending: pendingByMonth.get(month) || 0,
+      net,
+      marginPct: pct(net, rev),
+    };
+  });
+
+  const current = trend[trend.length - 1] || null;
+  const prev = trend[trend.length - 2] || null;
+
+  // Current-month breakdowns.
+  const curExpenses = expenses.filter((e) => monthKey(e.date) === latest);
+  const prevExpenses = expenses.filter((e) => prev && monthKey(e.date) === prev.month);
+  const val = (e) => (e.amountBusiness != null ? e.amountBusiness : e.amountUsd) || 0;
+
+  const byCategory = [...sumBy(curExpenses, (e) => e.category, val).entries()]
+    .map(([category, amount]) => ({ category, amount }))
+    .sort((a, b) => b.amount - a.amount);
+
+  const prevVendor = sumBy(prevExpenses, (e) => e.vendorKey, val);
+  const byVendor = [...sumBy(curExpenses, (e) => e.vendorKey, val).entries()]
+    .map(([vendorKey, amount]) => {
+      const vendor = (curExpenses.find((e) => e.vendorKey === vendorKey) || {}).vendor || vendorKey;
+      const prevAmt = prevVendor.get(vendorKey) || 0;
+      return { vendorKey, vendor, amount, prevAmount: prevAmt, momPct: pct(amount - prevAmt, prevAmt) };
+    })
+    .sort((a, b) => b.amount - a.amount);
+
+  const recurring = round2(curExpenses.filter((e) => e.kind === 'subscription').reduce((s, e) => s + val(e), 0));
+  const usage = round2(curExpenses.filter((e) => e.kind !== 'subscription').reduce((s, e) => s + val(e), 0));
+
+  // Burn = trailing-3-month average business expense.
+  const last3 = trend.slice(-3);
+  const burnRate = last3.length ? round2(last3.reduce((s, t) => s + t.expense, 0) / last3.length) : 0;
+  const runwayMonths = cashOnHand != null && burnRate > 0 ? round2(cashOnHand / burnRate) : null;
+
+  return {
+    asOfMonth: latest,
+    current,
+    previous: prev,
+    momExpenseDeltaPct: current && prev ? pct(current.expense - prev.expense, prev.expense) : null,
+    trend,
+    byCategory,
+    byVendor,
+    recurringVsUsage: { recurring, usage },
+    burnRate,
+    runwayMonths,
+    totals: {
+      expense: round2(trend.reduce((s, t) => s + t.expense, 0)),
+      revenue: round2(trend.reduce((s, t) => s + t.revenue, 0)),
+      net: round2(trend.reduce((s, t) => s + t.net, 0)),
+    },
+  };
+}
+
+module.exports = { computeFinanceStats, monthKey, recentMonths };

--- a/scripts/lib/finance-stats.test.mjs
+++ b/scripts/lib/finance-stats.test.mjs
@@ -58,3 +58,17 @@ test('runway = cashOnHand / trailing-3mo burn when provided', () => {
 });
 
 function round(n) { return Math.round(n * 100) / 100; }
+
+test('excluded rows are skipped everywhere and surfaced in the excluded rollup', () => {
+  const withExcluded = [
+    ...expenses,
+    { date: '2026-06-20', vendorKey: 'anthropic', vendor: 'Anthropic (Claude API)', category: 'llm', kind: 'usage-recharge', amountUsd: 400, businessPct: 100, amountBusiness: 400, excluded: true, excludedReason: 'paid-by-family' },
+  ];
+  const s = computeFinanceStats({ expenses: withExcluded, revenue, asOfMonth: '2026-06', monthsBack: 3 });
+  const base = computeFinanceStats({ expenses, revenue, asOfMonth: '2026-06', monthsBack: 3 });
+  assert.equal(s.current.expense, base.current.expense);       // totals unchanged
+  assert.equal(s.recurringVsUsage.usage, base.recurringVsUsage.usage);
+  assert.equal(s.excluded.count, 1);
+  assert.equal(s.excluded.totalUsd, 400);
+  assert.equal(base.excluded.count, 0);
+});

--- a/scripts/lib/finance-stats.test.mjs
+++ b/scripts/lib/finance-stats.test.mjs
@@ -1,0 +1,60 @@
+// Unit test for the P&L rollup module (require the real module — Rule 15).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { computeFinanceStats, recentMonths } = require('./finance-stats.js');
+
+const expenses = [
+  { date: '2026-05-10', vendorKey: 'anthropic', vendor: 'Anthropic', category: 'llm', kind: 'usage-recharge', amountUsd: 500, businessPct: 100, amountBusiness: 500 },
+  { date: '2026-06-10', vendorKey: 'anthropic', vendor: 'Anthropic', category: 'llm', kind: 'usage-recharge', amountUsd: 1000, businessPct: 100, amountBusiness: 1000 },
+  { date: '2026-06-15', vendorKey: 'scrapingbee', vendor: 'ScrapingBee', category: 'scraping', kind: 'subscription', amountUsd: 99.99, businessPct: 100, amountBusiness: 99.99 },
+  { date: '2026-06-20', vendorKey: 'x-premium', vendor: 'X Premium', category: 'other', kind: 'subscription', amountUsd: 8, businessPct: 50, amountBusiness: 4 },
+];
+const revenue = [
+  { month: '2026-05', sourceKey: 'affiliate', source: 'Affiliate', amountUsd: 200, status: 'realized' },
+  { month: '2026-06', sourceKey: 'affiliate', source: 'Affiliate', amountUsd: 300, status: 'realized' },
+  { month: '2026-06', sourceKey: 'buymeacoffee', source: 'Buy Me A Coffee', amountUsd: 15, status: 'pending' },
+];
+
+test('recentMonths enumerates trailing months across a year boundary', () => {
+  assert.deepEqual(recentMonths('2026-02', 3), ['2025-12', '2026-01', '2026-02']);
+});
+
+test('current-month net = realized revenue − business expense; pending excluded', () => {
+  const s = computeFinanceStats({ expenses, revenue, asOfMonth: '2026-06', monthsBack: 3 });
+  // Business expense June = 1000 + 99.99 + 4 (X Premium at 50%) = 1103.99
+  assert.equal(s.current.expense, 1103.99);
+  assert.equal(s.current.revenue, 300);          // pending $15 NOT counted
+  assert.equal(s.current.revenuePending, 15);
+  assert.equal(s.current.net, round(300 - 1103.99));
+});
+
+test('businessPct is respected (X Premium booked at 50% → $4 not $8)', () => {
+  const s = computeFinanceStats({ expenses, revenue, asOfMonth: '2026-06', monthsBack: 3 });
+  const x = s.byVendor.find((v) => v.vendorKey === 'x-premium');
+  assert.equal(x.amount, 4);
+});
+
+test('MoM expense delta and category rollup', () => {
+  const s = computeFinanceStats({ expenses, revenue, asOfMonth: '2026-06', monthsBack: 3 });
+  // May expense 500 → June 1103.99 ⇒ +120.8%
+  assert.ok(s.momExpenseDeltaPct > 120 && s.momExpenseDeltaPct < 121);
+  const llm = s.byCategory.find((c) => c.category === 'llm');
+  assert.equal(llm.amount, 1000);
+  assert.equal(s.byCategory[0].category, 'llm'); // sorted desc
+});
+
+test('recurring vs usage split by kind', () => {
+  const s = computeFinanceStats({ expenses, revenue, asOfMonth: '2026-06', monthsBack: 3 });
+  assert.equal(s.recurringVsUsage.recurring, 103.99); // scrapingbee 99.99 + x-premium 4
+  assert.equal(s.recurringVsUsage.usage, 1000);       // anthropic
+});
+
+test('runway = cashOnHand / trailing-3mo burn when provided', () => {
+  const s = computeFinanceStats({ expenses, revenue, asOfMonth: '2026-06', monthsBack: 3, cashOnHand: 2000 });
+  // burn = avg(0[Apr], 500[May], 1103.99[Jun]) = 534.66; runway = 2000/534.66 ≈ 3.74
+  assert.ok(s.runwayMonths > 3.5 && s.runwayMonths < 4.0);
+});
+
+function round(n) { return Math.round(n * 100) / 100; }

--- a/scripts/lib/finance-vendors.json
+++ b/scripts/lib/finance-vendors.json
@@ -31,6 +31,14 @@
     { "key": "washington-post", "vendor": "The Washington Post", "category": "data-subscription", "kind": "subscription", "businessPct": 100, "match": { "fromContains": "washingtonpost.com", "subjectContains": "subscription" } }
   ],
 
+  "externallyPaid": {
+    "_note": "Charges someone other than the business paid (family covered early costs — 2026-07-05 user request). Matching rows stay in the ledger for audit but get excluded:true and are skipped by finance-stats. Rules only, no amounts (public repo). 'kinds' omitted = all kinds; 'before' is an exclusive YYYY-MM-DD upper bound on row.date. scrapingbee 'extra-topup' rows are produced by reclassifyMonthlyDupes (2nd+ subscription charge in the same calendar month = credit top-up / early renewal).",
+    "rules": [
+      { "vendorKey": "anthropic", "kinds": ["usage-recharge"], "before": "2026-05-01", "reason": "paid-by-family" },
+      { "vendorKey": "scrapingbee", "kinds": ["extra-topup"], "before": "2026-05-01", "reason": "paid-by-family" }
+    ]
+  },
+
   "revenueSources": [
     { "key": "affiliate", "source": "Affiliate commissions", "provider": "Impact + Partnerize", "capture": "api", "note": "Accrued monthly from getAffiliateStats totals.commission (NEVER totals.revenue)." },
     { "key": "buymeacoffee", "source": "Buy Me A Coffee", "provider": "buymeacoffee.com", "capture": "gmail", "realizedOnPayout": true, "match": { "fromContains": "buymeacoffee.com", "subjectContainsAny": ["supported you", "new member", "became a supporter"] }, "note": "Book as PENDING until a payout clears (account had a verification hold)." }

--- a/scripts/lib/finance-vendors.json
+++ b/scripts/lib/finance-vendors.json
@@ -1,0 +1,38 @@
+{
+  "_note": "Vendor allowlist + match rules for the BWSC finance tracker. Committed as code-adjacent config (no dollar amounts, no PII — vendor names already appear in scraper-cost-report.yml / check-secrets-health.js). The actual ledgers (with amounts) live in the PRIVATE repo under data/finances/, gitignored here. A receipt is booked only on a confident positive match; anything else → review queue (never auto-booked). businessPct is the share booked to the business (per-vendor split); mixed-domain vendors (Google) are separated per-charge via match rules, not by percent.",
+  "categories": ["hosting", "scraping", "llm", "email", "analytics", "data-subscription", "domains", "other"],
+
+  "personalExclude": {
+    "_note": "Hard-reject senders/patterns BEFORE vendor matching. Guards mixed-domain vendors (Google) and known-personal receipts so they never reach the allowlist.",
+    "fromExact": ["googleplay-noreply@google.com", "googlestore-noreply@google.com"],
+    "fromContains": ["united.com", "amtrak.com", "lyftmail.com", "njtransit.com", "optimum.net", "apple.com", "crunch.com", "tryfi.com", "suno.com", "wispr.ai", "nysun.com/personal-placeholder"]
+  },
+
+  "expenseVendors": [
+    { "key": "anthropic", "vendor": "Anthropic (Claude API)", "category": "llm", "kind": "usage-recharge", "businessPct": 100, "match": { "from": "invoice+statements@mail.anthropic.com" } },
+    { "key": "google-cloud", "vendor": "Google Cloud (Gemini API)", "category": "llm", "kind": "usage", "businessPct": 100, "match": { "from": "payments-noreply@google.com", "subjectContains": "received your payment", "bodyContains": "Google Cloud Platform" } },
+    { "key": "openrouter", "vendor": "OpenRouter", "category": "llm", "kind": "usage-recharge", "businessPct": 100, "match": { "from": "receipts@openrouter.ai" } },
+    { "key": "openai", "vendor": "OpenAI (API)", "category": "llm", "kind": "usage", "businessPct": 100, "match": { "fromContains": "openai.com", "subjectContains": "receipt" } },
+    { "key": "brightdata", "vendor": "Bright Data", "category": "scraping", "kind": "usage-recharge", "businessPct": 100, "match": { "from": "noreply@brightdata.com", "subjectContains": "recharged" }, "amountAnchor": "recharged for", "note": "Book the recharge emails; amount is 'recharged for $X' (whole-dollar, with a decoy balance figure in the same line). The monthly 'bill (paid)' PDF is a SUMMARY — see brightdata-invoice-ignore." },
+    { "key": "brightdata-invoice-ignore", "vendor": "Bright Data (monthly summary — DO NOT BOOK)", "category": "scraping", "kind": "ignore", "businessPct": 0, "match": { "from": "noreply@brightdata.com", "subjectContains": "monthly bill" }, "note": "Explicit ignore rule so the summary invoice never double-counts the recharges." },
+    { "key": "scrapingbee", "vendor": "ScrapingBee", "category": "scraping", "kind": "subscription", "businessPct": 100, "match": { "from": "contact@scrapingbee.com" } },
+    { "key": "scrapingdog", "vendor": "Scrapingdog", "category": "scraping", "kind": "subscription", "businessPct": 100, "match": { "stripeAcct": "acct_1GXTgWLsPRCYo9Br", "bodyContains": "OPENDATA LABS" } },
+    { "key": "browserbase", "vendor": "Browserbase", "category": "scraping", "kind": "usage", "businessPct": 100, "match": { "stripeAcct": "acct_1Oq0jrGhqv5yXZ43", "bodyContains": "Browserbase" } },
+    { "key": "vercel", "vendor": "Vercel", "category": "hosting", "kind": "usage", "businessPct": 100, "match": { "from": "invoice+statements@vercel.com" } },
+    { "key": "resend", "vendor": "Resend", "category": "email", "kind": "subscription", "businessPct": 100, "match": { "from": "invoice+statements@invoicing.resend.com" } },
+    { "key": "posthog", "vendor": "PostHog", "category": "analytics", "kind": "usage", "businessPct": 100, "match": { "stripeAcct": "acct_1HIMDDEuIatRXSdz", "bodyContains": "PostHog" } },
+    { "key": "github", "vendor": "GitHub", "category": "hosting", "kind": "subscription", "businessPct": 100, "match": { "from": "noreply@github.com", "subjectContains": "Payment Receipt" } },
+    { "key": "x-developer", "vendor": "X Developer Platform (API)", "category": "data-subscription", "kind": "subscription", "businessPct": 100, "match": { "stripeAcct": "acct_1S46seBJoSOSGwEl", "bodyContains": "X Developer Platform" } },
+    { "key": "x-premium", "vendor": "X Premium", "category": "other", "kind": "subscription", "businessPct": 100, "match": { "stripeAcct": "acct_1Ika5JA3KZ32dPo1", "bodyContains": "Premium" }, "note": "Owner: 100% BWSC. Distinct Stripe acct from x-developer." },
+    { "key": "improvmx", "vendor": "ImprovMX", "category": "email", "kind": "subscription", "businessPct": 100, "match": { "from": "support@improvmx.com" } },
+    { "key": "canva", "vendor": "Canva", "category": "other", "kind": "subscription", "businessPct": 100, "match": { "from": "no-reply@account.canva.com" } },
+    { "key": "ny-sun", "vendor": "The New York Sun", "category": "data-subscription", "kind": "subscription", "businessPct": 100, "match": { "from": "invoice+statements@payments.nysun.com" } },
+    { "key": "broadway-brands", "vendor": "Broadway Brands", "category": "data-subscription", "kind": "subscription", "businessPct": 100, "match": { "stripeAcct": "acct_17ohgmL39wk6fORM", "bodyContains": "Broadway Brands" } },
+    { "key": "washington-post", "vendor": "The Washington Post", "category": "data-subscription", "kind": "subscription", "businessPct": 100, "match": { "fromContains": "washingtonpost.com", "subjectContains": "subscription" } }
+  ],
+
+  "revenueSources": [
+    { "key": "affiliate", "source": "Affiliate commissions", "provider": "Impact + Partnerize", "capture": "api", "note": "Accrued monthly from getAffiliateStats totals.commission (NEVER totals.revenue)." },
+    { "key": "buymeacoffee", "source": "Buy Me A Coffee", "provider": "buymeacoffee.com", "capture": "gmail", "realizedOnPayout": true, "match": { "fromContains": "buymeacoffee.com", "subjectContainsAny": ["supported you", "new member", "became a supporter"] }, "note": "Book as PENDING until a payout clears (account had a verification hold)." }
+  ]
+}

--- a/scripts/lib/stage-data-changes.sh
+++ b/scripts/lib/stage-data-changes.sh
@@ -7,9 +7,10 @@
 # With no arguments: stages all of data/ (minus exclusions).
 # With arguments:    stages only the listed paths (minus exclusions).
 #
-# Excluded paths (copyrighted content that must never hit the public repo):
+# Excluded paths (copyrighted content / billing PII that must never hit the public repo):
 #   - data/aggregator-archive/   (scraped HTML archives)
 #   - data/review-texts/         (full-text reviews)
+#   - data/finances/             (billing receipts + P&L ledgers — PII)
 #
 # The exclusions are enforced via git pathspec negation (:!prefix).
 # They apply even if a caller accidentally passes one of these paths.
@@ -33,6 +34,7 @@ set -euo pipefail
 EXCLUDE_PATHS=(
   ':!data/aggregator-archive/'
   ':!data/review-texts/'
+  ':!data/finances/'
 )
 
 # Default to data/ if no arguments provided

--- a/src/app/admin/finances/Dashboard.tsx
+++ b/src/app/admin/finances/Dashboard.tsx
@@ -1,0 +1,308 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+interface TrendMonth {
+  month: string;
+  expense: number;
+  revenue: number;
+  revenuePending: number;
+  net: number;
+  marginPct: number | null;
+}
+
+interface CategoryRow {
+  category: string;
+  amount: number;
+}
+
+interface VendorRow {
+  vendorKey: string;
+  vendor: string;
+  amount: number;
+  prevAmount: number;
+  momPct: number | null;
+}
+
+interface Stats {
+  asOfMonth: string;
+  current: TrendMonth | null;
+  previous: TrendMonth | null;
+  momExpenseDeltaPct: number | null;
+  trend: TrendMonth[];
+  byCategory: CategoryRow[];
+  byVendor: VendorRow[];
+  recurringVsUsage: { recurring: number; usage: number };
+  burnRate: number;
+  runwayMonths: number | null;
+  totals: { expense: number; revenue: number; net: number };
+  ledgerCounts: { expenses: number; revenue: number };
+  reviewQueueCount: number;
+  updatedAt: string;
+  cached?: boolean;
+}
+
+type Months = 6 | 12;
+
+const fmtMoney = (n: number | undefined | null) =>
+  typeof n === 'number'
+    ? n < 0
+      ? `-$${Math.abs(n).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+      : `$${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+    : '—';
+
+const fmtPct = (n: number | undefined | null) =>
+  typeof n === 'number' ? `${n >= 0 ? '+' : ''}${n.toFixed(1)}%` : '—';
+
+// "2026-06" → "Jun ’26" (rows) / "June 2026" (header). The bare 2-digit form
+// ("Jun 26") reads like a calendar date, so always disambiguate the year.
+const fmtMonth = (ym: string) => {
+  const [y, m] = ym.split('-').map(Number);
+  const d = new Date(Date.UTC(y, m - 1, 1));
+  return `${d.toLocaleDateString(undefined, { month: 'short', timeZone: 'UTC' })} ’${String(y).slice(2)}`;
+};
+
+const fmtMonthLong = (ym: string) => {
+  const [y, m] = ym.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, 1)).toLocaleDateString(undefined, {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+};
+
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-surface-raised border border-white/[0.06] rounded-lg p-4 sm:p-5">
+      <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-3">{title}</h2>
+      {children}
+    </div>
+  );
+}
+
+function BigStat({ label, value, accent, sub }: { label: string; value: string; accent?: 'pos' | 'neg' | null; sub?: string | null }) {
+  const cls = accent === 'pos' ? 'text-green-400' : accent === 'neg' ? 'text-red-400' : 'text-white';
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wide text-gray-500">{label}</div>
+      <div className={`text-2xl sm:text-3xl font-extrabold tabular-nums mt-1 ${cls}`}>{value}</div>
+      <div className="text-[11px] text-gray-500 mt-1 h-4">{sub || ''}</div>
+    </div>
+  );
+}
+
+export default function Dashboard() {
+  const [months, setMonths] = useState<Months>(6);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (m: Months, refresh = false) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ months: String(m) });
+      if (refresh) params.set('refresh', '1');
+      const res = await fetch(`/api/admin/finance-stats?${params.toString()}`, { cache: 'no-store' });
+      if (res.status === 404) {
+        setError('Unauthorized — your admin session has expired. Re-enter via /api/admin/login?token=…');
+        setStats(null);
+        return;
+      }
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        setError(body?.error || `HTTP ${res.status}`);
+        return;
+      }
+      setStats((await res.json()) as Stats);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(months);
+  }, [months, load]);
+
+  const cur = stats?.current;
+  const maxTrend = stats ? Math.max(...stats.trend.map(t => Math.max(t.expense, t.revenue)), 1) : 1;
+
+  return (
+    <div className="space-y-5">
+      {/* Range tabs + refresh */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <div className="inline-flex rounded-lg border border-white/[0.06] overflow-hidden">
+          {([6, 12] as Months[]).map(m => (
+            <button
+              key={m}
+              onClick={() => setMonths(m)}
+              className={`px-4 py-2 text-sm font-medium transition-colors ${
+                months === m ? 'bg-white text-gray-900' : 'bg-transparent text-gray-400 hover:text-white'
+              }`}
+            >
+              {m}mo
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={() => load(months, true)}
+          disabled={loading}
+          className="px-3 py-2 text-sm font-medium border border-white/[0.06] rounded-lg text-gray-300 hover:bg-surface-raised disabled:opacity-50"
+        >
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+        {stats && (
+          <span className="text-xs text-gray-500 ml-auto">
+            {stats.cached ? 'cached' : 'fresh'} · updated {new Date(stats.updatedAt).toLocaleTimeString()}
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div className="border border-red-800 bg-red-950/40 rounded-lg p-4 text-sm text-red-300">{error}</div>
+      )}
+
+      {stats && (
+        <>
+          {/* Top line: this month's P&L */}
+          <Card title={`This month — ${fmtMonthLong(stats.asOfMonth)}`}>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              <BigStat
+                label="Net"
+                value={fmtMoney(cur?.net)}
+                accent={cur == null ? null : cur.net >= 0 ? 'pos' : 'neg'}
+                sub={cur?.marginPct != null ? `${cur.marginPct.toFixed(0)}% margin` : null}
+              />
+              <BigStat
+                label="Revenue"
+                value={fmtMoney(cur?.revenue)}
+                sub={cur && cur.revenuePending > 0 ? `+${fmtMoney(cur.revenuePending)} pending` : null}
+              />
+              <BigStat
+                label="Expenses"
+                value={fmtMoney(cur?.expense)}
+                sub={stats.momExpenseDeltaPct != null ? `${fmtPct(stats.momExpenseDeltaPct)} MoM` : null}
+                accent={stats.momExpenseDeltaPct != null && stats.momExpenseDeltaPct > 25 ? 'neg' : null}
+              />
+              <BigStat
+                label="Burn rate"
+                value={fmtMoney(stats.burnRate)}
+                sub={stats.runwayMonths != null ? `${stats.runwayMonths.toFixed(1)} mo runway` : 'trailing 3-mo avg'}
+              />
+            </div>
+          </Card>
+
+          {/* Monthly trend — paired bars, table-legible */}
+          <Card title={`Monthly trend — last ${stats.trend.length} months`}>
+            <div className="space-y-2">
+              {stats.trend.map(t => (
+                <div key={t.month} className="grid grid-cols-[3rem_1fr_5rem] items-center gap-2 text-sm">
+                  <span className="text-gray-500 text-xs">{fmtMonth(t.month)}</span>
+                  <div className="space-y-1">
+                    <div className="h-2 rounded-sm bg-green-400/80" style={{ width: `${Math.max((t.revenue / maxTrend) * 100, t.revenue > 0 ? 2 : 0)}%` }} />
+                    <div className="h-2 rounded-sm bg-red-400/70" style={{ width: `${Math.max((t.expense / maxTrend) * 100, t.expense > 0 ? 2 : 0)}%` }} />
+                  </div>
+                  <span
+                    className={`text-right tabular-nums font-semibold ${
+                      t.revenue === 0 && t.expense === 0
+                        ? 'text-gray-600' // no activity that month — don't color a meaningless zero
+                        : t.net >= 0
+                        ? 'text-green-400'
+                        : 'text-red-400'
+                    }`}
+                  >
+                    {fmtMoney(t.net)}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-4 text-[11px] text-gray-500 mt-3">
+              <span><span className="inline-block w-2 h-2 rounded-sm bg-green-400/80 mr-1" />revenue</span>
+              <span><span className="inline-block w-2 h-2 rounded-sm bg-red-400/70 mr-1" />expenses</span>
+              <span className="ml-auto">
+                {months}mo totals: {fmtMoney(stats.totals.revenue)} in · {fmtMoney(stats.totals.expense)} out ·{' '}
+                <span className={stats.totals.net >= 0 ? 'text-green-400' : 'text-red-400'}>{fmtMoney(stats.totals.net)} net</span>
+              </span>
+            </div>
+          </Card>
+
+          {/* Category + recurring split */}
+          <div className="grid sm:grid-cols-2 gap-5">
+            <Card title="This month by category">
+              {stats.byCategory.length === 0 ? (
+                <div className="text-sm text-gray-500">No expenses booked this month yet.</div>
+              ) : (
+                <div className="space-y-2">
+                  {stats.byCategory.map(c => (
+                    <div key={c.category} className="flex items-center gap-2 text-sm">
+                      <span className="w-32 text-gray-400 shrink-0">{c.category}</span>
+                      <div className="flex-1 h-2 rounded-sm bg-white/[0.06] overflow-hidden">
+                        <div
+                          className="h-full bg-red-400/70"
+                          style={{ width: `${(c.amount / (stats.byCategory[0]?.amount || 1)) * 100}%` }}
+                        />
+                      </div>
+                      <span className="w-20 text-right text-white font-semibold tabular-nums">{fmtMoney(c.amount)}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </Card>
+            <Card title="Recurring vs usage">
+              <div className="grid grid-cols-2 gap-3">
+                <BigStat label="Subscriptions" value={fmtMoney(stats.recurringVsUsage.recurring)} sub="fixed monthly" />
+                <BigStat label="Usage-based" value={fmtMoney(stats.recurringVsUsage.usage)} sub="APIs, recharges" />
+              </div>
+              {stats.reviewQueueCount > 0 && (
+                <div className="mt-3 text-xs text-yellow-500">
+                  {stats.reviewQueueCount} receipt{stats.reviewQueueCount === 1 ? '' : 's'} awaiting classification in the review queue.
+                </div>
+              )}
+            </Card>
+          </div>
+
+          {/* Vendor table */}
+          {stats.byVendor.length > 0 && (
+            <Card title="This month by vendor">
+              <div className="overflow-x-auto -mx-4 sm:-mx-5">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-xs text-gray-500 uppercase tracking-wide">
+                      <th className="text-left font-medium px-4 sm:px-5 pb-2">Vendor</th>
+                      <th className="text-right font-medium px-2 pb-2">This mo</th>
+                      <th className="text-right font-medium px-2 pb-2">Last mo</th>
+                      <th className="text-right font-medium px-4 sm:px-5 pb-2">MoM</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {stats.byVendor.map(v => (
+                      <tr key={v.vendorKey} className="border-t border-white/[0.06]">
+                        <td className="px-4 sm:px-5 py-2 text-white font-medium">{v.vendor}</td>
+                        <td className="px-2 py-2 text-right text-white font-semibold tabular-nums">{fmtMoney(v.amount)}</td>
+                        <td className="px-2 py-2 text-right text-gray-300 tabular-nums">{fmtMoney(v.prevAmount)}</td>
+                        <td
+                          className={`px-4 sm:px-5 py-2 text-right tabular-nums ${
+                            v.momPct == null ? 'text-gray-600' : v.momPct > 25 ? 'text-red-400' : v.momPct < 0 ? 'text-green-400' : 'text-gray-300'
+                          }`}
+                        >
+                          {fmtPct(v.momPct)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          )}
+
+          <div className="text-xs text-gray-600">
+            {stats.ledgerCounts.expenses} expense rows · {stats.ledgerCounts.revenue} revenue rows · amounts USD ·
+            businessPct applied · pending revenue excluded from net.
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/finances/Dashboard.tsx
+++ b/src/app/admin/finances/Dashboard.tsx
@@ -33,6 +33,7 @@ interface Stats {
   byCategory: CategoryRow[];
   byVendor: VendorRow[];
   recurringVsUsage: { recurring: number; usage: number };
+  excluded: { count: number; totalUsd: number };
   burnRate: number;
   runwayMonths: number | null;
   totals: { expense: number; revenue: number; net: number };
@@ -300,6 +301,10 @@ export default function Dashboard() {
           <div className="text-xs text-gray-600">
             {stats.ledgerCounts.expenses} expense rows · {stats.ledgerCounts.revenue} revenue rows · amounts USD ·
             businessPct applied · pending revenue excluded from net.
+            {stats.excluded?.count > 0 && (
+              <> {stats.excluded.count} early charge{stats.excluded.count === 1 ? '' : 's'} ({fmtMoney(stats.excluded.totalUsd)})
+              paid externally — not counted.</>
+            )}
           </div>
         </>
       )}

--- a/src/app/admin/finances/page.tsx
+++ b/src/app/admin/finances/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from 'next/navigation';
+import { isAdmin } from '@/lib/admin-auth';
+import Dashboard from './Dashboard';
+
+export const dynamic = 'force-dynamic';
+
+// No metadata export — we don't want this page in search indexes or social cards.
+// robots.ts disallows /admin/ for every crawler.
+
+export default function AdminFinancesPage() {
+  if (!isAdmin()) {
+    // Plain 404 rather than a gate form — don't advertise the admin surface.
+    // Bootstrap via /api/admin/login?token=XXX (same as /admin/affiliate).
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-surface text-white">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
+        <header className="mb-6">
+          <h1 className="text-2xl sm:text-3xl font-extrabold text-white">Finances</h1>
+          <p className="text-sm text-gray-400 mt-1">
+            Monthly P&L from the receipt ledger (private repo). Cached 5 minutes.
+          </p>
+        </header>
+        <Dashboard />
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/finance-stats/route.ts
+++ b/src/app/api/admin/finance-stats/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { isAdmin } from '@/lib/admin-auth';
+// Pure P&L rollup shared with scripts (same server-only pattern as
+// affiliate-stats — keeps the module out of the Next.js client bundle graph).
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { computeFinanceStats } = require('../../../../../scripts/lib/finance-stats') as {
+  computeFinanceStats: (opts: {
+    expenses: unknown[];
+    revenue: unknown[];
+    monthsBack?: number;
+  }) => Record<string, unknown>;
+};
+
+/**
+ * Admin finance dashboard JSON API.
+ *
+ * GET /api/admin/finance-stats?months=12[&refresh=1]
+ *
+ * - Auth-gated via admin_token cookie (isAdmin → plain 404, same as affiliate)
+ * - Ledgers live in the PRIVATE repo thomaspryor/broadway-scorecard-data under
+ *   data/finances/ (billing PII — never in this repo / the build). Read here at
+ *   runtime via the GitHub contents API with REVIEW_TEXTS_TOKEN, mirroring
+ *   /api/admin/ingest-review. A missing ledger file is treated as empty, not an
+ *   error, so the dashboard works before the first ingest run.
+ * - Module-level cache, 5-minute TTL, keyed on months; ?refresh=1 busts it.
+ */
+
+export const dynamic = 'force-dynamic';
+
+const GH_API_BASE = 'https://api.github.com';
+const PRIVATE_REPO = 'thomaspryor/broadway-scorecard-data';
+
+interface CachedEntry {
+  data: unknown;
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const cache = new Map<number, CachedEntry>();
+
+async function fetchPrivateJson<T>(path: string, token: string, fallback: T): Promise<T> {
+  const res = await fetch(
+    `${GH_API_BASE}/repos/${PRIVATE_REPO}/contents/${path}?ref=main`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github.raw+json',
+      },
+      cache: 'no-store',
+    },
+  );
+  if (res.status === 404) return fallback; // not created yet — empty ledger
+  if (!res.ok) throw new Error(`GitHub ${res.status} reading ${path}`);
+  return (await res.json()) as T;
+}
+
+export async function GET(request: NextRequest) {
+  if (!isAdmin()) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  const token = process.env.REVIEW_TEXTS_TOKEN;
+  if (!token) {
+    return NextResponse.json({ error: 'REVIEW_TEXTS_TOKEN not configured on server' }, { status: 500 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const months = Math.min(Math.max(parseInt(searchParams.get('months') || '12', 10) || 12, 1), 24);
+  const refresh = searchParams.get('refresh') === '1';
+
+  if (refresh) {
+    cache.delete(months);
+  } else {
+    const hit = cache.get(months);
+    if (hit && hit.expiresAt > Date.now()) {
+      return NextResponse.json({ ...(hit.data as object), cached: true });
+    }
+  }
+
+  try {
+    const [expenses, revenue, reviewQueue] = await Promise.all([
+      fetchPrivateJson<unknown[]>('data/finances/expense-ledger.json', token, []),
+      fetchPrivateJson<unknown[]>('data/finances/revenue-ledger.json', token, []),
+      fetchPrivateJson<unknown[]>('data/finances/review-queue.json', token, []),
+    ]);
+
+    const stats = computeFinanceStats({ expenses, revenue, monthsBack: months });
+    const payload = {
+      ...stats,
+      ledgerCounts: { expenses: expenses.length, revenue: revenue.length },
+      reviewQueueCount: reviewQueue.length,
+      updatedAt: new Date().toISOString(),
+    };
+    cache.set(months, { data: payload, expiresAt: Date.now() + CACHE_TTL_MS });
+    return NextResponse.json({ ...payload, cached: false });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
# Finance tracker — Phases A–C

Automated business P&L from vendor receipt emails. Ledgers (with amounts) live in the **private** data repo under `data/finances/` (gitignored here); this repo carries only code and the amount-free vendor allowlist.

## Phase A — foundations
- `scripts/lib/finance-vendors.json`: vendor allowlist + match rules (no amounts, no PII). Confident-match-or-review-queue; nothing auto-books on a guess.
- `scripts/lib/finance-matchers.js`: pure classification, amount/currency extraction (Stripe-acct disambiguation for X Premium vs X Developer vs Scrapingdog), dedup hashing that survives the MCP→Gmail-API switch.
- `scripts/lib/finance-stats.js`: pure P&L rollup (trend, category/vendor breakdowns, recurring-vs-usage, burn rate, runway) shared by scripts and the admin API.
- `data/finances/` gitignored (PII guard).

## Phase B — ingestion
- `scripts/ingest-finances.js`: receipts → expense ledger. Sources: `--from-file` (bootstrap/tests) or Gmail API read-only (production cron, needs `GMAIL_*` secrets — Phase D). Idempotent by Gmail id + dedup hash; unmatched receipts go to a review queue, never auto-booked. Bright Data monthly summary invoice explicitly ignored so recharges don't double-count.

## Phase C — dashboard
- `GET /api/admin/finance-stats`: admin-cookie-gated (plain 404 unauthenticated, mirroring `/api/admin/affiliate-stats`); reads the three ledgers from the private repo via the GitHub contents API (`REVIEW_TEXTS_TOKEN`); missing ledger files = empty (works pre-bootstrap); 5-min cache with `?refresh=1`.
- `/admin/finances`: this-month net/revenue/expenses/burn, 6/12-month trend, category bars, recurring-vs-usage, vendor MoM table, review-queue notice. Modeled 1:1 on the affiliate dashboard idiom.

## Externally-paid exclusions
Family covered the early Anthropic API overages and one-off ScrapingBee top-ups, so they aren't business costs:
- `externallyPaid` rules in the vendor config (rules only — no amounts): `anthropic` usage-recharges and `scrapingbee` extra-topups dated before 2026-05-01 → `excluded: true`, skipped from every stat, surfaced in the dashboard footer.
- `reclassifyMonthlyDupes()`: 2nd+ same-calendar-month subscription charge retyped `extra-topup` (ScrapingBee charged 5× in Feb 2026). Idempotent; config edits apply retroactively across the ledger.

## Verification
- 20 finance unit tests (`node --test`), all passing; real-function `require()` per repo Rule 15.
- E2E ingest on real-shaped receipts: June books **$1,772.58**; back-dated April Anthropic + duplicate Feb ScrapingBee receipts excluded; Feb base subscription kept; re-run books 0 duplicates.
- `tsc --noEmit` and `next lint` clean; auth behaviors exercised on a local dev server; desktop + mobile screenshots reviewed and approved in-session.

## Not in this PR (Phase D)
Gmail ingest cron + monthly affiliate revenue accrual — blocked on `GMAIL_CLIENT_ID` / `GMAIL_CLIENT_SECRET` / `GMAIL_REFRESH_TOKEN` secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5M3ertPS9xo6ZKnRdexpF