### PR TITLE
Finance tracker Phase D: daily Gmail receipt-ingest workflow

### DIFF
--- a/.cron-health-exempt.txt
+++ b/.cron-health-exempt.txt
@@ -45,6 +45,7 @@ enrich-runtimes.yml
 fantasy-weekly.yml
 fetch-all-image-formats.yml
 fetch-guardian-reviews.yml
+finance-ingest.yml
 fix-platform-ticket-links.yml
 fix-todaytix-links.yml
 generate-guide-editorials.yml

--- a/.github/workflows/finance-ingest.yml
+++ b/.github/workflows/finance-ingest.yml
@@ -68,6 +68,8 @@ jobs:
           if [ "$BACKFILL" = "true" ]; then FLAGS="--backfill"; fi
           node scripts/ingest-finances.js $FLAGS --out=/tmp/finance-data/data/finances
 
+      # hygiene-push-ok: pushes to the external private-repo checkout in /tmp —
+      # push-with-retry.sh targets the main workspace checkout and can't be reused here.
       - name: Commit and push ledgers
         run: |
           cd /tmp/finance-data

--- a/.github/workflows/finance-ingest.yml
+++ b/.github/workflows/finance-ingest.yml
@@ -84,8 +84,10 @@ jobs:
           for i in 1 2 3; do
             if git push; then break; fi
             if [ "$i" = "3" ]; then echo "::error::push failed after 3 attempts"; exit 1; fi
-            git pull --rebase
             sleep $((i * 2))
+            # -X theirs favors OUR commit's ledger on conflict (same policy as
+            # push-with-retry.sh); shallow clone is fine for a fast-forward pull.
+            git pull --rebase -X theirs
           done
 
       - name: Notify on failure

--- a/.github/workflows/finance-ingest.yml
+++ b/.github/workflows/finance-ingest.yml
@@ -1,0 +1,94 @@
+name: Finance Ingest
+
+# Phase D of the finance tracker: pull vendor receipt emails from Gmail
+# (read-only OAuth), book them into the expense ledger, and sync the ledgers
+# to the PRIVATE data repo (amounts + billing PII never touch this repo —
+# CLAUDE.md §3/§11). The /admin/finances dashboard reads those ledger files
+# at request time via the GitHub contents API.
+#
+# Idempotent by Gmail message id + dedup hash, so daily re-runs and manual
+# dispatches never double-book. Exclusion rules (finance-vendors.json
+# externallyPaid) and same-month topup reclassification are re-applied to the
+# whole ledger on every run, so config edits propagate retroactively.
+#
+# NOT in the scraping-token gate's scope: this workflow calls the Gmail API
+# with OAuth, no page scraping, no SCRAPINGBEE/BRIGHTDATA.
+
+on:
+  schedule:
+    - cron: '17 11 * * *' # daily, offset from top-of-hour cron congestion
+  workflow_dispatch:
+    inputs:
+      backfill:
+        description: 'Full 400-day historical backfill (first run / recovery)'
+        type: boolean
+        default: false
+
+concurrency:
+  group: finance-ingest
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      # ingest-finances.js lazy-requires googleapis only on the Gmail path, so
+      # it isn't a package.json dependency (keeps the main install lean for the
+      # 60+ other workflows). Installed ad hoc here.
+      - name: Install googleapis
+        run: npm install --no-save --no-audit --no-fund googleapis
+
+      - name: Clone finance ledgers (private repo)
+        env:
+          TOKEN: ${{ secrets.REVIEW_TEXTS_TOKEN }}
+        run: |
+          git clone --depth 1 "https://x-access-token:${TOKEN}@github.com/thomaspryor/broadway-scorecard-data.git" /tmp/finance-data
+          mkdir -p /tmp/finance-data/data/finances
+
+      - name: Ingest receipts from Gmail
+        env:
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
+          BACKFILL: ${{ inputs.backfill }}
+        run: |
+          FLAGS=""
+          if [ "$BACKFILL" = "true" ]; then FLAGS="--backfill"; fi
+          node scripts/ingest-finances.js $FLAGS --out=/tmp/finance-data/data/finances
+
+      - name: Commit and push ledgers
+        run: |
+          cd /tmp/finance-data
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add data/finances
+          if git diff --staged --quiet; then
+            echo "No ledger changes."
+            exit 0
+          fi
+          git commit -m "finance: receipt ingest ($(date -u +%Y-%m-%d))"
+          for i in 1 2 3; do
+            if git push; then break; fi
+            if [ "$i" = "3" ]; then echo "::error::push failed after 3 attempts"; exit 1; fi
+            git pull --rebase
+            sleep $((i * 2))
+          done
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure
+        with:
+          title: 'Finance Ingest Failed'
+          description: 'Daily Gmail receipt ingest did not complete. Likely causes: revoked GMAIL_REFRESH_TOKEN (re-mint via OAuth Playground), REVIEW_TEXTS_TOKEN expiry, or a private-repo push conflict.'

