### PR TITLE
Finance dashboard v2: month drill-down, review-queue list, Vercel exclusion

### DIFF
--- a/scripts/lib/finance-matchers.test.mjs
+++ b/scripts/lib/finance-matchers.test.mjs
@@ -264,3 +264,13 @@ test('Claude Max subscription books as anthropic-max subscription, not API usage
   assert.ok(apiRow.excluded);
   assert.ok(!apiRowMay.excluded);
 });
+
+test('Vercel Jan–Mar 2026 excluded (family-paid), including the Feb bill and Mar refund; Apr+ kept', () => {
+  const rows = [
+    { vendorKey: 'vercel', kind: 'usage', date: '2026-02-21' },   // the $3.5K bill
+    { vendorKey: 'vercel', kind: 'refund', date: '2026-03-04' },  // its refund
+    { vendorKey: 'vercel', kind: 'usage', date: '2026-04-22' },   // April onward = business
+  ];
+  M.applyExternallyPaid(rows, config);
+  assert.deepEqual(rows.map((r) => !!r.excluded), [true, true, false]);
+});

--- a/scripts/lib/finance-vendors.json
+++ b/scripts/lib/finance-vendors.json
@@ -34,6 +34,15 @@
     { "key": "ny-sun", "vendor": "The New York Sun", "category": "data-subscription", "kind": "subscription", "businessPct": 100, "match": { "from": "invoice+statements@payments.nysun.com" } },
     { "key": "broadway-brands", "vendor": "Broadway Brands", "category": "data-subscription", "kind": "subscription", "businessPct": 100, "match": { "stripeAcct": "acct_17ohgmL39wk6fORM", "bodyContains": "Broadway Brands" } },
     { "key": "washington-post", "vendor": "The Washington Post", "category": "data-subscription", "kind": "subscription", "businessPct": 100, "match": { "fromContains": "washingtonpost.com", "subjectContains": "subscription" } },
+    { "key": "apify", "vendor": "Apify", "category": "scraping", "kind": "subscription", "businessPct": 100, "match": { "fromContains": "apify.com", "subjectContains": "payment successful" }, "note": "Scraping platform (APIFY_TOKEN in repo secrets). 4 unbooked invoices found in the 2026-07-06 queue triage." },
+    { "key": "expo", "vendor": "Expo (650 Industries)", "category": "hosting", "kind": "subscription", "businessPct": 100, "match": { "fromContains": "expo.dev", "subjectContains": "receipt" }, "note": "Build/update infra for the BroadwayScorecard iOS app. 4 unbooked receipts found in the 2026-07-06 queue triage." },
+    { "key": "apify-notices-ignore", "vendor": "Apify (non-receipt notices)", "category": "scraping", "kind": "ignore", "businessPct": 0, "match": { "fromContains": "apify.com" }, "note": "Renewal reminders etc. Must stay below the apify booking rule." },
+    { "key": "browserbase-native-ignore", "vendor": "Browserbase (native confirmation — DO NOT BOOK)", "category": "scraping", "kind": "ignore", "businessPct": 0, "match": { "fromContains": "browserbase.com" }, "note": "Browserbase charges book via the Stripe receipt (stripeAcct rule); the 'payment was successful' email from browserbase.com is a companion — booking it would double-count." },
+    { "key": "scrapingdog-notices-ignore", "vendor": "Scrapingdog (failure/auth notices)", "category": "scraping", "kind": "ignore", "businessPct": 0, "match": { "fromContains": "scrapingdog.com" }, "note": "Payment-failed / auth notices; real charges book via the OPENDATA LABS Stripe receipt." },
+    { "key": "openrouter-notices-ignore", "vendor": "OpenRouter (non-receipt notices)", "category": "llm", "kind": "ignore", "businessPct": 0, "match": { "fromContains": "openrouter.ai" }, "note": "Marketing/policy mail. Must stay below the openrouter booking rule (exact-from receipts@)." },
+    { "key": "vercel-notices-ignore", "vendor": "Vercel (support threads, usage alerts)", "category": "hosting", "kind": "ignore", "businessPct": 0, "match": { "fromContains": "vercel.com" }, "note": "Support correspondence + credit-usage notifications. Must stay below the vercel booking rule (exact-from invoice+statements@)." },
+    { "key": "bww-alerts-ignore", "vendor": "BroadwayWorld (alert confirmations)", "category": "other", "kind": "ignore", "businessPct": 0, "match": { "fromContains": "broadwayworld.com" }, "note": "Free review-alert subscription confirmations — no billing." },
+    { "key": "impact-notices-ignore", "vendor": "Impact (commission payout notices)", "category": "other", "kind": "ignore", "businessPct": 0, "match": { "fromContains": "impact.com" }, "note": "Revenue side — booked by accrue-revenue.js from the Impact API, not from emails." },
     { "key": "anthropic-notices-ignore", "vendor": "Anthropic (non-receipt notices)", "category": "llm", "kind": "ignore", "businessPct": 0, "match": { "fromContains": "anthropic.com" }, "note": "Catch-all AFTER anthropic-max/anthropic booking rules: spend-threshold alerts, API-access notices, failed-payment warnings, login links. Order matters — must stay below the booking rules." }
   ],
 
