### PR TITLE
Finance tracker: affiliate revenue accrual, Claude Max exclusion, queue suppression

### DIFF
--- a/.github/workflows/finance-ingest.yml
+++ b/.github/workflows/finance-ingest.yml
@@ -68,6 +68,22 @@ jobs:
           if [ "$BACKFILL" = "true" ]; then FLAGS="--backfill"; fi
           node scripts/ingest-finances.js $FLAGS --out=/tmp/finance-data/data/finances
 
+      # Book affiliate commission into the revenue ledger (same module as
+      # /admin/affiliate). continue-on-error: an Impact/Partnerize flake must
+      # not block the expense ingest; the script itself refuses to write
+      # partial data, and the next daily run self-heals.
+      - name: Accrue affiliate revenue
+        continue-on-error: true
+        env:
+          IMPACT_ACCOUNT_SID: ${{ secrets.IMPACT_ACCOUNT_SID }}
+          IMPACT_AUTH_TOKEN: ${{ secrets.IMPACT_AUTH_TOKEN }}
+          PARTNERIZE_APP_KEY: ${{ secrets.PARTNERIZE_APP_KEY }}
+          PARTNERIZE_API_KEY: ${{ secrets.PARTNERIZE_API_KEY }}
+          PARTNERIZE_PUBLISHER_ID: ${{ secrets.PARTNERIZE_PUBLISHER_ID }}
+          POSTHOG_PERSONAL_API_KEY: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+        run: node scripts/accrue-revenue.js --out=/tmp/finance-data/data/finances
+
       # hygiene-push-ok: pushes to the external private-repo checkout in /tmp —
       # push-with-retry.sh targets the main workspace checkout and can't be reused here.
       - name: Commit and push ledgers

--- a/scripts/accrue-revenue.js
+++ b/scripts/accrue-revenue.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * accrue-revenue.js — write affiliate commission into the finance revenue
+ * ledger. Runs after ingest-finances.js in finance-ingest.yml.
+ *
+ * Uses getAffiliateStats (same module as /admin/affiliate and the affiliate
+ * report) and books totals.commission ONLY — never totals.revenue (that's the
+ * partner's ticket sales, not ours; see CLAUDE.md §Critic/commercial rules and
+ * the revenueSources note in finance-vendors.json).
+ *
+ * Window math (Impact caps ranges at 45 days):
+ * - current month  = last dayOfMonth days (≈ month-to-date) → 'pending' row
+ * - prior month    = (last dayOfMonth + priorMonthLen days) − MTD, only fetched
+ *   through the 12th (12 + 31 = 43 ≤ 45) → finalizes prior month to 'realized'
+ *
+ * Flags: --out=DIR (default data/finances) · --dry-run · --today=YYYY-MM-DD (tests)
+ *
+ * Aborts WITHOUT writing if the Impact provider errored or is skipped —
+ * a partial fetch would silently understate the month.
+ */
+const fs = require('fs');
+const path = require('path');
+const { getAffiliateStats } = require('./lib/affiliate-stats');
+const { computeAffiliateAccrual, daysInPriorMonth } = require('./lib/revenue-accrual');
+
+function parseArgs(argv) {
+  const a = { out: 'data/finances', dryRun: false, today: null };
+  for (const arg of argv.slice(2)) {
+    if (arg === '--dry-run') a.dryRun = true;
+    else if (arg.startsWith('--out=')) a.out = arg.slice(6);
+    else if (arg.startsWith('--today=')) a.today = arg.slice(8);
+  }
+  return a;
+}
+
+function impactHealthy(stats) {
+  if ((stats.errors || []).some((e) => e.provider === 'impact')) return false;
+  if (!stats.impact || stats.impact.skipped) return false;
+  return true;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const todayIso = args.today || new Date().toISOString().slice(0, 10);
+  const dom = Number(todayIso.slice(8, 10));
+
+  const mtdStats = await getAffiliateStats({ days: Math.max(dom, 1) });
+  if (!impactHealthy(mtdStats)) {
+    console.error('Impact unavailable — refusing to accrue partial revenue.',
+      JSON.stringify(mtdStats.errors || []), mtdStats.impact && mtdStats.impact.reason || '');
+    process.exit(1);
+  }
+  const mtdCommission = mtdStats.totals.commission;
+
+  let priorWindowCommission = null;
+  if (dom <= 12) {
+    const priorStats = await getAffiliateStats({ days: dom + daysInPriorMonth(todayIso) });
+    if (impactHealthy(priorStats))
+
+      priorWindowCommission = priorStats.totals.commission;
+    else console.error('Prior-month window fetch failed — finalization deferred to a later run.');
+  }
+
+  const ledgerPath = path.join(args.out, 'revenue-ledger.json');
+  let ledger = [];
+  try { ledger = JSON.parse(fs.readFileSync(ledgerPath, 'utf8')); } catch { /* first run */ }
+
+  const { ledger: next, changes } = computeAffiliateAccrual({ todayIso, mtdCommission, priorWindowCommission, ledger });
+  for (const c of changes) console.log(`  ${c.month} affiliate $${c.amountUsd} (${c.status}) — ${c.action}`);
+
+  if (args.dryRun) { console.log('[dry-run] nothing written.'); return; }
+  fs.mkdirSync(args.out, { recursive: true });
+  fs.writeFileSync(ledgerPath, JSON.stringify(next, null, 2));
+  console.log(`Wrote ${next.length} revenue rows → ${ledgerPath}`);
+}
+
+if (require.main === module) main().catch((e) => { console.error(e.message); process.exit(1); });
+module.exports = { parseArgs, impactHealthy };