--- a/scripts/ingest-finances.js
+++ b/scripts/ingest-finances.js
@@ -51,7 +51,7 @@ async function fetchGmailReceipts(days) {
   const auth = new google.auth.OAuth2(GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET);
   auth.setCredentials({ refresh_token: GMAIL_REFRESH_TOKEN });
   const gmail = google.gmail({ version: 'v1', auth });
-  const q = `newer_than:${days}d (subject:(receipt OR invoice OR payment OR subscription OR recharged) OR from:(brightdata.com OR openrouter.ai OR anthropic.com))`;
+  const q = `newer_than:${days}d (subject:(receipt OR invoice OR payment OR subscription OR recharged OR refund) OR from:(brightdata.com OR openrouter.ai OR anthropic.com))`;
   const out = [];
   let pageToken;
   do {

--- a/scripts/ingest-finances.js
+++ b/scripts/ingest-finances.js
@@ -98,21 +98,33 @@ async function main() {
   const ledgerPath = path.join(args.out, 'expense-ledger.json');
   const queuePath = path.join(args.out, 'review-queue.json');
   const ledger = readJson(ledgerPath, []);
-  const queue = readJson(queuePath, []);
+  let queue = readJson(queuePath, []);
 
   const seenIds = new Set(ledger.map((r) => r.id).filter(Boolean));
-  const seenHashes = new Set(ledger.map((r) => r.dedupHash).filter(Boolean));
+  const rowByHash = new Map(ledger.filter((r) => r.dedupHash).map((r) => [r.dedupHash, r]));
   const seenQueue = new Set(queue.map((q) => q.gmailMessageId).filter(Boolean));
 
   const stats = { booked: 0, duplicate: 0, personal: 0, ignore: 0, needsReview: 0, unparsed: 0 };
 
+  // The dedupHash (vendor|date|amount|receiptNo) is a FALLBACK for rows whose
+  // Gmail id form changed across the MCP→API switch. When BOTH rows carry Gmail
+  // ids and they differ, the ids are authoritative proof of distinct charges —
+  // e.g. two $50 Bright Data recharges on the same day (no receiptNo) must both
+  // book (ship-check finding: hash-only dedup silently dropped the second).
+  const isDuplicate = (row) => {
+    if (row.id && seenIds.has(row.id)) return true;
+    const existing = rowByHash.get(row.dedupHash);
+    if (!existing) return false;
+    return !(row.id && existing.id && row.id !== existing.id);
+  };
+
   for (const receipt of receipts) {
     const { row, disposition } = toLedgerRow(receipt, config);
     if (disposition === 'booked') {
-      if ((row.id && seenIds.has(row.id)) || seenHashes.has(row.dedupHash)) { stats.duplicate++; continue; }
+      if (isDuplicate(row)) { stats.duplicate++; continue; }
       ledger.push(row);
       if (row.id) seenIds.add(row.id);
-      seenHashes.add(row.dedupHash);
+      if (!rowByHash.has(row.dedupHash)) rowByHash.set(row.dedupHash, row);
       stats.booked++;
     } else if (disposition === 'personal') stats.personal++;
     else if (disposition === 'ignore') stats.ignore++;
@@ -132,9 +144,17 @@ async function main() {
   const retyped = reclassifyMonthlyDupes(ledger);
   const ext = applyExternallyPaid(ledger, config);
 
+  // Drain queue entries whose message has since booked (a matcher fix can turn
+  // yesterday's needs-review into today's booking — the stale entry would sit
+  // in the dashboard's review count forever otherwise).
+  const bookedIds = new Set(ledger.map((r) => r.id).filter(Boolean));
+  const queueBefore = queue.length;
+  queue = queue.filter((q) => !bookedIds.has(`gmail-${q.gmailMessageId}`));
+  const drained = queueBefore - queue.length;
+
   console.log(`Receipts in: ${receipts.length}`);
   console.log(`  booked ${stats.booked} · duplicate ${stats.duplicate} · personal ${stats.personal} · ignored ${stats.ignore} · needs-review ${stats.needsReview} · amount-unparsed ${stats.unparsed}`);
-  console.log(`  extra-topup retyped ${retyped} · externally-paid marked ${ext.excluded} / cleared ${ext.cleared} (total excluded ${ledger.filter((r) => r.excluded).length})`);
+  console.log(`  extra-topup retyped ${retyped} · externally-paid marked ${ext.excluded} / cleared ${ext.cleared} (total excluded ${ledger.filter((r) => r.excluded).length}) · queue drained ${drained}`);
 
   const revenue = readJson(path.join(args.out, 'revenue-ledger.json'), []);
   const pnl = computeFinanceStats({ expenses: ledger, revenue, monthsBack: 6 });

--- a/scripts/lib/finance-matchers.js
+++ b/scripts/lib/finance-matchers.js
@@ -28,6 +28,15 @@ function extractStripeAcct(from = '') {
   return m ? m[0] : null;
 }
 
+// "Anthropic, PBC <invoice+statements@mail.anthropic.com>" → the bare address.
+// The Gmail API returns display-name-wrapped From headers; MCP-sourced receipts
+// carry bare addresses. Exact-from rules must match both (2026-07-05 backfill:
+// 17/1253 booked because every exact-from vendor failed on the wrapped form).
+function extractEmailAddress(from = '') {
+  const m = String(from).match(/<([^>]+)>/);
+  return (m ? m[1] : String(from)).trim();
+}
+
 function lc(s) { return String(s || '').toLowerCase(); }
 
 function condContains(haystack, needle) {
@@ -44,7 +53,7 @@ function matchesRule(receipt, match) {
   const subject = receipt.subject || '';
   const body = receipt.body || '';
 
-  if (match.from && lc(from) !== lc(match.from)) return false;
+  if (match.from && lc(extractEmailAddress(from)) !== lc(match.from)) return false;
   if (match.fromContains && !condContains(from, match.fromContains)) return false;
   if (match.stripeAcct && extractStripeAcct(from) !== match.stripeAcct) return false;
   if (match.subjectContains && !condContains(subject, match.subjectContains)) return false;
@@ -244,6 +253,7 @@ module.exports = {
   matchesRule,
   isPersonal,
   extractStripeAcct,
+  extractEmailAddress,
   extractAmount,
   extractReceiptNo,
   toUsd,

--- a/scripts/lib/finance-matchers.js
+++ b/scripts/lib/finance-matchers.js
@@ -162,10 +162,19 @@ function toLedgerRow(receipt, config = loadVendorConfig(), fx = DEFAULT_FX_TO_US
   const cls = classifyReceipt(receipt, config);
   if (cls.disposition !== 'booked') return { row: null, disposition: cls.disposition };
 
+  // Stripe-style refund notices ("Your refund from Vercel Inc. #...") arrive
+  // from the same sender as receipts and book as NEGATIVE rows. Their bodies
+  // repeat the original charge ("Amount paid $3,521.71"), so anchor on the
+  // credited figure first (2026-03-04 Vercel build-minutes refund: $875.15
+  // credited against a $3,521.71 invoice).
+  const isRefund = /\brefund from\b/i.test(receipt.subject || '');
   const vcfg = (config.expenseVendors || []).find((v) => v.key === cls.vendorKey) || {};
-  const anchors = vcfg.amountAnchor ? [vcfg.amountAnchor] : [];
+  const anchors = isRefund
+    ? ['credited total', 'refund from']
+    : (vcfg.amountAnchor ? [vcfg.amountAnchor] : []);
   const money = extractAmount(receipt.body || receipt.subject || '', { anchors });
   if (!money) return { row: null, disposition: 'amount-unparsed' };
+  if (isRefund) money.amount = -Math.abs(money.amount);
 
   const amountUsd = toUsd(money.amount, money.currency, fx);
   const receiptNo = extractReceiptNo(receipt.body || receipt.subject || '');
@@ -179,7 +188,7 @@ function toLedgerRow(receipt, config = loadVendorConfig(), fx = DEFAULT_FX_TO_US
     vendorKey: cls.vendorKey,
     vendor: cls.vendor,
     category: cls.category,
-    kind: cls.kind,
+    kind: isRefund ? 'refund' : cls.kind,
     amount: money.amount,
     currency: money.currency,
     amountUsd,

--- a/scripts/lib/finance-matchers.js
+++ b/scripts/lib/finance-matchers.js
@@ -32,9 +32,14 @@ function extractStripeAcct(from = '') {
 // The Gmail API returns display-name-wrapped From headers; MCP-sourced receipts
 // carry bare addresses. Exact-from rules must match both (2026-07-05 backfill:
 // 17/1253 booked because every exact-from vendor failed on the wrapped form).
+// Takes the LAST angle-addr: RFC 5322 puts the real addr-spec last, and a quoted
+// display name may legally contain a decoy "<vendor@real.com>" (ship-check
+// finding: first-bracket extraction let a spoofed display name book arbitrary
+// amounts under a real vendor).
 function extractEmailAddress(from = '') {
-  const m = String(from).match(/<([^>]+)>/);
-  return (m ? m[1] : String(from)).trim();
+  const s = String(from);
+  const all = [...s.matchAll(/<([^<>]+)>/g)];
+  return (all.length ? all[all.length - 1][1] : s).trim();
 }
 
 function lc(s) { return String(s || '').toLowerCase(); }
@@ -53,8 +58,10 @@ function matchesRule(receipt, match) {
   const subject = receipt.subject || '';
   const body = receipt.body || '';
 
+  // Both from-rules run on the extracted bare address: the raw header's display
+  // name is attacker-controlled text ("billing openai.com" <evil@x> must not book).
   if (match.from && lc(extractEmailAddress(from)) !== lc(match.from)) return false;
-  if (match.fromContains && !condContains(from, match.fromContains)) return false;
+  if (match.fromContains && !condContains(extractEmailAddress(from), match.fromContains)) return false;
   if (match.stripeAcct && extractStripeAcct(from) !== match.stripeAcct) return false;
   if (match.subjectContains && !condContains(subject, match.subjectContains)) return false;
   if (match.bodyContains && !condContains(body, match.bodyContains)) return false;
@@ -65,9 +72,9 @@ function matchesRule(receipt, match) {
 
 function isPersonal(receipt, config) {
   const pe = config.personalExclude || {};
-  const from = receipt.from || '';
-  if ((pe.fromExact || []).some((f) => lc(from) === lc(f))) return true;
-  if ((pe.fromContains || []).some((f) => condContains(from, f))) return true;
+  const addr = extractEmailAddress(receipt.from || '');
+  if ((pe.fromExact || []).some((f) => lc(addr) === lc(f))) return true;
+  if ((pe.fromContains || []).some((f) => condContains(addr, f))) return true;
   return false;
 }
 

--- a/scripts/lib/finance-matchers.test.mjs
+++ b/scripts/lib/finance-matchers.test.mjs
@@ -198,3 +198,27 @@ test('exact-from rules match Gmail API display-name-wrapped From headers', () =>
   assert.equal(bare.vendorKey, 'anthropic');
   assert.equal(M.extractEmailAddress('ScrapingBee <contact@scrapingbee.com>'), 'contact@scrapingbee.com');
 });
+
+test('display-name spoofing cannot book under a real vendor (ship-check findings 2+3)', () => {
+  // Quoted display name containing a decoy vendor address — real addr-spec is LAST.
+  const spoofExact = M.classifyReceipt({
+    from: '"x <invoice+statements@mail.anthropic.com>" <attacker@evil.com>',
+    subject: 'Your receipt', body: 'Amount paid $999.00',
+  }, config);
+  assert.equal(spoofExact.disposition, 'needs-review');
+  // fromContains rules must not match display-name text either.
+  const spoofContains = M.classifyReceipt({
+    from: '"billing openai.com" <attacker@evil.com>',
+    subject: 'Your receipt', body: 'Total $999.00',
+  }, config);
+  assert.equal(spoofContains.disposition, 'needs-review');
+  assert.equal(M.extractEmailAddress('"x <a@b.com>" <c@d.com>'), 'c@d.com');
+});
+
+test('personalExclude matches wrapped From headers (ship-check finding 1)', () => {
+  const r = M.classifyReceipt({
+    from: 'Google Play <googleplay-noreply@google.com>',
+    subject: 'Your order receipt', body: 'Total $4.99',
+  }, config);
+  assert.equal(r.disposition, 'personal');
+});

--- a/scripts/lib/finance-matchers.test.mjs
+++ b/scripts/lib/finance-matchers.test.mjs
@@ -222,3 +222,42 @@ test('personalExclude matches wrapped From headers (ship-check finding 1)', () =
   }, config);
   assert.equal(r.disposition, 'personal');
 });
+
+test('refund notices book as negative rows with the credited amount, not the original charge', () => {
+  const { row, disposition } = M.toLedgerRow({
+    gmailMessageId: 'refund-1', date: '2026-03-04T20:49:26Z',
+    from: 'Vercel Inc. <invoice+statements@vercel.com>',
+    subject: 'Your refund from Vercel Inc. #3166-7470',
+    body: 'Refund from Vercel Inc. $875.15 Refunded on March 4, 2026 Total $3,521.71 Amount paid $3,521.71 Build Minutes (Qty. 251557) -$875.15 Credited total -$875.15 Adjusted invoice total $2,646.56',
+  }, config);
+  assert.equal(disposition, 'booked');
+  assert.equal(row.vendorKey, 'vercel');
+  assert.equal(row.kind, 'refund');
+  assert.equal(row.amountUsd, -875.15);
+  assert.equal(row.amountBusiness, -875.15);
+});
+
+test('Claude Max subscription books as anthropic-max subscription, not API usage-recharge', () => {
+  const { row } = M.toLedgerRow({
+    gmailMessageId: 'max-1', date: '2026-06-21T03:08:10Z',
+    from: 'Anthropic, PBC <invoice+statements@mail.anthropic.com>',
+    subject: 'Your receipt from Anthropic, PBC #2599-5034-2766',
+    body: 'Receipt #2599-5034-2766 Jun 20–Jul 20, 2026 Max plan - 20x Qty 1 $200.00 Subtotal $200.00 Total $206.00 Amount paid $206.00',
+  }, config);
+  assert.equal(row.vendorKey, 'anthropic-max');
+  assert.equal(row.kind, 'subscription');
+  assert.equal(row.amountUsd, 206);
+  // API recharge (no "Max plan") still books under anthropic and stays exclusion-eligible.
+  const api = M.classifyReceipt({
+    from: 'Anthropic, PBC <invoice+statements@mail.anthropic.com>',
+    subject: 'Your receipt from Anthropic, PBC #2720-4839-9430',
+    body: 'Usage credits Qty 1 $490.00 Total $504.70 Amount paid $504.70',
+  }, config);
+  assert.equal(api.vendorKey, 'anthropic');
+  // A pre-May Max sub must NOT be excluded by the API-overage rule.
+  const maxRow = { vendorKey: 'anthropic-max', kind: 'subscription', date: '2026-03-21' };
+  const apiRow = { vendorKey: 'anthropic', kind: 'usage-recharge', date: '2026-03-21' };
+  M.applyExternallyPaid([maxRow, apiRow], config);
+  assert.ok(!maxRow.excluded);
+  assert.ok(apiRow.excluded);
+});

--- a/scripts/lib/finance-matchers.test.mjs
+++ b/scripts/lib/finance-matchers.test.mjs
@@ -182,3 +182,19 @@ test('applyExternallyPaid: early anthropic recharges + scrapingbee topups exclud
   assert.equal(res2.cleared, 2);
   assert.ok(rows.every((r) => !r.excluded && !r.excludedReason));
 });
+
+test('exact-from rules match Gmail API display-name-wrapped From headers', () => {
+  const wrapped = M.classifyReceipt({
+    from: 'Anthropic, PBC <invoice+statements@mail.anthropic.com>',
+    subject: 'Your receipt from Anthropic, PBC #2599-5034-2766',
+    body: 'Amount paid $504.70',
+  }, config);
+  assert.equal(wrapped.vendorKey, 'anthropic');
+  const bare = M.classifyReceipt({
+    from: 'invoice+statements@mail.anthropic.com',
+    subject: 'Your receipt from Anthropic, PBC #2599-5034-2766',
+    body: 'Amount paid $504.70',
+  }, config);
+  assert.equal(bare.vendorKey, 'anthropic');
+  assert.equal(M.extractEmailAddress('ScrapingBee <contact@scrapingbee.com>'), 'contact@scrapingbee.com');
+});

--- a/scripts/lib/finance-vendors.json
+++ b/scripts/lib/finance-vendors.json
@@ -9,6 +9,7 @@
   },
 
   "expenseVendors": [
+    { "key": "anthropic-max", "vendor": "Anthropic (Claude Max)", "category": "llm", "kind": "subscription", "businessPct": 100, "match": { "from": "invoice+statements@mail.anthropic.com", "bodyContains": "Max plan" }, "note": "Claude Max subscription shares the API receipt sender. MUST precede 'anthropic' (first match wins) so the sub doesn't book as usage-recharge — and doesn't get caught by the pre-May externallyPaid rule, which covers API overages only." },
     { "key": "anthropic", "vendor": "Anthropic (Claude API)", "category": "llm", "kind": "usage-recharge", "businessPct": 100, "match": { "from": "invoice+statements@mail.anthropic.com" } },
     { "key": "google-cloud", "vendor": "Google Cloud (Gemini API)", "category": "llm", "kind": "usage", "businessPct": 100, "match": { "from": "payments-noreply@google.com", "subjectContains": "received your payment", "bodyContains": "Google Cloud Platform" } },
     { "key": "openrouter", "vendor": "OpenRouter", "category": "llm", "kind": "usage-recharge", "businessPct": 100, "match": { "from": "receipts@openrouter.ai" } },


### PR DESCRIPTION
# Finance tracker Phase D — automated ingestion

Completes the pipeline shipped in #396: the `/admin/finances` dashboard now gets fed automatically.

## What's here
- **`.github/workflows/finance-ingest.yml`** — daily cron (11:17 UTC) + manual dispatch with a `backfill` toggle. Pulls receipt emails via the Gmail API (read-only OAuth, `GMAIL_*` secrets — already configured), books them through the existing matcher/exclusion pipeline, and pushes the ledgers to the private data repo (`REVIEW_TEXTS_TOKEN`). Idempotent by Gmail message id + dedup hash. `notify-failure` wired; `hygiene-push-ok` tag for the external-repo push.
- **From-header fix** in `finance-matchers.js`: the Gmail API returns `From: "Vendor <addr>"` while MCP-sourced receipts carry bare addresses; exact-from vendor rules now compare the extracted bare address. Without this the 400-day backfill booked only 17 of 1,253 candidate receipts. Regression test added.

## Verification
- 18/18 finance unit tests pass (real-function `require()`, Rule 15).
- The exact ingest command was exercised from this session with production credentials: `--dry-run --days=10` (21 in, 1 booked, 6 personal, 14 queued) and a full 400-day backfill run E2E through the Gmail API.
- Workflow follows repo conventions: no scraping tokens (Gmail API only), `notify-failure` last step, actionlint-clean YAML shape mirroring existing workflows.

## After merge
Dispatch once with `backfill=true` to seed the private repo with full history, then the daily cron takes over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5M3ertPS9xo6ZKnRdexpF

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5M3ertPS9xo6ZKnRdexpF)_