### PR TITLE
UGC launch audit: visual-QA harness + findings

### DIFF
--- a/tests/e2e/ugc-qa/README.md
+++ b/tests/e2e/ugc-qa/README.md
@@ -1,0 +1,44 @@
+# UGC visual QA harness (2026-07-05 launch audit)
+
+Manual Playwright driver used for the pre-launch UGC audit. Not wired into CI —
+`playwright.config.ts` only picks up `*.spec.ts`, so this directory is inert
+until pieces are promoted into real specs.
+
+## What's here
+
+- `supabase-mock.js` — in-memory GoTrue + PostgREST mock installed via Playwright
+  route interception, plus `injectSession()` to act as a signed-in user
+  (localStorage `bsc_auth`). Supports eq-filters, order, `return=representation`,
+  `vnd.pgrst.object`, the `reorder_list_items` RPC, and per-table simulated write
+  failures (`failWrites: ['reviews']`). **This is the intended base for the
+  Phase 4 regression specs** (failed-save-preserves-text, log-another-viewing-appends)
+  — the existing fixture pages can't test real auth/save paths.
+- `capture.js` — flow driver: fixture states, My Shows mock tabs, and live
+  show-page signed-in flows (save, second viewing, failed save, watchlist,
+  add-to-list) at 390px + 1440px. Screenshots to `shots/`, findings to
+  `findings.json`.
+- `findings-2026-07-05.json` — audit-run findings snapshot.
+- `bootstrap-stub-data.js` — synthesizes gitignored `data/*.json` stubs from
+  committed `public/data/mobile-shows.json` for environments without the private
+  data repo (cloud sessions). Refuses to touch git-tracked files. NOTE: the
+  prebuild scripts it feeds (`build-slug-redirects.js`, `generate-diary-data.js`)
+  DO overwrite tracked outputs — `git checkout` them afterwards; never commit
+  stub-derived data.
+
+## Usage
+
+```bash
+# real data (local): skip bootstrap. Cloud/stub: node tests/e2e/ugc-qa/bootstrap-stub-data.js
+NEXT_PUBLIC_FEATURES="...,userAccounts" \
+NEXT_PUBLIC_SUPABASE_URL="https://stub-supabase.local" \
+NEXT_PUBLIC_SUPABASE_ANON_KEY="eyJ<any-jwt-shaped-string>" \
+npx next dev -p 3456
+
+node tests/e2e/ugc-qa/capture.js [fixture|myshows|live|all]
+```
+
+The stub Supabase URL never resolves — all traffic to it is intercepted by the
+mock, so "live" flows exercise the real components end-to-end offline.
+
+Full audit context + launch plan: Notion card "Rating/Review + Wishlist launch
+audit" (2026-07-05).

