### PR TITLE
data(video-reviews): apply second-pass audit — remove 4 more non-reviews

### DIFF
--- a/data/video-reviews-transcripts/beaches-2026/theatreislife.json
+++ b/data/video-reviews-transcripts/beaches-2026/theatreislife.json
@@ -17,5 +17,8 @@
   "reasoning": "Creator acknowledges special moments and praises the cast, but says the production doesn't meet Broadway design/quality expectations and will play better on tour/regionally. This is a lukewarm mixed take rather than a recommendation.",
   "keyQuote": "There are really special moments, especially in the second act of this production. It just is sort of outweighed by the fact that you're seeing this on a Broadway stage and expect more design wise, quality wise.",
   "scoredAt": "2026-07-05T12:01:47.678Z",
-  "scoringModel": "claude-opus-4-7"
+  "scoringModel": "claude-opus-4-7",
+  "wrongProduction": true,
+  "wrongProductionReason": "News reaction about closing/tour, not a first-hand review",
+  "flaggedBy": "audit-before-share second pass 2026-07-05 (user-approved policy)"
 }

--- a/data/video-reviews-transcripts/cult-of-love-2024/theatreislife.json
+++ b/data/video-reviews-transcripts/cult-of-love-2024/theatreislife.json
@@ -3,7 +3,7 @@
   "platform": "tiktok",
   "videoId": "7457775237128670494",
   "videoUrl": "https://www.tiktok.com/@theatreislife/video/7457775237128670494",
-  "title": "Highest praise is I’m running on 2hr of plane sleep and both these sh...",
+  "title": "Highest praise is I\u2019m running on 2hr of plane sleep and both these sh...",
   "publishedAt": "20250109",
   "views": "4039",
   "duration": "2:50",
@@ -21,5 +21,8 @@
   "ensembleScores": {
     "sonnet": 88,
     "opus": 88
-  }
+  },
+  "wrongProduction": true,
+  "wrongProductionReason": "Covers two shows (Cult of Love + English) \u2014 roundup, not standalone review",
+  "flaggedBy": "audit-before-share second pass 2026-07-05 (user-approved policy)"
 }

--- a/data/video-reviews-transcripts/death-becomes-her-2024/broadwaybob.json
+++ b/data/video-reviews-transcripts/death-becomes-her-2024/broadwaybob.json
@@ -16,5 +16,8 @@
   "reasoning": "Creator hasn't seen the Broadway production directly (saw out-of-town tryout and clips), but expresses strong enthusiasm about the cast recording, tightened comedy, and says they'd see it right now if in NYC. Minor caveat about the score being weaker.",
   "keyQuote": "it's a show that's bringing me a lot of joy right now when I really need it... if I were in New York, I would see it right now",
   "scoredAt": "2026-07-05T12:02:38.088Z",
-  "scoringModel": "claude-opus-4-7"
+  "scoringModel": "claude-opus-4-7",
+  "wrongProduction": true,
+  "wrongProductionReason": "Creator admits not seeing the Broadway production (out-of-town tryout + clips only)",
+  "flaggedBy": "audit-before-share second pass 2026-07-05 (user-approved policy)"
 }

--- a/data/video-reviews-transcripts/heart-of-rock-and-roll-2024/tyvid5.json
+++ b/data/video-reviews-transcripts/heart-of-rock-and-roll-2024/tyvid5.json
@@ -22,7 +22,7 @@
     "sonnet": 88,
     "opus": 90
   },
-  "wrongProduction": false,
-  "wrongProductionReason": "GPT-4o audit: Opening night event experience, not a substantive review",
-  "wrongProductionCleared": "audit-before-share side B RECOVER verdict 2026-07-05: creator attended opening night, first-hand review"
+  "wrongProduction": true,
+  "wrongProductionReason": "Opening-night event vlog (glam, red carpet, celebs), not substantive show critique \u2014 reverses 2026-07-05 side-B recovery",
+  "flaggedBy": "audit-before-share second pass 2026-07-05 (user-approved policy)"
 }