--- a/scripts/ingest-finances.js
+++ b/scripts/ingest-finances.js
@@ -22,7 +22,7 @@
  */
 const fs = require('fs');
 const path = require('path');
-const { toLedgerRow, loadVendorConfig, reclassifyMonthlyDupes, applyExternallyPaid } = require('./lib/finance-matchers');
+const { toLedgerRow, loadVendorConfig, reclassifyMonthlyDupes, applyExternallyPaid, classifyReceipt } = require('./lib/finance-matchers');
 const { computeFinanceStats } = require('./lib/finance-stats');
 
 function parseArgs(argv) {
@@ -146,10 +146,17 @@ async function main() {
 
   // Drain queue entries whose message has since booked (a matcher fix can turn
   // yesterday's needs-review into today's booking — the stale entry would sit
-  // in the dashboard's review count forever otherwise).
+  // in the dashboard's review count forever otherwise), then re-classify the
+  // remainder against the CURRENT config so new personalExclude/ignore rules
+  // retroactively clear old entries (bodies aren't stored in the queue, but
+  // personal + ignore rules only need from/subject).
   const bookedIds = new Set(ledger.map((r) => r.id).filter(Boolean));
   const queueBefore = queue.length;
   queue = queue.filter((q) => !bookedIds.has(`gmail-${q.gmailMessageId}`));
+  queue = queue.filter((q) => {
+    const cls = classifyReceipt({ from: q.from, subject: q.subject, body: '' }, config);
+    return cls.disposition !== 'personal' && cls.disposition !== 'ignore';
+  });
   const drained = queueBefore - queue.length;
 
   console.log(`Receipts in: ${receipts.length}`);

--- a/scripts/lib/finance-matchers.test.mjs
+++ b/scripts/lib/finance-matchers.test.mjs
@@ -254,10 +254,13 @@ test('Claude Max subscription books as anthropic-max subscription, not API usage
     body: 'Usage credits Qty 1 $490.00 Total $504.70 Amount paid $504.70',
   }, config);
   assert.equal(api.vendorKey, 'anthropic');
-  // A pre-May Max sub must NOT be excluded by the API-overage rule.
-  const maxRow = { vendorKey: 'anthropic-max', kind: 'subscription', date: '2026-03-21' };
+  // Max subs are excluded outright on any date (personal — 2026-07-05 user
+  // decision); API recharges follow the pre-May family-paid rule.
+  const maxRow = { vendorKey: 'anthropic-max', kind: 'subscription', date: '2026-06-21' };
   const apiRow = { vendorKey: 'anthropic', kind: 'usage-recharge', date: '2026-03-21' };
-  M.applyExternallyPaid([maxRow, apiRow], config);
-  assert.ok(!maxRow.excluded);
+  const apiRowMay = { vendorKey: 'anthropic', kind: 'usage-recharge', date: '2026-05-21' };
+  M.applyExternallyPaid([maxRow, apiRow, apiRowMay], config);
+  assert.equal(maxRow.excludedReason, 'personal');
   assert.ok(apiRow.excluded);
+  assert.ok(!apiRowMay.excluded);
 });