--- a/tests/e2e/ugc-qa/bootstrap-stub-data.js
+++ b/tests/e2e/ugc-qa/bootstrap-stub-data.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Bootstrap gitignored data/*.json stubs for a cloud session without the
+ * private core-data repo. Synthesizes shows.json from committed
+ * public/data/mobile-shows.json; writes kitchen-sink empty stubs for the rest.
+ * NEVER writes to tracked files.
+ */
+const fs = require('fs');
+const path = require('path');
+const ROOT = process.cwd();
+const DATA = path.join(ROOT, 'data');
+const NOW = '2026-07-01T00:00:00.000Z';
+
+// Guard: refuse to overwrite any git-tracked file
+const { execSync } = require('child_process');
+const tracked = new Set(
+  execSync('git ls-files data', { cwd: ROOT }).toString().trim().split('\n')
+);
+function writeJson(rel, obj) {
+  if (tracked.has(rel)) {
+    console.log(`SKIP tracked: ${rel}`);
+    return;
+  }
+  const p = path.join(ROOT, rel);
+  if (fs.existsSync(p)) {
+    console.log(`exists, leaving: ${rel}`);
+    return;
+  }
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(obj, null, 1));
+  console.log(`wrote ${rel}`);
+}
+
+// ---- shows.json from mobile-shows.json ----
+const mobile = require(path.join(ROOT, 'public/data/mobile-shows.json'));
+const WANT = new Set([
+  // ids referenced by __dev-mock-data.ts
+  'book-of-mormon-2011','cabaret-2024','chess-2025','death-becomes-her-2024',
+  'gypsy-2024','hamilton-2015','les-miserables-west-end-1985',
+  'merrily-we-roll-along-2023','oh-mary-2024','operation-mincemeat-2025',
+  'ragtime-2025','rent-off-broadway-1996','smash-2025','sunset-boulevard-2024',
+  'wicked-2003',
+]);
+// plus a handful of currently-open broadway shows for live show-page flows
+const open = mobile.shows.filter(s => s.st === 'open' && !/west-end|off-broadway/.test(s.id)).slice(0, 8);
+for (const s of open) WANT.add(s.id);
+
+const cat = id => /west-end/.test(id) ? 'west-end' : /off-broadway/.test(id) ? 'off-broadway' : 'broadway';
+const picked = mobile.shows.filter(s => WANT.has(s.id));
+const missing = [...WANT].filter(id => !picked.some(s => s.id === id));
+if (missing.length) console.log('not in mobile-shows (skipped):', missing.join(', '));
+
+const shows = picked.map(s => ({
+  id: s.id,
+  title: s.t,
+  slug: s.s,
+  venue: s.v || 'Unknown Theatre',
+  openingDate: s.od || '2024-01-01',
+  closingDate: s.cd || null,
+  status: s.st || 'open',
+  type: s.ty || 'musical',
+  category: cat(s.id),
+  runtime: '2h 30m',
+  intermissions: 1,
+  images: s.img ? { thumbnail: s.img.th, poster: s.img.po } : undefined,
+  synopsis: s.syn || '',
+  tags: s.tg || [],
+  creativeTeam: (s.ct || []).map(c => ({ name: c.n, role: c.r })),
+  isRevival: (s.tg || []).includes('revival'),
+}));
+writeJson('data/shows.json', { _meta: { lastUpdated: NOW }, shows });
+
+// ---- empty-but-shaped stubs ----
+const stubs = {
+  'data/reviews.json': { _meta: { lastUpdated: NOW }, reviews: [] },
+  'data/audience.json': { _meta: { lastUpdated: NOW }, audience: [] },
+  'data/buzz.json': { _meta: { lastUpdated: NOW }, threads: [] },
+  'data/blog-reviews-for-scoring.json': { _meta: { lastUpdated: NOW }, reviews: [] },
+  'data/awards.json': { _meta: { lastUpdated: NOW }, awards: [], shows: {}, seasons: {} },
+  'data/tony-nominations.json': { _meta: { lastUpdated: NOW }, seasons: {}, nominations: [], shows: {} },
+  'data/commercial.json': { _meta: { lastUpdated: NOW }, shows: {}, commercial: [] },
+  'data/grosses.json': { _meta: { lastUpdated: NOW }, shows: {}, grosses: {} },
+  'data/grosses-history.json': { _meta: { lastUpdated: NOW }, shows: {}, weeks: [] },
+  'data/critic-consensus.json': { _meta: { lastUpdated: NOW }, shows: {}, consensus: {} },
+  'data/audience-buzz.json': { _meta: { lastUpdated: NOW }, shows: {} },
+  'data/cast-changes.json': { _meta: { lastUpdated: NOW }, shows: [] },
+  'data/gold-lists-computed.json': { _meta: { lastUpdated: NOW }, lists: [], badges: {} },
+  'data/related-shows.json': { _meta: { lastUpdated: NOW }, related: {}, shows: {} },
+  'data/show-schedules.json': { _meta: { lastUpdated: NOW }, schedules: {}, shows: {} },
+  'data/theater-metadata.json': { _meta: { lastUpdated: NOW }, theaters: {}, theatres: {} },
+  'data/west-end-venues.json': [],
+  'data/lottery-rush.json': { _meta: { lastUpdated: NOW }, shows: {}, lotteries: [] },
+  'data/todaytix-showtimes.json': { _meta: { lastUpdated: NOW }, shows: {}, showIds: [] },
+  'data/curated-historical-shows.json': { _meta: { lastUpdated: NOW }, shows: [] },
+  'data/show-score-urls.json': { _meta: { lastUpdated: NOW }, urls: {}, shows: {} },
+  'data/nyt-critics-picks.json': { urls: [] },
+  'data/actor-images.json': { _meta: { lastUpdated: NOW }, images: {}, actors: {} },
+  'data/fantasy-league.json': { _meta: { lastUpdated: NOW }, config: {}, entries: [] },
+  'data/fantasy-scores.json': { _meta: { lastUpdated: NOW }, scores: {}, shows: {} },
+  'data/tony-win-probabilities.json': { _meta: { lastUpdated: NOW }, categories: {}, probabilities: {} },
+  'data/tony-polymarket-odds.json': { _meta: { lastUpdated: NOW }, markets: [], categories: {} },
+  'data/tony-kalshi-odds.json': { _meta: { lastUpdated: NOW }, markets: [], categories: {} },
+  'data/tony-loso-stats.json': { _meta: { lastUpdated: NOW }, stats: {}, shows: {} },
+  'data/tony-critic-picks.json': { _meta: { lastUpdated: NOW }, picks: [], critics: {} },
+  'data/tony-frozen-audience-grades.json': { _meta: { lastUpdated: NOW }, grades: {}, shows: {} },
+  'data/analysis/gd-vs-broadwayscore.json': { _meta: { lastUpdated: NOW }, rows: [], shows: {} },
+};
+for (const [rel, obj] of Object.entries(stubs)) writeJson(rel, obj);
+console.log('done');