--- a/data/video-reviews.json
+++ b/data/video-reviews.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "description": "Video critic reviews scored by LLM from transcripts",
-    "generatedAt": "2026-07-05T17:17:03.108Z",
+    "generatedAt": "2026-07-05T18:27:57.976Z",
     "pipelineVersion": "1.0.0"
   },
   "11-to-midnight-off-broadway-2026": [
@@ -582,20 +582,6 @@
       "keyQuote": "So grab your best friend and go see beaches, a new musical on Broadway right now. I promise you're gonna wanna be there with them.",
       "thumbnail": null,
       "publishedAt": "20260407"
-    },
-    {
-      "creatorName": "Kate Reinking",
-      "handle": "theatreislife",
-      "platform": "tiktok",
-      "videoUrl": "https://www.tiktok.com/@theatreislife/video/7641741201506422046",
-      "score": 60,
-      "views": "24700",
-      "bucket": "Mixed",
-      "confidence": "medium",
-      "reasoning": "Creator acknowledges special moments and praises the cast, but says the production doesn't meet Broadway design/quality expectations and will play better on tour/regionally. This is a lukewarm mixed take rather than a recommendation.",
-      "keyQuote": "There are really special moments, especially in the second act of this production. It just is sort of outweighed by the fact that you're seeing this on a Broadway stage and expect more design wise, quality wise.",
-      "thumbnail": null,
-      "publishedAt": "20260519"
     },
     {
       "creatorName": "Tyler Nabinger",
@@ -1468,20 +1454,6 @@
   ],
   "cult-of-love-2024": [
     {
-      "creatorName": "Kate Reinking",
-      "handle": "theatreislife",
-      "platform": "tiktok",
-      "videoUrl": "https://www.tiktok.com/@theatreislife/video/7457775237128670494",
-      "score": 88,
-      "views": "4039",
-      "bucket": "Rave",
-      "confidence": "high",
-      "reasoning": "The reviewer expresses strong enthusiasm for Cult of Love, noting it hit them emotionally in unexpected ways, compares it favorably to acclaimed plays like Appropriate and August: Osage County, explicitly recommends it ('Go see cult of love'), and says 'Cannot recommend either of these enough.' They cried during the show and called it 'thrilling to watch.'",
-      "keyQuote": "if you are a fan of plays like appropriate and August was Age County, this is your jam. Go see cult of love.",
-      "thumbnail": null,
-      "publishedAt": "20250109"
-    },
-    {
       "creatorName": "Matthew Hardy (Bored and Confused?)",
       "handle": "MatthewHardyMusical",
       "platform": "youtube",
@@ -1726,20 +1698,6 @@
       "keyQuote": "I think death becomes her is going to join musicals like legally Blonde, Hairspray, and waitress in some of the best movie to musical adaptations.",
       "thumbnail": null,
       "publishedAt": "20241121"
-    },
-    {
-      "creatorName": "Broadway Bob",
-      "handle": "broadwaybob",
-      "platform": "tiktok",
-      "videoUrl": "https://www.tiktok.com/@broadwaybob/video/7501509999445691679",
-      "score": 85,
-      "views": "4798",
-      "bucket": "Rave",
-      "confidence": "medium",
-      "reasoning": "Creator hasn't seen the Broadway production directly (saw out-of-town tryout and clips), but expresses strong enthusiasm about the cast recording, tightened comedy, and says they'd see it right now if in NYC. Minor caveat about the score being weaker.",
-      "keyQuote": "it's a show that's bringing me a lot of joy right now when I really need it... if I were in New York, I would see it right now",
-      "thumbnail": null,
-      "publishedAt": "20250507"
     },
     {
       "creatorName": "Joe Weinberg",
@@ -2661,20 +2619,6 @@
     }
   ],
   "heart-of-rock-and-roll-2024": [
-    {
-      "creatorName": "Tyler (@tyvid5)",
-      "handle": "tyvid5",
-      "platform": "tiktok",
-      "videoUrl": "https://www.tiktok.com/@tyvid5/video/7366284382958554411",
-      "score": 89,
-      "views": "2115",
-      "bucket": "Rave",
-      "confidence": "high",
-      "reasoning": "The reviewer attended opening night and expressed strong enthusiasm throughout, calling the show 'amazing,' describing it as 'the highlight of the season and one of the most fun times I've had at a Broadway show,' and praising the 'electric cast.' The closing metaphor about 'power of love' reinforces the overwhelmingly positive sentiment.",
-      "keyQuote": "And that is the perfect word to describe this show in the electric cast that brings it to life.",
-      "thumbnail": null,
-      "publishedAt": "20240507"
-    },
     {
       "creatorName": "Ash Hufford",
       "handle": "ashleyhufford",


### PR DESCRIPTION
## What

Applies the second-pass side-A audit (run on the cleaned 529-review set after #400): **520 KEEP / 5 REMOVE / 4 REVIEW_MANUALLY**, adjudicated by reading the transcripts:

**Removed (4):**
- `beaches-2026/theatreislife` — closing-news reaction, not a review
- `cult-of-love-2024/theatreislife` — two-show roundup
- `death-becomes-her-2024/broadwaybob` — creator admits not seeing the Broadway production
- `heart-of-rock-and-roll-2024/tyvid5` — opening-night party vlog (glam/red carpet/celebs); reverses the earlier side-B recovery, which was wrong

**Kept (5):** `the-balusters-2026/broadwayben` ("might just be my favorite play currently on Broadway…") and `the-roommate-2024/tylernabinger` ("who I thought had wonderful chemistry") are clear first-hand opinions; the other 3 were already adjudicated in #400 — the auditor only objects to missing explicit "I attended" phrasing, a known false-positive pattern for these creators' formats.

`video-reviews.json` rebuilt: **529 → 525**.

## Verification

- Rebuild count matches expectation exactly (−4).
- Data-only change; feature remains behind the `videoReviews` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMQQ3GJJogmaAc9VGEZaeL

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMQQ3GJJogmaAc9VGEZaeL)_