--- a/scripts/lib/finance-vendors.json
+++ b/scripts/lib/finance-vendors.json
@@ -5,7 +5,9 @@
   "personalExclude": {
     "_note": "Hard-reject senders/patterns BEFORE vendor matching. Guards mixed-domain vendors (Google) and known-personal receipts so they never reach the allowlist.",
     "fromExact": ["googleplay-noreply@google.com", "googlestore-noreply@google.com"],
-    "fromContains": ["united.com", "amtrak.com", "lyftmail.com", "njtransit.com", "optimum.net", "apple.com", "crunch.com", "tryfi.com", "suno.com", "wispr.ai", "nysun.com/personal-placeholder"]
+    "fromContains": ["united.com", "amtrak.com", "lyftmail.com", "njtransit.com", "optimum.net", "apple.com", "crunch.com", "tryfi.com", "suno.com", "wispr.ai", "nysun.com/personal-placeholder",
+      "amazon.com", "paypal.com", "chase.com", "venmo.com", "doordash.com", "airbnb.com", "expedia.com", "turo.com", "etsy.com", "jm-maintenance.com", "waveapps.com", "rectanglehealth.com", "transactis.net", "plantemoran.com", "statefarmservice.com", "physiologicnyc.com", "astound.com", "eclinicalmail.com", "rcn.net", "xero.com", "thomas.pryor@gmail.com", "thomaspryor@gmail.com",
+      "janeapp.com", "eventfulbypooja.com", "resly.com.au", "ebmmedical.com", "marcusattorneys.com", "bryanjohnson.com", "substack.com", "fitbod", "returnqueen", "buttondown.email", "driped.com", "notify.proton.me"]
   },
 
   "expenseVendors": [
@@ -16,6 +18,8 @@
     { "key": "openai", "vendor": "OpenAI (API)", "category": "llm", "kind": "usage", "businessPct": 100, "match": { "fromContains": "openai.com", "subjectContains": "receipt" } },
     { "key": "brightdata", "vendor": "Bright Data", "category": "scraping", "kind": "usage-recharge", "businessPct": 100, "match": { "from": "noreply@brightdata.com", "subjectContains": "recharged" }, "amountAnchor": "recharged for", "note": "Book the recharge emails; amount is 'recharged for $X' (whole-dollar, with a decoy balance figure in the same line). The monthly 'bill (paid)' PDF is a SUMMARY — see brightdata-invoice-ignore." },
     { "key": "brightdata-invoice-ignore", "vendor": "Bright Data (monthly summary — DO NOT BOOK)", "category": "scraping", "kind": "ignore", "businessPct": 0, "match": { "from": "noreply@brightdata.com", "subjectContains": "monthly bill" }, "note": "Explicit ignore rule so the summary invoice never double-counts the recharges." },
+    { "key": "brightdata-order-ignore", "vendor": "Bright Data (order-complete companion — DO NOT BOOK)", "category": "scraping", "kind": "ignore", "businessPct": 0, "match": { "from": "noreply@brightdata.com", "subjectContains": "your order is complete" }, "note": "Each recharge sends TWO emails: 'recharged for $X' (booked) and 'Your order is complete… receipt is attached' (amount only in the PDF). Ignoring the companion prevents double-booking; 22 of these sat in the review queue after the 2026-07-05 backfill." },
+    { "key": "brightdata-notices-ignore", "vendor": "Bright Data (non-billing notices)", "category": "scraping", "kind": "ignore", "businessPct": 0, "match": { "fromContains": "brightdata.com" }, "note": "Catch-all AFTER the booking + ignore rules above: security notices, token-expiry reminders, product marketing. Order matters — this must stay below brightdata/brightdata-invoice-ignore/brightdata-order-ignore." },
     { "key": "scrapingbee", "vendor": "ScrapingBee", "category": "scraping", "kind": "subscription", "businessPct": 100, "match": { "from": "contact@scrapingbee.com" } },
     { "key": "scrapingdog", "vendor": "Scrapingdog", "category": "scraping", "kind": "subscription", "businessPct": 100, "match": { "stripeAcct": "acct_1GXTgWLsPRCYo9Br", "bodyContains": "OPENDATA LABS" } },
     { "key": "browserbase", "vendor": "Browserbase", "category": "scraping", "kind": "usage", "businessPct": 100, "match": { "stripeAcct": "acct_1Oq0jrGhqv5yXZ43", "bodyContains": "Browserbase" } },
@@ -29,14 +33,16 @@
     { "key": "canva", "vendor": "Canva", "category": "other", "kind": "subscription", "businessPct": 100, "match": { "from": "no-reply@account.canva.com" } },
     { "key": "ny-sun", "vendor": "The New York Sun", "category": "data-subscription", "kind": "subscription", "businessPct": 100, "match": { "from": "invoice+statements@payments.nysun.com" } },
     { "key": "broadway-brands", "vendor": "Broadway Brands", "category": "data-subscription", "kind": "subscription", "businessPct": 100, "match": { "stripeAcct": "acct_17ohgmL39wk6fORM", "bodyContains": "Broadway Brands" } },
-    { "key": "washington-post", "vendor": "The Washington Post", "category": "data-subscription", "kind": "subscription", "businessPct": 100, "match": { "fromContains": "washingtonpost.com", "subjectContains": "subscription" } }
+    { "key": "washington-post", "vendor": "The Washington Post", "category": "data-subscription", "kind": "subscription", "businessPct": 100, "match": { "fromContains": "washingtonpost.com", "subjectContains": "subscription" } },
+    { "key": "anthropic-notices-ignore", "vendor": "Anthropic (non-receipt notices)", "category": "llm", "kind": "ignore", "businessPct": 0, "match": { "fromContains": "anthropic.com" }, "note": "Catch-all AFTER anthropic-max/anthropic booking rules: spend-threshold alerts, API-access notices, failed-payment warnings, login links. Order matters — must stay below the booking rules." }
   ],
 
   "externallyPaid": {
     "_note": "Charges someone other than the business paid (family covered early costs — 2026-07-05 user request). Matching rows stay in the ledger for audit but get excluded:true and are skipped by finance-stats. Rules only, no amounts (public repo). 'kinds' omitted = all kinds; 'before' is an exclusive YYYY-MM-DD upper bound on row.date. scrapingbee 'extra-topup' rows are produced by reclassifyMonthlyDupes (2nd+ subscription charge in the same calendar month = credit top-up / early renewal).",
     "rules": [
       { "vendorKey": "anthropic", "kinds": ["usage-recharge"], "before": "2026-05-01", "reason": "paid-by-family" },
-      { "vendorKey": "scrapingbee", "kinds": ["extra-topup"], "before": "2026-05-01", "reason": "paid-by-family" }
+      { "vendorKey": "scrapingbee", "kinds": ["extra-topup"], "before": "2026-05-01", "reason": "paid-by-family" },
+      { "vendorKey": "anthropic-max", "reason": "personal", "_note": "2026-07-05 user decision: Claude Max subscription stays off the business P&L entirely (no date bound)." }
     ]
   },
 