--- a/tests/e2e/ugc-qa/capture.js
+++ b/tests/e2e/ugc-qa/capture.js
@@ -1,0 +1,315 @@
+/**
+ * UGC visual QA driver — captures the rating/watchlist/lists flows at mobile
+ * (390px) and desktop (1440px) against the local dev server, with a fully
+ * mocked Supabase backend so we act as a real signed-in user.
+ *
+ * Usage: node capture.js [phase]   phase = fixture | myshows | live | all
+ */
+const path = require('path');
+const fs = require('fs');
+const { chromium } = require('playwright-core');
+const { installSupabaseMock, injectSession } = require('./supabase-mock');
+
+const BASE = 'http://localhost:3456';
+const OUT = path.join(__dirname, 'shots');
+fs.mkdirSync(OUT, { recursive: true });
+
+const VIEWPORTS = {
+  mobile: { width: 390, height: 844 },
+  desktop: { width: 1440, height: 900 },
+};
+
+const findings = [];
+function note(id, severity, text) {
+  findings.push({ id, severity, text });
+  console.log(`[${severity}] ${id}: ${text}`);
+}
+
+async function shot(page, name, opts = {}) {
+  const file = path.join(OUT, `${name}.png`);
+  try {
+    await page.screenshot({ path: file, fullPage: opts.fullPage || false, timeout: 12000 });
+    console.log(`  📸 ${name}`);
+  } catch (e) {
+    console.log(`  ⚠️ screenshot failed: ${name}: ${e.message.split('\n')[0]}`);
+    await page.keyboard.press('Escape').catch(() => {});
+  }
+}
+
+async function checkOverflow(page, label) {
+  const overflow = await page.evaluate(() => {
+    const doc = document.documentElement;
+    return { scrollW: doc.scrollWidth, clientW: doc.clientWidth };
+  });
+  if (overflow.scrollW > overflow.clientW + 1) {
+    note(label, 'BUG', `horizontal overflow: scrollWidth ${overflow.scrollW} > viewport ${overflow.clientW}`);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Phase A: fixture page (widget-level UX, no auth)
+// ─────────────────────────────────────────────────────────────
+async function phaseFixture(browser) {
+  console.log('\n=== PHASE A: rating widget fixture ===');
+  for (const [vpName, vp] of Object.entries(VIEWPORTS)) {
+    const ctx = await browser.newContext({ viewport: vp, hasTouch: vpName === 'mobile', isMobile: vpName === 'mobile', deviceScaleFactor: vpName === 'mobile' ? 3 : 1 });
+    const page = await ctx.newPage();
+
+    // A1: empty state → tap star → panel
+    await page.goto(`${BASE}/test/show-rating-fixture?state=empty`);
+    await page.waitForSelector('[data-testid="show-rating-fixture"]');
+    const card = page.locator('[data-testid="rating-card"]');
+    await shot(page, `A1-${vpName}-empty-initial`);
+
+    if (vpName === 'mobile') {
+      // mobile: tap 4th star via touchscreen to trigger touch path
+      const star4 = card.getByRole('button', { name: '4 stars' }).first();
+      await star4.tap();
+    } else {
+      await card.getByRole('button', { name: '4 stars' }).first().click();
+    }
+    await page.waitForTimeout(400);
+    await shot(page, `A2-${vpName}-star-tapped-panel-open`);
+    await checkOverflow(page, `A2-${vpName}`);
+
+    // Half-star affordance on mobile
+    if (vpName === 'mobile') {
+      const halfBtn = page.getByRole('button', { name: /make it/i });
+      if (await halfBtn.count()) {
+        await shot(page, `A3-mobile-halfstar-button`);
+      } else {
+        note('A3-mobile', 'UX', 'no half-star affordance appeared after tap');
+      }
+    }
+
+    // A4: date picker — do NOT click/focus it: onFocus calls showPicker() and the
+    // native popup wedges page.screenshot. Inspect attributes only.
+    const dateInput = page.locator('input[type="date"]');
+    if (await dateInput.count()) {
+      const max = await dateInput.getAttribute('max');
+      const today = new Date().toISOString().split('T')[0];
+      if (max && max > today) note(`A4-${vpName}`, 'BUG', `date max=${max} is in the future (today=${today}) — future closing date leaks into picker cap`);
+    }
+
+    // A5: long review text near limit
+    const textarea = page.locator('textarea');
+    await textarea.fill('x'.repeat(1950));
+    await page.waitForTimeout(200);
+    await shot(page, `A5-${vpName}-near-charlimit`);
+    await textarea.fill('A wonderful night at the theatre. '.repeat(3));
+
+    // A6: save
+    await page.getByRole('button', { name: /^save/i }).click();
+    await page.waitForTimeout(400);
+    await shot(page, `A6-${vpName}-after-save`);
+
+    // A7: existing state — controls row (hover-only affordances on desktop?)
+    await page.goto(`${BASE}/test/show-rating-fixture?state=existing`);
+    await page.waitForSelector('[data-testid="rating-card"]');
+    await shot(page, `A7-${vpName}-existing-initial`);
+    if (vpName === 'desktop') {
+      // check whether edit/delete are invisible until hover
+      const editBtn = page.locator('[data-testid="rating-card"] [aria-label="Edit rating"]').first();
+      const opacity = await editBtn.evaluate(el => getComputedStyle(el.parentElement).opacity).catch(() => null);
+      if (opacity === '0') note('A7-desktop', 'UX', 'edit/delete controls are opacity-0 until hover — undiscoverable');
+      await page.locator('[data-testid="rating-card"]').hover();
+      await page.waitForTimeout(200);
+      await shot(page, `A7b-desktop-existing-hover`);
+    }
+
+    // A8: multi-viewing state
+    await page.goto(`${BASE}/test/show-rating-fixture?state=multi`);
+    await page.waitForSelector('[data-testid="rating-card"]');
+    await shot(page, `A8-${vpName}-multi-viewings`, { fullPage: true });
+    await checkOverflow(page, `A8-${vpName}`);
+
+    // A9: "+ New Viewing" flow
+    const newViewing = page.getByRole('button', { name: /new viewing/i });
+    if (await newViewing.count()) {
+      await newViewing.click();
+      await page.waitForTimeout(400);
+      await shot(page, `A9-${vpName}-new-viewing-panel`);
+      // Does the new-viewing panel pre-fill the OLD rating?
+      const starsLabel = await page.locator('text=/\\d\\.\\d stars/').first().textContent().catch(() => null);
+      if (starsLabel) note(`A9-${vpName}`, 'UX', `"+ New Viewing" pre-fills previous rating (${starsLabel.trim()}) instead of starting fresh`);
+    }
+
+    await ctx.close();
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Phase B: My Shows with mock data
+// ─────────────────────────────────────────────────────────────
+async function phaseMyShows(browser) {
+  console.log('\n=== PHASE B: My Shows (mock data) ===');
+  for (const [vpName, vp] of Object.entries(VIEWPORTS)) {
+    const ctx = await browser.newContext({ viewport: vp, hasTouch: vpName === 'mobile', isMobile: vpName === 'mobile' });
+    const page = await ctx.newPage();
+
+    for (const tab of ['diary', 'watchlist', 'lists']) {
+      await page.goto(`${BASE}/my-shows?mock=1&tab=${tab}`);
+      await page.waitForSelector('text=shows seen', { timeout: 30000 }).catch(() => {});
+      await page.waitForTimeout(800);
+      await shot(page, `B-${vpName}-myshows-${tab}`, { fullPage: true });
+      await checkOverflow(page, `B-${vpName}-${tab}`);
+    }
+
+    await ctx.close();
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Phase C: live show page, real signed-in actions vs mocked Supabase
+// ─────────────────────────────────────────────────────────────
+async function phaseLive(browser) {
+  console.log('\n=== PHASE C: live show page, signed-in flows ===');
+  const SHOW = '/show/gypsy-2024';
+
+  for (const [vpName, vp] of Object.entries(VIEWPORTS)) {
+    // C0: signed-OUT star tap → sign-in modal
+    {
+      const ctx = await browser.newContext({ viewport: vp, hasTouch: vpName === 'mobile', isMobile: vpName === 'mobile' });
+      await installSupabaseMock(ctx);
+      const page = await ctx.newPage();
+      await page.goto(BASE + SHOW, { waitUntil: 'domcontentloaded' });
+      await page.waitForTimeout(2500);
+      await shot(page, `C0-${vpName}-showpage-signedout`, { fullPage: vpName === 'mobile' });
+      await checkOverflow(page, `C0-${vpName}`);
+
+      const ratingHeader = page.locator('text=My Rating & Review').first();
+      if (!(await ratingHeader.count())) {
+        note(`C0-${vpName}`, 'BUG', 'rating widget not found on show page (flag or render issue)');
+      } else {
+        await ratingHeader.scrollIntoViewIfNeeded();
+        const star = page.locator('h3:has-text("My Rating & Review") ~ * button[aria-label="4 stars"], [aria-label="4 stars"]').first();
+        if (vpName === 'mobile') await star.tap().catch(() => star.click()); else await star.click();
+        await page.waitForTimeout(600);
+        await shot(page, `C1-${vpName}-signedout-star-tap`);
+      }
+      await ctx.close();
+    }
+
+    // C2+: signed-in
+    {
+      const ctx = await browser.newContext({ viewport: vp, hasTouch: vpName === 'mobile', isMobile: vpName === 'mobile' });
+      const { store, log } = await installSupabaseMock(ctx);
+      await injectSession(ctx);
+      const page = await ctx.newPage();
+      page.on('console', m => { if (m.type() === 'error') console.log('  [console.error]', m.text().slice(0, 160)); });
+
+      await page.goto(BASE + SHOW, { waitUntil: 'domcontentloaded' });
+      await page.waitForTimeout(3000);
+      await shot(page, `C2-${vpName}-signedin-initial`);
+
+      const star = page.locator('[aria-label="4 stars"]').first();
+      await star.scrollIntoViewIfNeeded();
+      if (vpName === 'mobile') await star.tap().catch(() => star.click()); else await star.click();
+      await page.waitForTimeout(500);
+      await shot(page, `C3-${vpName}-signedin-panel`);
+
+      // type review + date, save
+      await page.locator('textarea').fill('Audra was transcendent. Best Rose I have ever seen.');
+      await page.locator('input[type="date"]').fill('2025-06-15').catch(() => {});
+      await page.getByRole('button', { name: /^save/i }).click();
+      await page.waitForTimeout(1500);
+      await shot(page, `C4-${vpName}-after-save`);
+      const inserts = log.filter(l => l.method === 'POST' && l.path.includes('/reviews'));
+      console.log(`  reviews in store: ${store.reviews.length}, POSTs: ${inserts.length}`);
+      if (store.reviews.length !== 1) note(`C4-${vpName}`, 'BUG', `expected 1 review after save, store has ${store.reviews.length}`);
+
+      // C5: DOUBLE-RATING probe. After save the star row is disabled read-only;
+      // the only path to a second viewing is the small "+ New Viewing" text link.
+      const canRestar = await page.locator('[aria-label="5 stars"]:not([disabled])').count();
+      note(`C5pre-${vpName}`, 'UX', `after saving, star row is ${canRestar ? 'still tappable' : 'DISABLED read-only — only affordances are tiny "+ New Viewing"/hover-pencil'}`);
+      const newViewing = page.getByRole('button', { name: /new viewing/i }).first();
+      await newViewing.scrollIntoViewIfNeeded();
+      await newViewing.click();
+      await page.waitForTimeout(500);
+      await shot(page, `C5-${vpName}-second-rating-panel`);
+      await page.getByRole('button', { name: /^save/i }).click();
+      await page.waitForTimeout(1500);
+      await shot(page, `C5b-${vpName}-after-second-save`);
+      const patches = log.filter(l => l.method === 'PATCH' && l.path.includes('/reviews'));
+      console.log(`  after 2nd save: reviews=${store.reviews.length} POSTs=${log.filter(l => l.method === 'POST' && l.path.includes('/reviews')).length} PATCHes=${patches.length}`);
+      note(`C5-${vpName}`, store.reviews.length === 2 ? 'INFO' : 'BUG',
+        store.reviews.length === 2
+          ? 'second star-click created a second viewing (append)'
+          : `second star-click resulted in ${store.reviews.length} review(s) — ${patches.length ? 'it PATCHed the first one (lastSavedId reuse)' : 'unexpected'}`);
+
+      await ctx.close();
+    }
+
+    // C6: FAILED SAVE — does typed text survive?
+    {
+      const ctx = await browser.newContext({ viewport: vp, hasTouch: vpName === 'mobile', isMobile: vpName === 'mobile' });
+      await installSupabaseMock(ctx, { failWrites: ['reviews'] });
+      await injectSession(ctx);
+      const page = await ctx.newPage();
+      await page.goto(BASE + SHOW, { waitUntil: 'domcontentloaded' });
+      await page.waitForTimeout(3000);
+      const star = page.locator('[aria-label="4 stars"]').first();
+      await star.scrollIntoViewIfNeeded();
+      if (vpName === 'mobile') await star.tap().catch(() => star.click()); else await star.click();
+      await page.waitForTimeout(400);
+      const REVIEW_TEXT = 'This took me ten minutes to type on my phone and I would be furious to lose it.';
+      await page.locator('textarea').fill(REVIEW_TEXT);
+      await page.getByRole('button', { name: /^save/i }).click();
+      await page.waitForTimeout(1500);
+      await shot(page, `C6-${vpName}-after-failed-save`);
+      const panelStillOpen = await page.locator('textarea').count();
+      const textPreserved = panelStillOpen && (await page.locator('textarea').inputValue().catch(() => '')) === REVIEW_TEXT;
+      note(`C6-${vpName}`, textPreserved ? 'INFO' : 'BUG',
+        textPreserved ? 'failed save preserved panel + text' : `failed save ${panelStillOpen ? 'kept panel but lost text' : 'CLOSED panel and discarded typed review'}`);
+      await ctx.close();
+    }
+
+    // C7: watchlist + add-to-list buttons
+    {
+      const ctx = await browser.newContext({ viewport: vp, hasTouch: vpName === 'mobile', isMobile: vpName === 'mobile' });
+      const { store } = await installSupabaseMock(ctx);
+      await injectSession(ctx);
+      const page = await ctx.newPage();
+      await page.goto(BASE + SHOW, { waitUntil: 'domcontentloaded' });
+      await page.waitForTimeout(3000);
+
+      const watchBtn = page.getByRole('button', { name: /watchlist|want to see/i }).first();
+      if (await watchBtn.count()) {
+        await watchBtn.scrollIntoViewIfNeeded();
+        await watchBtn.click();
+        await page.waitForTimeout(1200);
+        await shot(page, `C7-${vpName}-watchlist-clicked`);
+        console.log(`  watchlist rows: ${store.watchlist.length}`);
+      } else {
+        note(`C7-${vpName}`, 'INFO', 'no watchlist button found on show page');
+        await shot(page, `C7-${vpName}-no-watchlist-btn`);
+      }
+
+      const addToList = page.getByRole('button', { name: /add to list/i }).first();
+      if (await addToList.count()) {
+        await addToList.scrollIntoViewIfNeeded();
+        await addToList.click();
+        await page.waitForTimeout(600);
+        await shot(page, `C8-${vpName}-addtolist-dropdown`);
+      }
+      await ctx.close();
+    }
+  }
+}
+
+(async () => {
+  const phase = process.argv[2] || 'all';
+  const browser = await chromium.launch({ executablePath: process.env.CHROMIUM_PATH || undefined });
+  try {
+    const run = async (name, fn) => {
+      try { await fn(browser); } catch (e) { note(name, 'HARNESS', `phase crashed: ${e.message.split('\n')[0]}`); }
+    };
+    if (phase === 'fixture' || phase === 'all') await run('fixture', phaseFixture);
+    if (phase === 'myshows' || phase === 'all') await run('myshows', phaseMyShows);
+    if (phase === 'live' || phase === 'all') await run('live', phaseLive);
+  } finally {
+    await browser.close();
+  }
+  fs.writeFileSync(path.join(__dirname, 'findings.json'), JSON.stringify(findings, null, 2));
+  console.log(`\n${findings.length} findings written to findings.json`);
+})();

--- a/tests/e2e/ugc-qa/findings-2026-07-05.json
+++ b/tests/e2e/ugc-qa/findings-2026-07-05.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "C5pre-mobile",
+    "severity": "UX",
+    "text": "after saving, star row is DISABLED read-only — only affordances are tiny \"+ New Viewing\"/hover-pencil"
+  },
+  {
+    "id": "C5-mobile",
+    "severity": "INFO",
+    "text": "second star-click created a second viewing (append)"
+  },
+  {
+    "id": "C6-mobile",
+    "severity": "BUG",
+    "text": "failed save CLOSED panel and discarded typed review"
+  },
+  {
+    "id": "C5pre-desktop",
+    "severity": "UX",
+    "text": "after saving, star row is DISABLED read-only — only affordances are tiny \"+ New Viewing\"/hover-pencil"
+  },
+  {
+    "id": "C5-desktop",
+    "severity": "INFO",
+    "text": "second star-click created a second viewing (append)"
+  },
+  {
+    "id": "C6-desktop",
+    "severity": "BUG",
+    "text": "failed save CLOSED panel and discarded typed review"
+  }
+]

--- a/tests/e2e/ugc-qa/supabase-mock.js
+++ b/tests/e2e/ugc-qa/supabase-mock.js
@@ -1,0 +1,188 @@
+/**
+ * In-memory Supabase (GoTrue + PostgREST) mock for Playwright route interception.
+ * Matches the subset of PostgREST the app uses: eq filters, order, select,
+ * Prefer: return=representation, vnd.pgrst.object Accept, rpc.
+ */
+const crypto = require('crypto');
+
+const USER_ID = '11111111-2222-3333-4444-555555555555';
+const NOW = () => new Date().toISOString();
+
+const USER = {
+  id: USER_ID,
+  aud: 'authenticated',
+  role: 'authenticated',
+  email: 'qa@example.com',
+  user_metadata: { full_name: 'QA Tester', avatar_url: null },
+  app_metadata: { provider: 'google' },
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+function fakeSession() {
+  const payload = Buffer.from(JSON.stringify({
+    sub: USER_ID, role: 'authenticated', exp: 2052464000, session_id: 'sess-1',
+  })).toString('base64url');
+  const token = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.${payload}.fakesig`;
+  return {
+    access_token: token,
+    token_type: 'bearer',
+    expires_in: 3600 * 24 * 365,
+    expires_at: 2052464000,
+    refresh_token: 'fake-refresh-token',
+    user: USER,
+  };
+}
+
+function makeStore(seed = {}) {
+  return {
+    profiles: seed.profiles || [{
+      id: USER_ID, display_name: 'QA Tester', avatar_url: null,
+      default_visibility: 'private', created_at: NOW(), updated_at: NOW(),
+    }],
+    reviews: seed.reviews || [],
+    watchlist: seed.watchlist || [],
+    lists: seed.lists || [],
+    list_items: seed.list_items || [],
+  };
+}
+
+// parse PostgREST query string filters like user_id=eq.X&order=...&select=...
+function matchFilters(row, searchParams) {
+  for (const [key, val] of searchParams.entries()) {
+    if (['select', 'order', 'limit', 'offset', 'on_conflict'].includes(key)) continue;
+    if (val.startsWith('eq.')) {
+      const want = val.slice(3);
+      if (String(row[key]) !== want) return false;
+    }
+  }
+  return true;
+}
+
+function applyOrder(rows, searchParams) {
+  const order = searchParams.get('order');
+  if (!order) return rows;
+  const [col, dir] = order.split('.');
+  return [...rows].sort((a, b) => {
+    const av = a[col] ?? '', bv = b[col] ?? '';
+    return (av < bv ? -1 : av > bv ? 1 : 0) * (dir === 'desc' ? -1 : 1);
+  });
+}
+
+/**
+ * Install route mocks on a Playwright context or page.
+ * opts.failWrites: array of table names whose INSERT/PATCH return 500.
+ * Returns { store, log } — log records every REST call for assertions.
+ */
+async function installSupabaseMock(target, opts = {}) {
+  const store = makeStore(opts.seed);
+  const log = [];
+  const failWrites = new Set(opts.failWrites || []);
+
+  await target.route('**://stub-supabase.local/**', async (route) => {
+    const req = route.request();
+    const url = new URL(req.url());
+    const method = req.method();
+    const path = url.pathname;
+    log.push({ method, path, qs: url.search, body: req.postData() });
+
+    const json = (status, body) => route.fulfill({
+      status,
+      contentType: 'application/json',
+      headers: { 'access-control-allow-origin': '*' },
+      body: JSON.stringify(body),
+    });
+
+    if (method === 'OPTIONS') {
+      return route.fulfill({
+        status: 204,
+        headers: {
+          'access-control-allow-origin': '*',
+          'access-control-allow-headers': '*',
+          'access-control-allow-methods': '*',
+        },
+      });
+    }
+
+    // ---- GoTrue ----
+    if (path.startsWith('/auth/v1/')) {
+      if (path.endsWith('/user')) return json(200, USER);
+      if (path.endsWith('/token')) return json(200, fakeSession());
+      if (path.endsWith('/logout')) return json(204, {});
+      return json(200, {});
+    }
+
+    // ---- PostgREST rpc ----
+    if (path.startsWith('/rest/v1/rpc/')) {
+      const fn = path.split('/').pop();
+      if (fn === 'reorder_list_items') {
+        const { p_item_ids, p_positions } = JSON.parse(req.postData() || '{}');
+        p_item_ids.forEach((id, i) => {
+          const item = store.list_items.find(r => r.id === id);
+          if (item) item.position = p_positions[i];
+        });
+        return json(204, null);
+      }
+      return json(404, { message: `unknown rpc ${fn}` });
+    }
+
+    // ---- PostgREST tables ----
+    if (path.startsWith('/rest/v1/')) {
+      const table = path.split('/')[3];
+      if (!store[table]) return json(404, { message: `unknown table ${table}` });
+      const wantObject = (req.headers()['accept'] || '').includes('vnd.pgrst.object');
+
+    if (method === 'GET') {
+        let rows = store[table].filter(r => matchFilters(r, url.searchParams));
+        rows = applyOrder(rows, url.searchParams);
+        return json(200, wantObject ? (rows[0] ?? null) : rows);
+      }
+
+      if (method === 'POST') {
+        if (failWrites.has(table)) return json(500, { message: 'Simulated server error', code: '500' });
+        const body = JSON.parse(req.postData() || '{}');
+        const rowsIn = Array.isArray(body) ? body : [body];
+        const prefer = req.headers()['prefer'] || '';
+        const out = [];
+        for (const r of rowsIn) {
+          if (prefer.includes('merge-duplicates') || prefer.includes('resolution')) {
+            // upsert on id
+            const existing = store[table].find(x => x.id === r.id);
+            if (existing) { Object.assign(existing, r, { updated_at: NOW() }); out.push(existing); continue; }
+          }
+          const row = { id: crypto.randomUUID(), created_at: NOW(), updated_at: NOW(), ...r };
+          store[table].push(row);
+          out.push(row);
+        }
+        return json(201, wantObject ? out[0] : out);
+      }
+
+      if (method === 'PATCH') {
+        if (failWrites.has(table)) return json(500, { message: 'Simulated server error', code: '500' });
+        const updates = JSON.parse(req.postData() || '{}');
+        const rows = store[table].filter(r => matchFilters(r, url.searchParams));
+        rows.forEach(r => Object.assign(r, updates, { updated_at: NOW() }));
+        return json(200, wantObject ? (rows[0] ?? null) : rows);
+      }
+
+      if (method === 'DELETE') {
+        const doomed = store[table].filter(r => matchFilters(r, url.searchParams));
+        store[table] = store[table].filter(r => !doomed.includes(r));
+        return json(200, doomed);
+      }
+    }
+
+    return json(404, { message: 'unmocked ' + path });
+  });
+
+  return { store, log, USER_ID };
+}
+
+/** Seed localStorage with a signed-in Supabase session before app scripts run. */
+async function injectSession(context) {
+  const session = fakeSession();
+  await context.addInitScript((s) => {
+    window.localStorage.setItem('bsc_auth', JSON.stringify(s));
+  }, session);
+}
+
+module.exports = { installSupabaseMock, injectSession, USER_ID };


### PR DESCRIPTION
Pre-launch audit artifacts for the Rating/Review + Wishlist feature (session 2026-07-05).

## What's in this PR

- `tests/e2e/ugc-qa/supabase-mock.js` — in-memory GoTrue + PostgREST mock (Playwright route interception) + signed-in session injection. Lets tests exercise the **real** show-page save/watchlist/list flows offline, including simulated write failures. Intended base for the Phase 4 regression specs (failed-save-preserves-text, log-another-viewing-appends).
- `tests/e2e/ugc-qa/capture.js` — flow driver that produced the visual punch list (390px + 1440px): fixture states, My Shows tabs, live signed-in save / second-viewing / failed-save / watchlist / add-to-list.
- `tests/e2e/ugc-qa/findings-2026-07-05.json` — findings snapshot from the audit run.
- `tests/e2e/ugc-qa/bootstrap-stub-data.js` — synthesizes gitignored `data/*.json` stubs from committed `public/data/mobile-shows.json` for environments without the private data repo. Refuses to touch tracked files.
- `README.md` — usage + caveats.

Not wired into CI (`playwright.config.ts` only collects `*.spec.ts`); zero effect on builds or the site.

## Key audit findings (fix plan lives in the Notion card "Rating/Review + Wishlist launch audit")

Confirmed P0s: failed save closes the panel and discards typed review text (both legacy widget and ShowHeroRedesign share the close-in-`finally` bug); redesign's "Rate it" panel is hard-coded to 5.0 stars with no adjuster; mobile half-star input broken (synthetic mousemove after touch resets `isTouchDevice`); save panel opens below the fold at 390px; `useUserLists` mutations swallow errors → false success toasts; date picker allows future "date seen" + UTC off-by-one; rating analytics only fire in a dead code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gp1L5N8xyUG9oPfvG43rcR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gp1L5N8xyUG9oPfvG43rcR)_