@@ -42,7 +51,8 @@
     "rules": [
       { "vendorKey": "anthropic", "kinds": ["usage-recharge"], "before": "2026-05-01", "reason": "paid-by-family" },
       { "vendorKey": "scrapingbee", "kinds": ["extra-topup"], "before": "2026-05-01", "reason": "paid-by-family" },
-      { "vendorKey": "anthropic-max", "reason": "personal", "_note": "2026-07-05 user decision: Claude Max subscription stays off the business P&L entirely (no date bound)." }
+      { "vendorKey": "anthropic-max", "reason": "personal", "_note": "2026-07-05 user decision: Claude Max subscription stays off the business P&L entirely (no date bound)." },
+      { "vendorKey": "vercel", "before": "2026-04-01", "reason": "paid-by-family", "_note": "2026-07-06 user decision: family covered the first three Vercel months (Jan–Mar 2026). No kinds filter, so the Feb accidental-builds bill AND its Mar refund both drop — removing the cross-month refund artifact from the trend." }
     ]
   },
 

--- a/src/app/admin/finances/Dashboard.tsx
+++ b/src/app/admin/finances/Dashboard.tsx
@@ -24,6 +24,23 @@ interface VendorRow {
   momPct: number | null;
 }
 
+interface ExpenseRow {
+  date: string;
+  vendor: string;
+  category: string;
+  kind: string;
+  amount: number;
+  excluded: boolean;
+  excludedReason?: string;
+}
+
+interface QueueItem {
+  date: string;
+  from: string;
+  subject: string;
+  reason: string;
+}
+
 interface Stats {
   asOfMonth: string;
   current: TrendMonth | null;
@@ -34,6 +51,8 @@ interface Stats {
   byVendor: VendorRow[];
   recurringVsUsage: { recurring: number; usage: number };
   excluded: { count: number; totalUsd: number };
+  rows: ExpenseRow[];
+  queuePreview: QueueItem[];
   burnRate: number;
   runwayMonths: number | null;
   totals: { expense: number; revenue: number; net: number };
@@ -92,11 +111,40 @@ function BigStat({ label, value, accent, sub }: { label: string; value: string; 
   );
 }
 
+function MonthDetail({ rows }: { rows: ExpenseRow[] }) {
+  if (rows.length === 0) {
+    return <div className="text-xs text-gray-500 py-2 pl-14">No booked expenses this month.</div>;
+  }
+  return (
+    <div className="pl-2 sm:pl-14 py-2">
+      <table className="w-full text-xs sm:text-sm">
+        <tbody>
+          {rows.map((r, i) => (
+            <tr key={i} className={`border-t border-white/[0.04] ${r.excluded ? 'opacity-50' : ''}`}>
+              <td className="py-1 pr-2 text-gray-500 whitespace-nowrap">{r.date.slice(5)}</td>
+              <td className="py-1 pr-2 text-white">
+                {r.vendor}
+                {r.kind === 'refund' && <span className="ml-1.5 text-[10px] uppercase text-green-400">refund</span>}
+                {r.excluded && <span className="ml-1.5 text-[10px] uppercase text-gray-500">excluded · {r.excludedReason}</span>}
+              </td>
+              <td className="py-1 pr-2 text-gray-500 hidden sm:table-cell">{r.category} · {r.kind}</td>
+              <td className={`py-1 text-right tabular-nums font-semibold ${r.amount < 0 ? 'text-green-400' : r.excluded ? 'text-gray-500' : 'text-gray-200'}`}>
+                {fmtMoney(r.amount)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 export default function Dashboard() {
   const [months, setMonths] = useState<Months>(6);
   const [stats, setStats] = useState<Stats | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [openMonth, setOpenMonth] = useState<string | null>(null);
 
   const load = useCallback(async (m: Months, refresh = false) => {
     setLoading(true);
@@ -129,6 +177,9 @@ export default function Dashboard() {
 
   const cur = stats?.current;
   const maxTrend = stats ? Math.max(...stats.trend.map(t => Math.max(t.expense, t.revenue)), 1) : 1;
+  // First month with any tracked revenue — Impact's API only reaches back 45
+  // days, so earlier months genuinely have no revenue data (not $0 earned).
+  const revenueSince = stats?.trend.find(t => t.revenue > 0 || t.revenuePending > 0)?.month ?? null;
 
   return (
     <div className="space-y-5">
@@ -197,31 +248,50 @@ export default function Dashboard() {
 
           {/* Monthly trend — paired bars, table-legible */}
           <Card title={`Monthly trend — last ${stats.trend.length} months`}>
-            <div className="space-y-2">
-              {stats.trend.map(t => (
-                <div key={t.month} className="grid grid-cols-[3rem_1fr_5rem] items-center gap-2 text-sm">
-                  <span className="text-gray-500 text-xs">{fmtMonth(t.month)}</span>
-                  <div className="space-y-1">
-                    <div className="h-2 rounded-sm bg-green-400/80" style={{ width: `${Math.max((t.revenue / maxTrend) * 100, t.revenue > 0 ? 2 : 0)}%` }} />
-                    <div className="h-2 rounded-sm bg-red-400/70" style={{ width: `${Math.max((t.expense / maxTrend) * 100, t.expense > 0 ? 2 : 0)}%` }} />
+            <div className="text-[11px] text-gray-500 mb-2">Tap a month for the full expense list.</div>
+            <div className="space-y-1">
+              {stats.trend.map(t => {
+                const monthRows = stats.rows.filter(r => r.date.startsWith(t.month));
+                const refunds = monthRows.filter(r => !r.excluded && r.amount < 0).reduce((s, r) => s + r.amount, 0);
+                const gross = t.expense - refunds; // spend before refunds netted
+                const isOpen = openMonth === t.month;
+                return (
+                  <div key={t.month} className="rounded-md -mx-1 px-1 hover:bg-surface-overlay">
+                    <button
+                      onClick={() => setOpenMonth(isOpen ? null : t.month)}
+                      className="w-full grid grid-cols-[3.5rem_1fr_5.5rem] items-center gap-2 text-sm py-1.5 text-left"
+                    >
+                      <span className="text-gray-500 text-xs">{isOpen ? '▾ ' : '▸ '}{fmtMonth(t.month)}</span>
+                      <div className="space-y-1">
+                        <div className="h-2 rounded-sm bg-green-400/80" style={{ width: `${Math.max((t.revenue / maxTrend) * 100, t.revenue > 0 ? 2 : 0)}%` }} />
+                        <div className="flex items-center gap-1">
+                          <div className="h-2 rounded-sm bg-red-400/70" style={{ width: `${Math.max((gross / maxTrend) * 100, gross > 0 ? 2 : 0)}%` }} />
+                          {refunds < 0 && (
+                            <span className="text-[10px] text-green-400 whitespace-nowrap leading-none">{fmtMoney(refunds)} refunded</span>
+                          )}
+                        </div>
+                      </div>
+                      <span
+                        className={`text-right tabular-nums font-semibold ${
+                          t.revenue === 0 && t.expense === 0
+                            ? 'text-gray-600'
+                            : t.net >= 0
+                            ? 'text-green-400'
+                            : 'text-red-400'
+                        }`}
+                      >
+                        {fmtMoney(t.net)}
+                      </span>
+                    </button>
+                    {isOpen && <MonthDetail rows={monthRows} />}
                   </div>
-                  <span
-                    className={`text-right tabular-nums font-semibold ${
-                      t.revenue === 0 && t.expense === 0
-                        ? 'text-gray-600' // no activity that month — don't color a meaningless zero
-                        : t.net >= 0
-                        ? 'text-green-400'
-                        : 'text-red-400'
-                    }`}
-                  >
-                    {fmtMoney(t.net)}
-                  </span>
-                </div>
-              ))}
+                );
+              })}
             </div>
-            <div className="flex gap-4 text-[11px] text-gray-500 mt-3">
+            <div className="flex gap-4 flex-wrap text-[11px] text-gray-500 mt-3">
               <span><span className="inline-block w-2 h-2 rounded-sm bg-green-400/80 mr-1" />revenue</span>
-              <span><span className="inline-block w-2 h-2 rounded-sm bg-red-400/70 mr-1" />expenses</span>
+              <span><span className="inline-block w-2 h-2 rounded-sm bg-red-400/70 mr-1" />expenses (before refunds)</span>
+              {revenueSince && <span>revenue tracked from {fmtMonth(revenueSince)}</span>}
               <span className="ml-auto">
                 {months}mo totals: {fmtMoney(stats.totals.revenue)} in · {fmtMoney(stats.totals.expense)} out ·{' '}
                 <span className={stats.totals.net >= 0 ? 'text-green-400' : 'text-red-400'}>{fmtMoney(stats.totals.net)} net</span>
@@ -258,7 +328,7 @@ export default function Dashboard() {
               </div>
               {stats.reviewQueueCount > 0 && (
                 <div className="mt-3 text-xs text-yellow-500">
-                  {stats.reviewQueueCount} receipt{stats.reviewQueueCount === 1 ? '' : 's'} awaiting classification in the review queue.
+                  {stats.reviewQueueCount} email{stats.reviewQueueCount === 1 ? '' : 's'} in the review queue (listed below).
                 </div>
               )}
             </Card>
@@ -290,6 +360,30 @@ export default function Dashboard() {
                         >
                           {fmtPct(v.momPct)}
                         </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          )}
+
+          {/* Review queue — emails the matcher couldn't classify. Read-only:
+              booking rules live in finance-vendors.json. */}
+          {stats.queuePreview.length > 0 && (
+            <Card title={`Review queue — ${stats.reviewQueueCount} unclassified emails`}>
+              <div className="text-xs text-gray-500 mb-3">
+                Not booked, not counted — just unrecognized. To book or suppress one, add a vendor/ignore rule
+                (tell Claude the sender). Newest {stats.queuePreview.length} shown.
+              </div>
+              <div className="overflow-x-auto -mx-4 sm:-mx-5">
+                <table className="w-full text-xs sm:text-sm">
+                  <tbody>
+                    {stats.queuePreview.map((q, i) => (
+                      <tr key={i} className="border-t border-white/[0.04]">
+                        <td className="px-4 sm:px-5 py-1.5 text-gray-500 whitespace-nowrap align-top">{q.date}</td>
+                        <td className="px-2 py-1.5 text-gray-300 max-w-[10rem] truncate align-top">{q.from}</td>
+                        <td className="px-2 sm:px-5 py-1.5 text-gray-400 align-top">{q.subject}</td>
                       </tr>
                     ))}
                   </tbody>

--- a/src/app/api/admin/finance-stats/route.ts
+++ b/src/app/api/admin/finance-stats/route.ts
@@ -86,8 +86,35 @@ export async function GET(request: NextRequest) {
     ]);
 
     const stats = computeFinanceStats({ expenses, revenue, monthsBack: months });
+
+    // Row-level detail for the dashboard's month drill-down. Slimmed to what
+    // the UI renders — no raw email subjects/receipt numbers leave the server.
+    type Row = { date?: string; vendor?: string; category?: string; kind?: string; amountBusiness?: number; amountUsd?: number; excluded?: boolean; excludedReason?: string };
+    const rows = (expenses as Row[])
+      .map((e) => ({
+        date: e.date,
+        vendor: e.vendor,
+        category: e.category,
+        kind: e.kind,
+        amount: e.amountBusiness != null ? e.amountBusiness : e.amountUsd,
+        excluded: !!e.excluded,
+        excludedReason: e.excludedReason,
+      }))
+      .sort((a, b) => String(b.date).localeCompare(String(a.date)));
+
+    // Review-queue preview (admin-only page; senders/subjects are served at
+    // request time from the private repo, never bundled or committed here).
+    type QueueItem = { date?: string; from?: string; subject?: string; reason?: string };
+    const queuePreview = (reviewQueue as QueueItem[])
+      .slice()
+      .sort((a, b) => String(b.date).localeCompare(String(a.date)))
+      .slice(0, 50)
+      .map((q) => ({ date: String(q.date || '').slice(0, 10), from: q.from, subject: q.subject, reason: q.reason }));
+
     const payload = {
       ...stats,
+      rows,
+      queuePreview,
       ledgerCounts: { expenses: expenses.length, revenue: revenue.length },
       reviewQueueCount: reviewQueue.length,
       updatedAt: new Date().toISOString(),


### PR DESCRIPTION
# Finance dashboard v2 (user feedback round)

- **Month drill-down**: tap any trend month → full expense list (date, vendor, category·kind, amount; excluded rows greyed with reason, refunds tagged). The API ships slimmed rows only — no raw email subjects/receipt numbers reach the client.
- **Review queue on the page**: newest 50 unclassified emails listed (served at request time from the private repo).
- **Trend legibility**: expense bars show gross spend with refunds annotated inline instead of silently netting into confusing negative months; legend notes revenue tracking starts Jun '26 (Impact's 45-day window).
- **Vercel Jan–Mar 2026 excluded** (family-paid — user decision): drops the Feb $3.5K accidental-builds bill *and* its Mar $875.15 refund. Feb → $770.04, Mar → $736.66.
- **Queue triage**: Apify + Expo promoted to booked business vendors (8 receipts were unclassified); notice-only senders get ignore rules ordered below their booking rules.

## Verification
28/28 finance unit tests; full pipeline re-run on the real backfilled ledger; `tsc` + `next lint` clean; drill-down and queue card rendered with the real 178-row payload and read at full resolution. Known trunk E2E redness (RatingEditor, parallel session) unrelated.

## After merge
Dispatch `finance-ingest.yml` with `backfill=true` so the newly-recognized Apify/Expo receipts (some outside the daily 45-day window) get fetched and booked, and the Vercel exclusion applies to the live ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5M3ertPS9xo6ZKnRdexpF

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5M3ertPS9xo6ZKnRdexpF)_