--- a/scripts/lib/revenue-accrual.js
+++ b/scripts/lib/revenue-accrual.js
@@ -1,0 +1,80 @@
+/**
+ * revenue-accrual.js — pure upsert logic for the affiliate revenue ledger.
+ * NO network: the Impact/Partnerize fetch lives in scripts/accrue-revenue.js.
+ * Kept pure so the real function is `require()`d by the unit test (Rule 15).
+ *
+ * Model (cash-ish, month buckets):
+ * - The current month accrues as a single 'pending' affiliate row, refreshed
+ *   on every run with the month-to-date commission.
+ * - Early next month (while the prior month still fits Impact's 45-day window)
+ *   the prior month's row is finalized to 'realized' as
+ *   (prior-window commission − MTD commission). finance-stats already excludes
+ *   pending rows from net, so an accruing month never inflates the P&L.
+ * - Non-affiliate rows (e.g. Buy Me A Coffee) are never touched.
+ */
+
+function round2(n) { return Math.round(n * 100) / 100; }
+
+function monthOf(iso) { return String(iso).slice(0, 7); }
+
+function priorMonthOf(iso) {
+  const [y, m] = monthOf(iso).split('-').map(Number);
+  const d = new Date(Date.UTC(y, m - 2, 1));
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+function daysInPriorMonth(iso) {
+  const [y, m] = monthOf(iso).split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, 0)).getUTCDate();
+}
+
+function upsert(ledger, row) {
+  const i = ledger.findIndex((r) => r.month === row.month && r.sourceKey === row.sourceKey);
+  if (i === -1) { ledger.push(row); return 'inserted'; }
+  const prev = ledger[i];
+  // Never downgrade a realized month back to pending (a late re-run with a
+  // shorter window must not reopen closed books).
+  if (prev.status === 'realized' && row.status === 'pending') return 'kept-realized';
+  ledger[i] = { ...prev, ...row };
+  return 'updated';
+}
+
+/**
+ * @param {object} opts
+ * @param {string} opts.todayIso            'YYYY-MM-DD' (UTC)
+ * @param {number} opts.mtdCommission       commission for the last dayOfMonth days
+ * @param {number|null} opts.priorWindowCommission commission for the last
+ *        (dayOfMonth + daysInPriorMonth) days, or null when not fetched
+ * @param {Array} opts.ledger               existing revenue-ledger rows (mutated copy returned)
+ */
+function computeAffiliateAccrual({ todayIso, mtdCommission, priorWindowCommission = null, ledger = [] }) {
+  const out = ledger.map((r) => ({ ...r }));
+  const changes = [];
+  const month = monthOf(todayIso);
+
+  const cur = {
+    month,
+    sourceKey: 'affiliate',
+    source: 'Affiliate commissions',
+    amountUsd: round2(mtdCommission),
+    status: 'pending',
+    accruedAt: todayIso,
+  };
+  changes.push({ month, action: upsert(out, cur), amountUsd: cur.amountUsd, status: cur.status });
+
+  if (priorWindowCommission != null) {
+    const prior = {
+      month: priorMonthOf(todayIso),
+      sourceKey: 'affiliate',
+      source: 'Affiliate commissions',
+      amountUsd: round2(Math.max(priorWindowCommission - mtdCommission, 0)),
+      status: 'realized',
+      accruedAt: todayIso,
+    };
+    changes.push({ month: prior.month, action: upsert(out, prior), amountUsd: prior.amountUsd, status: prior.status });
+  }
+
+  return { ledger: out, changes };
+}
+
+module.exports = { computeAffiliateAccrual, priorMonthOf, daysInPriorMonth };

