### PR TITLE
feat: OB closing-date detector (alert-only)

### DIFF
--- a/.cron-health-exempt.txt
+++ b/.cron-health-exempt.txt
@@ -38,6 +38,7 @@ commercial-friday.yml
 commercial-stale-closures.yml
 daily-digest.yml
 demo-alias-watchdog.yml
+detect-ob-closings.yml
 drain-not-attempted.yml
 enrich-ibdb-dates.yml
 enrich-reviews.yml

--- a/.github/workflows/detect-ob-closings.yml
+++ b/.github/workflows/detect-ob-closings.yml
@@ -1,0 +1,102 @@
+# Off-Broadway closing-date detector — ALERT ONLY.
+#
+# OB shows have no closing-date automation today: update-show-status.yml and
+# audit-closing-dates.js are Broadway-only (broadway.com has no reliable OB
+# calendar, see memory/feedback_closing_date_audit_gaps.md). This workflow
+# never writes to shows.json — it only produces
+# data/audit/ob-closing-candidates.json for human review, using two signals
+# that require no new scraping: a review-text closing-date sweep and a
+# TodayTix showtimes-feed staleness diff.
+name: Detect OB Closings
+
+on:
+  schedule:
+    - cron: '0 12 * * 1'  # Weekly Mondays 12:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  detect:
+    name: Run OB closing-date detector
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout core data
+        uses: ./.github/actions/checkout-core-data
+        with:
+          token: ${{ secrets.REVIEW_TEXTS_TOKEN }}
+
+      - name: Checkout review-texts (private repo)
+        uses: ./.github/actions/checkout-review-texts
+        with:
+          token: ${{ secrets.REVIEW_TEXTS_TOKEN }}
+
+      - uses: ./.github/actions/setup-node
+
+      - name: Run detector
+        run: node scripts/detect-ob-closings.js --dry-run
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet data/audit/ob-closing-candidates.json data/audit/ob-todaytix-missing-state.json 2>/dev/null \
+            && git ls-files --error-unmatch data/audit/ob-closing-candidates.json >/dev/null 2>&1; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for large files
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: ./.github/actions/check-file-sizes
+
+      - name: Commit and push
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          git add data/audit/ob-closing-candidates.json data/audit/ob-todaytix-missing-state.json
+
+          SUMMARY=$(node -e "
+            const r = require('./data/audit/ob-closing-candidates.json');
+            console.log(r.reviewTextSweep.candidates.length + ' review-text candidates, ' + r.todaytixStaleness.candidates.length + ' TodayTix-stale candidates');
+          ")
+
+          git commit -m "audit: Weekly OB closing-date detector ($SUMMARY)
+
+          Co-Authored-By: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+
+          bash scripts/lib/push-with-retry.sh
+
+      - name: Summary
+        run: |
+          echo "## OB Closing-Date Detector (alert-only)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          node -e "
+            const r = require('./data/audit/ob-closing-candidates.json');
+            console.log('**Review-text sweep:** ' + r.reviewTextSweep.scanned + ' scanned, ' + r.reviewTextSweep.showsWithNoTexts + ' with no review-texts dir');
+            console.log('**Review-text candidates:** ' + r.reviewTextSweep.candidates.length);
+            r.reviewTextSweep.candidates.forEach(c => console.log('- ' + c.showId + ' -> ' + c.proposedClosingDate + ' [' + c.confidence + '] (' + c.reason + ')'));
+            console.log('');
+            console.log('**TodayTix staleness candidates:** ' + r.todaytixStaleness.candidates.length);
+            r.todaytixStaleness.candidates.forEach(c => console.log('- ' + c.showId + ' — missing ' + c.consecutiveMissingChecks + ' consecutive checks since ' + c.firstMissingDate));
+          " >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure
+        with:
+          title: 'Detect OB Closings Failed'
+          severity: 'warning'
+          resend_api_key: ${{ secrets.RESEND_API_KEY }}
+          owner_email: ${{ secrets.OWNER_EMAIL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -305,6 +305,11 @@ on:
       - 'data/outlet-registry.json'
       - 'tests/fixtures/classify-category-baseline.json'
       - 'public/data/mobile-shows.json'
+      # OB closing-date detector (alert-only) — colocated scripts/lib/*.test.mjs
+      # runs in the lib-test glob, but only if this job fires on push.
+      - 'scripts/detect-ob-closings.js'
+      - 'scripts/lib/ob-closing-detector.js'
+      - 'scripts/lib/ob-closing-detector.test.mjs'
       - 'package.json'
       - 'package-lock.json'
       - 'next.config.*'

--- a/scripts/detect-ob-closings.js
+++ b/scripts/detect-ob-closings.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * Off-Broadway closing-date detector — ALERT ONLY.
+ *
+ * Off-Broadway shows have no closing-date automation (Broadway-only via
+ * update-show-status.js / audit-closing-dates.js). OB runs are typically
+ * 1-6 week limited engagements, so a stale `status=open` is the common case,
+ * not the exception (see memory/feedback_closing_date_audit_gaps.md).
+ *
+ * This script never writes to shows.json. It only produces a report at
+ * data/audit/ob-closing-candidates.json for human review, using two signals
+ * that require no new scraping:
+ *
+ *   1. Review-text sweep — scans data/review-texts/<show>/*.json fullText
+ *      for closing-date boilerplate, corroborated across reviews.
+ *   2. TodayTix staleness diff — an open OB show with a todaytixId that has
+ *      dropped out of data/todaytix-showtimes.json for 2+ consecutive
+ *      weekly checks is a candidate-closed signal.
+ *
+ * Usage:
+ *   node scripts/detect-ob-closings.js [--dry-run]
+ *
+ * --dry-run is accepted for forward compatibility with a future write-mode;
+ * this version has no write-to-shows.json path at all, so it has no effect
+ * on behavior yet. The audit report is always written (that IS the alert).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { listShowDirs } = require('./lib/list-show-dirs');
+const {
+  extractClosingDateCandidates,
+  aggregateClosingDateCandidates,
+  updateTodayTixMissingState,
+  decideTodayTixCandidates,
+} = require('./lib/ob-closing-detector');
+
+const ROOT = path.join(__dirname, '..');
+const SHOWS_PATH = path.join(ROOT, 'data', 'shows.json');
+const REVIEW_TEXTS_DIR = path.join(ROOT, 'data', 'review-texts');
+const TODAYTIX_PATH = path.join(ROOT, 'data', 'todaytix-showtimes.json');
+const STATE_PATH = path.join(ROOT, 'data', 'audit', 'ob-todaytix-missing-state.json');
+const REPORT_PATH = path.join(ROOT, 'data', 'audit', 'ob-closing-candidates.json');
+
+const TODAYTIX_MISSING_THRESHOLD_CHECKS = 2;
+
+function loadJson(filePath, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (e) {
+    if (e.code === 'ENOENT') return fallback;
+    throw e;
+  }
+}
+
+function todayISO() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function getOpenOffBroadwayShows(showsData) {
+  return (showsData.shows || []).filter(
+    (s) => s.category === 'off-broadway' && s.status === 'open'
+  );
+}
+
+function runReviewTextSweep(obShows) {
+  const candidates = [];
+  const unconfirmed = [];
+  let scanned = 0;
+  let showsWithNoTexts = 0;
+
+  if (!fs.existsSync(REVIEW_TEXTS_DIR)) {
+    console.warn(`::warning::${REVIEW_TEXTS_DIR} not found — skipping review-text sweep entirely.`);
+    return { scanned: 0, showsWithNoTexts: obShows.length, candidates, unconfirmed };
+  }
+
+  for (const show of obShows) {
+    const showDir = path.join(REVIEW_TEXTS_DIR, show.id);
+    if (!fs.existsSync(showDir)) {
+      showsWithNoTexts++;
+      continue;
+    }
+    scanned++;
+
+    let files;
+    try {
+      files = fs.readdirSync(showDir).filter((f) => f.endsWith('.json'));
+    } catch (e) {
+      console.warn(`::warning::Could not read ${showDir}: ${e.message}`);
+      continue;
+    }
+
+    const reviewMentions = [];
+    for (const file of files) {
+      const filePath = path.join(showDir, file);
+      let data;
+      try {
+        data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      } catch (e) {
+        continue;
+      }
+      if (!data.fullText) continue;
+      const reviewId = `${show.id}/${file}`;
+      const candidatesForReview = extractClosingDateCandidates(data.fullText, data.publishDate);
+      for (const c of candidatesForReview) {
+        reviewMentions.push({ reviewId, isoDate: c.isoDate, quote: c.quote });
+      }
+    }
+
+    if (reviewMentions.length === 0) continue;
+
+    const proposal = aggregateClosingDateCandidates(show.id, show.openingDate, reviewMentions);
+    if (proposal) {
+      candidates.push(proposal);
+    } else {
+      unconfirmed.push({ showId: show.id, mentions: reviewMentions });
+    }
+  }
+
+  return { scanned, showsWithNoTexts, candidates, unconfirmed };
+}
+
+function runTodayTixStalenessDiff(obShows) {
+  const candidateShows = obShows.filter((s) => s.todaytixId);
+  const candidateShowIds = candidateShows.map((s) => s.id);
+
+  const todaytixData = loadJson(TODAYTIX_PATH, null);
+  if (!todaytixData) {
+    console.warn(`::warning::${TODAYTIX_PATH} not found — skipping TodayTix staleness diff.`);
+    return { checked: 0, candidates: [], skipped: true };
+  }
+
+  const presentShowIds = new Set(Object.keys(todaytixData.shows || {}));
+  const prevState = loadJson(STATE_PATH, {});
+  const nextState = updateTodayTixMissingState(prevState, candidateShowIds, presentShowIds, todayISO());
+
+  fs.mkdirSync(path.dirname(STATE_PATH), { recursive: true });
+  fs.writeFileSync(STATE_PATH, JSON.stringify(nextState, null, 2));
+
+  const candidates = decideTodayTixCandidates(nextState, TODAYTIX_MISSING_THRESHOLD_CHECKS);
+  return { checked: candidateShowIds.length, candidates, skipped: false };
+}
+
+function main() {
+  const showsData = loadJson(SHOWS_PATH, null);
+  if (!showsData) {
+    console.error(`::error::${SHOWS_PATH} not found — cannot run detector.`);
+    process.exit(1);
+  }
+
+  const obShows = getOpenOffBroadwayShows(showsData);
+  console.log(`Off-Broadway open shows: ${obShows.length}`);
+
+  const reviewTextSweep = runReviewTextSweep(obShows);
+  const todaytixStaleness = runTodayTixStalenessDiff(obShows);
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    // Alert-only version: there is no write-to-shows.json path yet, so this is
+    // always 'dry-run' regardless of the --dry-run flag (accepted for forward
+    // compatibility with a future write-mode).
+    mode: 'dry-run',
+    reviewTextSweep: {
+      scanned: reviewTextSweep.scanned,
+      showsWithNoTexts: reviewTextSweep.showsWithNoTexts,
+      candidates: reviewTextSweep.candidates,
+      unconfirmed: reviewTextSweep.unconfirmed,
+    },
+    todaytixStaleness: {
+      checked: todaytixStaleness.checked,
+      skipped: todaytixStaleness.skipped,
+      candidates: todaytixStaleness.candidates,
+    },
+  };
+
+  fs.mkdirSync(path.dirname(REPORT_PATH), { recursive: true });
+  fs.writeFileSync(REPORT_PATH, JSON.stringify(report, null, 2));
+
+  console.log('\n=== Review-text closing-date candidates ===');
+  if (reviewTextSweep.candidates.length === 0) {
+    console.log('  (none)');
+  }
+  for (const c of reviewTextSweep.candidates) {
+    console.log(`  ${c.showId} → ${c.proposedClosingDate} [${c.confidence}] (${c.reason})`);
+    for (const e of c.evidence) {
+      console.log(`      ${e.reviewId}: "${e.quote}"`);
+    }
+  }
+
+  console.log('\n=== TodayTix staleness candidates ===');
+  if (todaytixStaleness.candidates.length === 0) {
+    console.log('  (none)');
+  }
+  for (const c of todaytixStaleness.candidates) {
+    console.log(`  ${c.showId} — missing ${c.consecutiveMissingChecks} consecutive checks (since ${c.firstMissingDate})`);
+  }
+
+  console.log(`\nReport written to ${path.relative(ROOT, REPORT_PATH)}`);
+}
+
+main();

--- a/scripts/lib/ob-closing-detector.js
+++ b/scripts/lib/ob-closing-detector.js
@@ -1,0 +1,262 @@
+/**
+ * Pure decision functions for the Off-Broadway closing-date detector.
+ *
+ * Two independent signals feed the same report:
+ *  1. Review-text sweep — regex-scan review fullText for closing-date
+ *     boilerplate ("runs through <date>", "closes <date>", etc), resolve
+ *     the year from the review's publishDate (never from URLs), and
+ *     corroborate across reviews for the same show.
+ *  2. TodayTix staleness diff — an OB show with a todaytixId that has
+ *     dropped out of the daily showtimes feed for several consecutive
+ *     checks is a candidate-closed signal.
+ *
+ * Exported so scripts/detect-ob-closings.js and the colocated test file
+ * both call the same functions (CLAUDE.md §15 — never copy logic into tests).
+ */
+
+const MONTH_NAMES = {
+  jan: 1, january: 1,
+  feb: 2, february: 2,
+  mar: 3, march: 3,
+  apr: 4, april: 4,
+  may: 5,
+  jun: 6, june: 6,
+  jul: 7, july: 7,
+  aug: 8, august: 8,
+  sep: 9, sept: 9, september: 9,
+  oct: 10, october: 10,
+  nov: 11, november: 11,
+  dec: 12, december: 12,
+};
+
+const MONTH_RE_FRAGMENT = '(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)';
+const DOW_RE_FRAGMENT = '(?:Sun|Mon|Tue(?:s)?|Wed(?:nesday)?|Thu(?:rs)?|Fri|Sat)(?:day)?';
+
+const TEXT_DATE_FRAGMENT = `(?:${DOW_RE_FRAGMENT}\\.?,?\\s+)?(?<month>${MONTH_RE_FRAGMENT})\\.?\\s+(?<day>\\d{1,2})(?:st|nd|rd|th)?(?:,?\\s*(?<year>\\d{4}))?`;
+const NUMERIC_DATE_FRAGMENT = `(?<nmonth>\\d{1,2})\\/(?<nday>\\d{1,2})(?:\\/(?<nyear>\\d{2,4}))?`;
+
+// Anchor phrases that signal a closing-date boilerplate sentence. Order matters:
+// the longer "runs through/thru" and "limited run through" alternatives must be
+// tried before the bare "through"/"thru" so the anchor captured in the quote is
+// the fuller phrase when present.
+const ANCHOR_FRAGMENT = '(?:runs?\\s+(?:through|thru)|limited\\s+run\\s+through|through|thru|closes?|final\\s+performances?)';
+
+// A date must immediately follow the anchor (with only an optional connector
+// word like "on"/"is"/"are" in between) for a match. This is what rejects
+// "through the years" — "the" matches neither the month-name nor numeric
+// date fragment, so the whole alternation fails at that position.
+const MENTION_RE = new RegExp(
+  `\\b(?<anchor>${ANCHOR_FRAGMENT})\\b(?:\\s+(?:on|is|are))?\\s+(?:${TEXT_DATE_FRAGMENT}|${NUMERIC_DATE_FRAGMENT})`,
+  'gi'
+);
+
+/**
+ * Scans fullText for closing-date boilerplate mentions. Returns raw mentions
+ * with month/day parsed but year left unresolved (null) when the text omits it —
+ * resolveMentionDate() fills that in from review context, never from a URL.
+ */
+function extractClosingDateMentions(fullText) {
+  if (!fullText || typeof fullText !== 'string') return [];
+  const mentions = [];
+  const re = new RegExp(MENTION_RE.source, MENTION_RE.flags);
+  let m;
+  while ((m = re.exec(fullText)) !== null) {
+    const g = m.groups || {};
+    let month, day, year;
+    if (g.month) {
+      month = MONTH_NAMES[g.month.toLowerCase().replace(/\.$/, '')];
+      day = parseInt(g.day, 10);
+      year = g.year ? parseInt(g.year, 10) : null;
+    } else if (g.nmonth) {
+      month = parseInt(g.nmonth, 10);
+      day = parseInt(g.nday, 10);
+      year = g.nyear ? normalizeTwoDigitYear(g.nyear) : null;
+    } else {
+      continue;
+    }
+    if (!month || month < 1 || month > 12 || !day || day < 1 || day > 31) continue;
+    mentions.push({
+      anchor: g.anchor,
+      quote: m[0].trim(),
+      month,
+      day,
+      year,
+      index: m.index,
+    });
+    // Avoid zero-length-loop hazards; exec already advances past the match.
+  }
+  return mentions;
+}
+
+function normalizeTwoDigitYear(yearStr) {
+  if (yearStr.length === 4) return parseInt(yearStr, 10);
+  const twoDigit = parseInt(yearStr, 10);
+  return 2000 + twoDigit;
+}
+
+/**
+ * Resolves a mention's year using the review's publishDate when the mention
+ * text has no explicit year. If the resulting date falls more than a few days
+ * before the publish date, the boilerplate almost certainly refers to next
+ * year's date (e.g. a Dec-published review saying "through Jan 5").
+ *
+ * Returns an ISO date string ("YYYY-MM-DD") or null if unresolvable
+ * (no explicit year AND no publishDate to anchor against).
+ */
+function resolveMentionDate(mention, publishDateISO) {
+  let year = mention.year;
+  if (!year) {
+    if (!publishDateISO) return null;
+    const publishDate = new Date(`${publishDateISO}T00:00:00Z`);
+    if (isNaN(publishDate.getTime())) return null;
+    year = publishDate.getUTCFullYear();
+    const candidate = new Date(Date.UTC(year, mention.month - 1, mention.day));
+    const diffDays = (candidate.getTime() - publishDate.getTime()) / 86400000;
+    if (diffDays < -3) year += 1;
+  }
+  return `${year}-${String(mention.month).padStart(2, '0')}-${String(mention.day).padStart(2, '0')}`;
+}
+
+/**
+ * Convenience wrapper: extract + resolve in one call. Returns
+ * [{ isoDate, quote, anchor }] — mentions with an unresolvable year are dropped.
+ */
+function extractClosingDateCandidates(fullText, publishDateISO) {
+  return extractClosingDateMentions(fullText)
+    .map((mention) => {
+      const isoDate = resolveMentionDate(mention, publishDateISO);
+      if (!isoDate) return null;
+      return { isoDate, quote: mention.quote, anchor: mention.anchor };
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Run length in weeks between two ISO dates, or null if either is invalid
+ * or closing is not after opening.
+ */
+function runLengthWeeks(openingDateISO, closingDateISO) {
+  if (!openingDateISO || !closingDateISO) return null;
+  const opening = new Date(`${openingDateISO}T00:00:00Z`);
+  const closing = new Date(`${closingDateISO}T00:00:00Z`);
+  if (isNaN(opening.getTime()) || isNaN(closing.getTime())) return null;
+  const diffDays = (closing.getTime() - opening.getTime()) / 86400000;
+  if (diffDays <= 0) return null;
+  return diffDays / 7;
+}
+
+/**
+ * Corroborates closing-date candidates across a show's reviews and decides
+ * whether to propose a closingDate.
+ *
+ * reviewMentions: [{ reviewId, isoDate, quote }] — one entry per detected
+ * mention (a review can contribute 0, 1, or more).
+ *
+ * Proposes when:
+ *  - 2+ reviews (distinct reviewIds) agree on the same isoDate → confidence 'high'
+ *  - exactly 1 review contributes exactly 1 distinct isoDate, and the implied
+ *    run length (openingDate → isoDate) is 1–10 weeks → confidence 'medium'
+ * Otherwise returns null (including disagreement across reviews — that's
+ * ambiguous, not confident, and is surfaced separately for human review).
+ */
+function aggregateClosingDateCandidates(showId, openingDateISO, reviewMentions) {
+  if (!reviewMentions || reviewMentions.length === 0) return null;
+
+  const byDate = new Map();
+  for (const rm of reviewMentions) {
+    if (!byDate.has(rm.isoDate)) byDate.set(rm.isoDate, []);
+    byDate.get(rm.isoDate).push(rm);
+  }
+
+  let best = null;
+  for (const [isoDate, mentions] of byDate) {
+    const distinctReviews = new Set(mentions.map((m) => m.reviewId)).size;
+    if (!best || distinctReviews > best.distinctReviews) {
+      best = { isoDate, mentions, distinctReviews };
+    }
+  }
+
+  if (best.distinctReviews >= 2) {
+    return {
+      showId,
+      proposedClosingDate: best.isoDate,
+      confidence: 'high',
+      reason: `${best.distinctReviews} reviews agree`,
+      evidence: best.mentions,
+    };
+  }
+
+  if (byDate.size === 1 && best.distinctReviews === 1) {
+    const weeks = runLengthWeeks(openingDateISO, best.isoDate);
+    if (weeks !== null && weeks >= 1 && weeks <= 10) {
+      return {
+        showId,
+        proposedClosingDate: best.isoDate,
+        confidence: 'medium',
+        reason: `single review, ${weeks.toFixed(1)}wk implied run length`,
+        evidence: best.mentions,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Updates the consecutive-missing-checks state for the TodayTix staleness
+ * diff. Called once per detector run (weekly cron).
+ *
+ * prevState: { [showId]: { consecutiveMissingChecks, firstMissingDate, lastCheckedDate } }
+ * candidateShowIds: ids of open OB shows that carry a todaytixId
+ * presentShowIds: Set of ids currently present in data/todaytix-showtimes.json
+ *
+ * Shows that reappear in the feed are dropped from the next state (reset).
+ */
+function updateTodayTixMissingState(prevState, candidateShowIds, presentShowIds, todayISO) {
+  const nextState = {};
+  for (const showId of candidateShowIds) {
+    if (presentShowIds.has(showId)) continue;
+    const prev = prevState[showId];
+    if (prev) {
+      nextState[showId] = {
+        consecutiveMissingChecks: prev.consecutiveMissingChecks + 1,
+        firstMissingDate: prev.firstMissingDate,
+        lastCheckedDate: todayISO,
+      };
+    } else {
+      nextState[showId] = {
+        consecutiveMissingChecks: 1,
+        firstMissingDate: todayISO,
+        lastCheckedDate: todayISO,
+      };
+    }
+  }
+  return nextState;
+}
+
+/**
+ * Decides which entries in the (updated) missing-state cross the
+ * consecutive-checks threshold and should be surfaced as candidate-closed.
+ * Default threshold is 2 consecutive weekly checks (~2 weeks stale) —
+ * tolerates a single feed hiccup without flagging.
+ */
+function decideTodayTixCandidates(state, thresholdChecks = 2) {
+  return Object.entries(state)
+    .filter(([, v]) => v.consecutiveMissingChecks >= thresholdChecks)
+    .map(([showId, v]) => ({
+      showId,
+      consecutiveMissingChecks: v.consecutiveMissingChecks,
+      firstMissingDate: v.firstMissingDate,
+    }));
+}
+
+module.exports = {
+  MONTH_NAMES,
+  extractClosingDateMentions,
+  resolveMentionDate,
+  extractClosingDateCandidates,
+  runLengthWeeks,
+  aggregateClosingDateCandidates,
+  updateTodayTixMissingState,
+  decideTodayTixCandidates,
+};

--- a/scripts/lib/ob-closing-detector.test.mjs
+++ b/scripts/lib/ob-closing-detector.test.mjs
@@ -1,0 +1,196 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  extractClosingDateMentions,
+  resolveMentionDate,
+  extractClosingDateCandidates,
+  runLengthWeeks,
+  aggregateClosingDateCandidates,
+  updateTodayTixMissingState,
+  decideTodayTixCandidates,
+} = require('./ob-closing-detector.js');
+
+// --- extractClosingDateMentions: date-pattern extraction ---
+
+test('extracts "through Sun July 5" (day-of-week, no year)', () => {
+  const mentions = extractClosingDateMentions('The show runs through Sun July 5 at the theater.');
+  assert.equal(mentions.length, 1);
+  assert.equal(mentions[0].month, 7);
+  assert.equal(mentions[0].day, 5);
+  assert.equal(mentions[0].year, null);
+});
+
+test('extracts "through July 5, 2026" (explicit year)', () => {
+  const mentions = extractClosingDateMentions('Tickets are on sale through July 5, 2026 only.');
+  assert.equal(mentions.length, 1);
+  assert.equal(mentions[0].month, 7);
+  assert.equal(mentions[0].day, 5);
+  assert.equal(mentions[0].year, 2026);
+});
+
+test('extracts "runs thru 7/5" (numeric date, no year)', () => {
+  const mentions = extractClosingDateMentions('The limited engagement runs thru 7/5 at Theater Row.');
+  assert.equal(mentions.length, 1);
+  assert.equal(mentions[0].month, 7);
+  assert.equal(mentions[0].day, 5);
+  assert.equal(mentions[0].year, null);
+});
+
+test('extracts numeric date with 2-digit year', () => {
+  const mentions = extractClosingDateMentions('Performances continue through 7/5/26.');
+  assert.equal(mentions.length, 1);
+  assert.equal(mentions[0].year, 2026);
+});
+
+test('does NOT match "through the years" (negative case)', () => {
+  const mentions = extractClosingDateMentions('This show has evolved through the years into something special.');
+  assert.equal(mentions.length, 0);
+});
+
+test('does NOT match bare "closes" without a trailing date', () => {
+  const mentions = extractClosingDateMentions('The theater closes its doors early on weeknights.');
+  assert.equal(mentions.length, 0);
+});
+
+test('extracts "closes <date>"', () => {
+  const mentions = extractClosingDateMentions('The production closes August 14, 2026.');
+  assert.equal(mentions.length, 1);
+  assert.equal(mentions[0].month, 8);
+  assert.equal(mentions[0].day, 14);
+  assert.equal(mentions[0].year, 2026);
+});
+
+test('extracts "final performance <date>"', () => {
+  const mentions = extractClosingDateMentions('The final performance is September 1.');
+  assert.equal(mentions.length, 1);
+  assert.equal(mentions[0].month, 9);
+  assert.equal(mentions[0].day, 1);
+});
+
+test('extracts "limited run through <date>"', () => {
+  const mentions = extractClosingDateMentions('This is a limited run through June 30, 2026 at the venue.');
+  assert.equal(mentions.length, 1);
+  assert.equal(mentions[0].month, 6);
+  assert.equal(mentions[0].day, 30);
+  assert.equal(mentions[0].year, 2026);
+});
+
+// --- resolveMentionDate: year resolution from review context, never URLs ---
+
+test('resolves year from publishDate when text omits it (same-year case)', () => {
+  const mention = { month: 7, day: 5, year: null };
+  assert.equal(resolveMentionDate(mention, '2026-06-15'), '2026-07-05');
+});
+
+test('rolls to next year when computed date is well before publishDate', () => {
+  // Review published Dec 2026 says "through Jan 5" — must mean Jan 2027, not Jan 2026.
+  const mention = { month: 1, day: 5, year: null };
+  assert.equal(resolveMentionDate(mention, '2026-12-10'), '2027-01-05');
+});
+
+test('uses explicit year in the mention over publishDate inference', () => {
+  const mention = { month: 7, day: 5, year: 2027 };
+  assert.equal(resolveMentionDate(mention, '2026-06-15'), '2027-07-05');
+});
+
+test('returns null when no year in text and no publishDate available', () => {
+  const mention = { month: 7, day: 5, year: null };
+  assert.equal(resolveMentionDate(mention, undefined), null);
+});
+
+// --- extractClosingDateCandidates: the real Misterman FRC boilerplate ---
+
+test('Misterman fixture: resolves full closing date from review context', () => {
+  const fullText =
+    "Misterman runs through Sun July 5 at Theater Row, 410 West 42nd Street. " +
+    "Running Time: 90 minutes no intermission";
+  const candidates = extractClosingDateCandidates(fullText, '2026-06-20');
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].isoDate, '2026-07-05');
+  assert.match(candidates[0].quote, /runs through Sun July 5/);
+});
+
+// --- runLengthWeeks ---
+
+test('computes run length in weeks', () => {
+  assert.equal(runLengthWeeks('2026-06-01', '2026-06-15'), 2);
+});
+
+test('returns null when closing is not after opening', () => {
+  assert.equal(runLengthWeeks('2026-06-15', '2026-06-01'), null);
+});
+
+// --- aggregateClosingDateCandidates: corroboration ---
+
+test('proposes high confidence when 2+ reviews agree', () => {
+  const result = aggregateClosingDateCandidates('show-1', '2026-05-01', [
+    { reviewId: 'nyt/review.json', isoDate: '2026-07-05', quote: 'q1' },
+    { reviewId: 'timeout/review.json', isoDate: '2026-07-05', quote: 'q2' },
+  ]);
+  assert.equal(result.confidence, 'high');
+  assert.equal(result.proposedClosingDate, '2026-07-05');
+});
+
+test('proposes medium confidence for single review within 1-10wk run length', () => {
+  const result = aggregateClosingDateCandidates('show-1', '2026-05-01', [
+    { reviewId: 'nyt/review.json', isoDate: '2026-06-01', quote: 'q1' },
+  ]);
+  assert.equal(result.confidence, 'medium');
+  assert.equal(result.proposedClosingDate, '2026-06-01');
+});
+
+test('does not propose for single review outside 1-10wk run length', () => {
+  const result = aggregateClosingDateCandidates('show-1', '2026-05-01', [
+    { reviewId: 'nyt/review.json', isoDate: '2027-05-01', quote: 'q1' },
+  ]);
+  assert.equal(result, null);
+});
+
+test('does not propose when reviews disagree (ambiguous)', () => {
+  const result = aggregateClosingDateCandidates('show-1', '2026-05-01', [
+    { reviewId: 'nyt/review.json', isoDate: '2026-07-05', quote: 'q1' },
+    { reviewId: 'timeout/review.json', isoDate: '2026-07-12', quote: 'q2' },
+  ]);
+  assert.equal(result, null);
+});
+
+test('returns null for empty mentions', () => {
+  assert.equal(aggregateClosingDateCandidates('show-1', '2026-05-01', []), null);
+});
+
+// --- TodayTix staleness diff ---
+
+test('updateTodayTixMissingState starts a new entry for a newly-missing show', () => {
+  const state = updateTodayTixMissingState({}, ['show-a', 'show-b'], new Set(['show-b']), '2026-07-01');
+  assert.deepEqual(state, {
+    'show-a': { consecutiveMissingChecks: 1, firstMissingDate: '2026-07-01', lastCheckedDate: '2026-07-01' },
+  });
+});
+
+test('updateTodayTixMissingState increments consecutive count across runs', () => {
+  const week1 = updateTodayTixMissingState({}, ['show-a'], new Set(), '2026-07-01');
+  const week2 = updateTodayTixMissingState(week1, ['show-a'], new Set(), '2026-07-08');
+  assert.equal(week2['show-a'].consecutiveMissingChecks, 2);
+  assert.equal(week2['show-a'].firstMissingDate, '2026-07-01');
+  assert.equal(week2['show-a'].lastCheckedDate, '2026-07-08');
+});
+
+test('updateTodayTixMissingState resets (drops) a show that reappears', () => {
+  const week1 = updateTodayTixMissingState({}, ['show-a'], new Set(), '2026-07-01');
+  const week2 = updateTodayTixMissingState(week1, ['show-a'], new Set(['show-a']), '2026-07-08');
+  assert.deepEqual(week2, {});
+});
+
+test('decideTodayTixCandidates only flags entries at/above the threshold', () => {
+  const state = {
+    'show-a': { consecutiveMissingChecks: 1, firstMissingDate: '2026-07-08' },
+    'show-b': { consecutiveMissingChecks: 2, firstMissingDate: '2026-07-01' },
+    'show-c': { consecutiveMissingChecks: 3, firstMissingDate: '2026-06-24' },
+  };
+  const candidates = decideTodayTixCandidates(state, 2);
+  const ids = candidates.map((c) => c.showId).sort();
+  assert.deepEqual(ids, ['show-b', 'show-c']);
+});


### PR DESCRIPTION
## What was built

Off-Broadway closings have no automation today — `update-show-status.yml` only flips Broadway shows via Broadway.org, and `audit-closing-dates.js` is Broadway-only (broadway.com has no reliable OB calendar; see `memory/feedback_closing_date_audit_gaps.md`). OB shows are typically 1–6 week limited runs, so a stale `status=open`/`closingDate=null` is the common case — the trigger incident was `misterman-theatre-row-off-broadway-2026`, closed 2026-07-05 but stuck open until a manual fix on 2026-07-12.

This PR adds a **read-only, alert-only** weekly detector using two signals that need no new scraping:

1. **Review-text closing-date sweep** (`scripts/lib/ob-closing-detector.js`) — regex-scans `data/review-texts/<show>/*.json` `fullText` for boilerplate (`runs through <date>`, `closes <date>`, `final performance <date>`, `limited run through <date>`, numeric `M/D` dates). Year is resolved from the review's `publishDate` context (never from URLs, per CLAUDE.md rule 3) — rolls to next year when the computed date falls well before the publish date. Proposes a closing date when 2+ reviews agree (`high` confidence) or a single review implies a 1–10 week run (`medium` confidence); disagreement across reviews is left unconfirmed for human review, not guessed at.
2. **TodayTix staleness diff** — open OB shows with a `todaytixId` that vanish from `data/todaytix-showtimes.json` for 2+ consecutive weekly checks are flagged as candidate-closed. State tracked in `data/audit/ob-todaytix-missing-state.json` (consecutive-missing counter, resets when the show reappears).

**Never writes to `shows.json`.** Output is `data/audit/ob-closing-candidates.json` (candidates + evidence quotes + unconfirmed mentions) for human review only.

### Files
- `scripts/lib/ob-closing-detector.js` — pure decision functions (date extraction, year resolution, corroboration, staleness state machine)
- `scripts/lib/ob-closing-detector.test.mjs` — colocated `node:test` suite, `require()`s the real module (CLAUDE.md rule 15)
- `scripts/detect-ob-closings.js` — CLI, `--dry-run` accepted (no-op today — there's no write path to gate yet)
- `.github/workflows/detect-ob-closings.yml` — weekly Monday 12:00 UTC cron + `workflow_dispatch`, checks out core data + review-texts via the existing composite actions, commits the audit JSON, `notify-failure` (severity `warning`) on failure
- `.github/workflows/test.yml` — registered the new lib/test/CLI paths in the push allow-list

## Test output

```
node --test scripts/lib/ob-closing-detector.test.mjs
# tests 25
# pass 25
# fail 0
```

Covers: all 4 boilerplate patterns from the task brief, the numeric-date + 2-digit-year case, the `through the years` and bare-`closes` negative cases, the Misterman FRC fixture text end-to-end, year-rollover resolution, run-length math, all 4 corroboration branches (agree/single-in-range/single-out-of-range/disagree), and the TodayTix state machine (new/increment/reset/threshold).

`npx tsc --noEmit` — no new errors (pre-existing errors are unrelated missing-data-file TS2307s in `src/lib/data-*.ts` from this cloud session's incomplete data bootstrap, not caused by this change). `npx next lint` — no new warnings.

## What ran against real data vs fixtures

This is a cloud session without `REVIEW_TEXTS_TOKEN`, so `data/review-texts/` was unavailable.

- **TodayTix staleness diff — validated against real production data.** `data/shows.json` and `data/todaytix-showtimes.json` were available. Ran the CLI twice in sequence (simulating two weekly checks) against the real 47 open OB shows / 35 with a `todaytixId`: correctly identified the same 7 shows that are genuinely absent from the current showtimes feed (`girl-interrupted-off-broadway-2026`, `drunk-shakespeare-off-broadway-2022`, `my-joy-is-heavy-off-broadway-2025`, `age-is-a-feeling-off-broadway-2024`, `gotta-dance-off-broadway-2026`, `camping-off-broadway-2026`, `the-black-mirror-experience-off-broadway-2026`) and flagged them at the 2-check threshold, with 0 false positives among the other 28.
- **Review-text sweep — validated against synthetic fixtures** modeled on real boilerplate (the Misterman FRC text: `"Misterman runs through Sun July 5 at Theater Row, 410 West 42nd Street. Running Time: 90 minutes no intermission"`), both in the unit tests and in a temporary end-to-end smoke test (two synthetic review files for a real show id, confirmed the CLI produced a `high`-confidence candidate with correct evidence quotes, then removed the fixtures — nothing synthetic is committed).

## Next steps to graduate from alert-only to auto-write

1. Run for a few weeks, review `data/audit/ob-closing-candidates.json` manually each Monday to calibrate false-positive rate (especially the TodayTix 2-check threshold — may need tuning per show type).
2. Add a write path gated behind `--dry-run` (default `true`): on `high`-confidence review-text candidates only, write `closingDate` + flip `status: 'closed'`, following the same validate → rollback-on-failure pattern as `audit-closing-dates.yml`.
3. Decide whether TodayTix-staleness-only candidates (no corroborating review text) should ever auto-write, or always require human confirmation — TodayTix `endDate`/feed absence has known source-fidelity gaps (see `memory/feedback_closing_date_audit_gaps.md` point 2).
4. Consider extending the review-text sweep to West End OB-equivalent venues once this is proven on Broadway/OB data.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01X8hrwJNGyCDSDYxf3hSyYY)_