### PR TITLE
fix(video-reviews): checkout core data in weekly workflow; fail loudly on missing shows.json

### DIFF
--- a/.github/workflows/weekly-video-reviews.yml
+++ b/.github/workflows/weekly-video-reviews.yml
@@ -51,6 +51,16 @@ jobs:
         with:
           configure-git: 'true'
 
+      # classify-reviews.js and select-best-reviews.js read data/shows.json
+      # (private core data) to match transcripts to productions. Without this
+      # checkout they silently no-op'd for months: classify crashed on ENOENT
+      # into a swallowed catch, exit 0, and no CI run ever published a review
+      # (the 488 on the site all came from manual local runs, 2026-07-05).
+      - name: Checkout core data
+        uses: ./.github/actions/checkout-core-data
+        with:
+          token: ${{ secrets.REVIEW_TEXTS_TOKEN }}
+
       # yt-dlp is not on ubuntu-latest by default.
       # --break-system-packages required on Ubuntu 24.04+ (PEP 668).
       - name: Install yt-dlp

--- a/scripts/video-reviews/classify-reviews.js
+++ b/scripts/video-reviews/classify-reviews.js
@@ -38,6 +38,10 @@ if (!ANTHROPIC_API_KEY) {
 }
 
 function getOpenBroadwayShows() {
+  if (!fs.existsSync(SHOWS_PATH)) {
+    console.error(`Missing ${SHOWS_PATH} — data/shows.json is private core data; in CI the workflow must run .github/actions/checkout-core-data first.`);
+    process.exit(1);
+  }
   const data = JSON.parse(fs.readFileSync(SHOWS_PATH, 'utf8'));
   // Include open/previews shows plus closed shows from the last 3 seasons
   // (June 2023 onward) so transcripts can be matched to historical productions.
@@ -230,4 +234,4 @@ async function main() {
   }
 }
 
-main().catch(console.error);
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/video-reviews/score-video-reviews.js
+++ b/scripts/video-reviews/score-video-reviews.js
@@ -130,4 +130,4 @@ async function main() {
   }
   console.log('\nDone.');
 }
-main().catch(console.error);
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/video-reviews/select-best-reviews.js
+++ b/scripts/video-reviews/select-best-reviews.js
@@ -29,7 +29,14 @@ const MIN_WORDS = 100;
 let _showsCache = null;
 function getShowData(showId) {
   if (!_showsCache) {
-    try { _showsCache = JSON.parse(fs.readFileSync(SHOWS_PATH, 'utf8')).shows; } catch { _showsCache = []; }
+    // Missing shows.json must be fatal: with an empty cache every review's
+    // date sanity-check silently degrades and CI publishes nothing while
+    // reporting success (root cause of the 2026-04→07 no-op runs).
+    if (!fs.existsSync(SHOWS_PATH)) {
+      console.error(`Missing ${SHOWS_PATH} — data/shows.json is private core data; in CI the workflow must run .github/actions/checkout-core-data first.`);
+      process.exit(1);
+    }
+    _showsCache = JSON.parse(fs.readFileSync(SHOWS_PATH, 'utf8')).shows;
   }
   return _showsCache.find(s => s && s.id === showId) || null;
 }

--- a/tests/unit/video-discovery-merge.test.mjs
+++ b/tests/unit/video-discovery-merge.test.mjs
@@ -74,11 +74,14 @@ describe('preserveLlmFlags', () => {
     for (const f of files) {
       const data = JSON.parse(fs.readFileSync(path.join(DISCOVERY_DIR, f), 'utf8'));
       const prev = JSON.parse(JSON.stringify(data.videos));
-      // Simulate a manual pre-classify pass: flag every 10th non-candidate video
-      let expected = 0;
+      // Flag every 10th non-candidate video (guarantees flags even for files
+      // that predate the CI pre-classify pass). Committed files may ALSO carry
+      // real llmFlagged entries from the live pipeline, so the expected carry
+      // count is the TOTAL flagged in prev, not just the synthetic additions.
       for (let i = 0; i < prev.length; i += 10) {
-        if (!prev[i].isReviewCandidate) { prev[i].llmFlagged = true; expected++; }
+        if (!prev[i].isReviewCandidate) prev[i].llmFlagged = true;
       }
+      const expected = prev.filter(v => v.llmFlagged).length;
       // Simulate the fresh rescan discover-videos.js produces (no flags)
       const next = JSON.parse(JSON.stringify(data.videos)).map(v => {
         const { llmFlagged, ...rest } = v;


### PR DESCRIPTION
## Problem

Follow-up to #395. The post-merge backfill run exposed a second, older bug: **no CI run of `weekly-video-reviews.yml` has ever published a review.** The pipeline's classify/select/score steps read `data/shows.json` — private core data — but the workflow never ran `checkout-core-data`:

- `classify-reviews.js` crashed on ENOENT into `main().catch(console.error)` → error printed, **exit 0**, step "success" in 0 seconds.
- `select-best-reviews.js` swallowed the missing file into an empty shows cache.
- Today's backfill collected **216 new TikTok transcripts** (extraction works fine from CI) and then classified none of them.

All 488 published reviews came from the original manual local runs, where shows.json exists.

## Fix

- `weekly-video-reviews.yml`: add the `checkout-core-data` composite action (uses `REVIEW_TEXTS_TOKEN`) before the pipeline steps.
- `classify-reviews.js` / `select-best-reviews.js`: explicit `shows.json` existence check with an actionable error message.
- `classify-reviews.js` / `score-video-reviews.js`: `main().catch` now exits 1 — a crashed step can never report success again.

## Verification

- With shows.json absent: `classify-reviews.js` and `select-best-reviews.js` now **exit 1** with a clear message; previous code demonstrably exited 0 (reproduced both behaviors locally).
- `node --check` on all three scripts; workflow YAML parses; `audit-workflow-hygiene.js` passes (192 workflows).

## After merge

Re-dispatch `weekly-video-reviews.yml` (no refresh needed — discovery + transcripts are already committed). Classify will process the ~225-transcript backlog, then select/score/build should finally publish the recovered TikTok reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMQQ3GJJogmaAc9VGEZaeL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMQQ3GJJogmaAc9VGEZaeL)_