--- a/scripts/lib/revenue-accrual.test.mjs
+++ b/scripts/lib/revenue-accrual.test.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { computeAffiliateAccrual, priorMonthOf, daysInPriorMonth } = require('./revenue-accrual.js');
+
+test('mid-month run upserts a pending MTD row only', () => {
+  const { ledger, changes } = computeAffiliateAccrual({
+    todayIso: '2026-07-20', mtdCommission: 412.345, ledger: [],
+  });
+  assert.equal(ledger.length, 1);
+  assert.deepEqual(changes.map((c) => c.action), ['inserted']);
+  assert.equal(ledger[0].month, '2026-07');
+  assert.equal(ledger[0].amountUsd, 412.35); // rounded
+  assert.equal(ledger[0].status, 'pending');
+});
+
+test('early-month run finalizes prior month as (window − MTD) and keeps MTD pending', () => {
+  const existing = [
+    { month: '2026-06', sourceKey: 'affiliate', source: 'Affiliate commissions', amountUsd: 700, status: 'pending' },
+  ];
+  const { ledger } = computeAffiliateAccrual({
+    todayIso: '2026-07-03', mtdCommission: 55.5, priorWindowCommission: 857.27, ledger: existing,
+  });
+  const june = ledger.find((r) => r.month === '2026-06');
+  const july = ledger.find((r) => r.month === '2026-07');
+  assert.equal(june.status, 'realized');
+  assert.equal(june.amountUsd, 801.77); // 857.27 − 55.50
+  assert.equal(july.status, 'pending');
+  assert.equal(july.amountUsd, 55.5);
+});
+
+test('realized month is never downgraded back to pending, other sources untouched', () => {
+  const existing = [
+    { month: '2026-07', sourceKey: 'affiliate', source: 'Affiliate commissions', amountUsd: 900, status: 'realized' },
+    { month: '2026-07', sourceKey: 'buymeacoffee', source: 'Buy Me A Coffee', amountUsd: 27.7, status: 'pending' },
+  ];
+  const { ledger, changes } = computeAffiliateAccrual({
+    todayIso: '2026-07-20', mtdCommission: 850, ledger: existing,
+  });
+  const aff = ledger.find((r) => r.sourceKey === 'affiliate');
+  assert.equal(aff.status, 'realized');
+  assert.equal(aff.amountUsd, 900); // untouched
+  assert.equal(changes[0].action, 'kept-realized');
+  const bmac = ledger.find((r) => r.sourceKey === 'buymeacoffee');
+  assert.deepEqual(bmac, existing[1]); // never touched
+});
+
+test('prior amount floors at zero (window smaller than MTD can only be API noise)', () => {
+  const { ledger } = computeAffiliateAccrual({
+    todayIso: '2026-03-02', mtdCommission: 100, priorWindowCommission: 80, ledger: [],
+  });
+  assert.equal(ledger.find((r) => r.month === '2026-02').amountUsd, 0);
+});
+
+test('month helpers handle year boundary and leap purposes', () => {
+  assert.equal(priorMonthOf('2026-01-05'), '2025-12');
+  assert.equal(daysInPriorMonth('2026-03-05'), 28); // Feb 2026
+  assert.equal(daysInPriorMonth('2026-01-05'), 31); // Dec 2025
+});

--- a/src/app/admin/finances/Dashboard.tsx
+++ b/src/app/admin/finances/Dashboard.tsx
@@ -302,8 +302,8 @@ export default function Dashboard() {
             {stats.ledgerCounts.expenses} expense rows · {stats.ledgerCounts.revenue} revenue rows · amounts USD ·
             businessPct applied · pending revenue excluded from net.
             {stats.excluded?.count > 0 && (
-              <> {stats.excluded.count} early charge{stats.excluded.count === 1 ? '' : 's'} ({fmtMoney(stats.excluded.totalUsd)})
-              paid externally — not counted.</>
+              <> {stats.excluded.count} charge{stats.excluded.count === 1 ? '' : 's'} ({fmtMoney(stats.excluded.totalUsd)})
+              excluded — not business costs (family-paid early overages, personal subscriptions).</>
             )}
           </div>
         </>


### PR DESCRIPTION
# Finance tracker follow-ups (user-requested)

Three changes on top of #396/#403:

## 1. Affiliate revenue accrual
- `scripts/accrue-revenue.js` + pure `scripts/lib/revenue-accrual.js` (5 unit tests). Books `getAffiliateStats().totals.commission` (never `totals.revenue`) as a **pending** month-to-date row on each run; finalizes the prior month to **realized** through the 12th (fits Impact's 45-day window). Refuses to write when the Impact provider errors or is unconfigured — no silent understatement. `finance-stats` already excludes pending rows from net.
- New `finance-ingest.yml` step (`continue-on-error`), same secrets `weekly-affiliate-report.yml` already uses.

## 2. Claude Max off the business P&L
`externallyPaid` rule for `anthropic-max` (any date, reason `personal`), applied retroactively to the whole ledger each run. Dashboard footer wording generalized ("excluded — not business costs").

## 3. Review-queue suppression (1,044 → 302 on the real queue)
- ~30 clearly-personal senders added to `personalExclude` (Amazon/PayPal/Chase/Venmo/health/travel/self-sent).
- Explicit ignore rules: Bright Data **"order is complete"** companion receipts (amount lives only in the PDF; the "recharged" email is the booked record — prevents any future double-count), plus BD/Anthropic non-billing notices (catch-alls ordered *below* the booking rules).
- Ingest now re-classifies existing queue entries against current config every run, so rule edits drain the queue retroactively.

## Verification
27/27 finance unit tests; accrual refusal path exercised; full pipeline re-run on the real backfilled ledger (June business $1,483.49 post-Max-exclusion; 74 excluded charges $23,645.55; queue 302); `tsc` + `next lint` clean. Known trunk-wide E2E redness (RatingEditor spec from the parallel UGC session) is unrelated.

## After merge
Dispatch `finance-ingest.yml` once — it re-marks exclusions, drains the queue in the private repo, and books June + July-MTD affiliate revenue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5M3ertPS9xo6ZKnRdexpF

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5M3ertPS9xo6ZKnRdexpF)_