### PR TITLE
Stop invisible ScrapingBee burn: SD-empty authoritative + SB telemetry + SD tiers

### DIFF
--- a/scripts/collect-review-texts.js
+++ b/scripts/collect-review-texts.js
@@ -119,6 +119,7 @@ const { isWithinPriorRun } = require('./lib/wrong-production-autoclear');
 const { shouldRetryGarbageConsentWall } = require('./lib/consent-refetch');
 const { checkBrowserbaseCaps } = require('./lib/browserbase-caps');
 const { logExclusion } = require('./lib/exclusion-logger');
+const { recordSbCall } = require('./lib/bd-telemetry');
 const { shouldSkipPollerUpdate, safeRenameReview } = require('./lib/review-write-guard');
 
 /**
@@ -428,7 +429,7 @@ const UNCOLLECTABLE_OUTLETS = (() => {
 })();
 
 // Domain alias matching — imported from shared lib (scraper.js)
-const { domainMatchesExpected, checkScrapingBeeCredits } = require('./lib/scraper');
+const { domainMatchesExpected, checkScrapingBeeCredits, fetchWithScrapingdog: sdFetch } = require('./lib/scraper');
 const { discoverCorrectUrl: _sharedDiscoverUrl } = require('./lib/url-discovery');
 const { shouldRetryUrlDiscovery, recordSerpAttempt } = require('./lib/review-guards');
 const { clearFailureFlags } = require('./lib/clear-failure-flags');
@@ -2288,6 +2289,7 @@ async function fetchWithScrapingBee(url, useStealth = false) {
     const response = await axios.get('https://app.scrapingbee.com/api/v1/', requestConfig);
 
     stats.scrapingBeePageCredits += credits;
+    recordSbCall({ url, fn: proxyType, success: true, status: 200, credits });
 
     const html = response.data;
 
@@ -2316,6 +2318,7 @@ async function fetchWithScrapingBee(url, useStealth = false) {
     if (error.response) {
       const status = error.response.status;
       const message = error.response.data?.message || error.message;
+      recordSbCall({ url, fn: proxyType, success: false, status, credits: 0 });
 
       if (status === 401) {
         throw new Error(`ScrapingBee auth failed: ${message}`);
@@ -2327,6 +2330,32 @@ async function fetchWithScrapingBee(url, useStealth = false) {
     }
     throw error;
   }
+}
+
+// ============================================================================
+// TIER 1.9: Scrapingdog API (cheap tier ahead of ScrapingBee)
+// ============================================================================
+
+/**
+ * Fetch via Scrapingdog before spending ScrapingBee credits. Mirrors the SB
+ * tier's cost model (plain=1cr, JS=5cr, premium=10cr) at ~1/4 the per-credit
+ * price. Uses scraper.js's fetchWithScrapingdog (flag-gated, budget-guarded,
+ * telemetered). Throws on miss so the chain falls through to SB/BD.
+ */
+async function fetchWithScrapingdogTier(url) {
+  const hostname = (() => { try { return new URL(url).hostname.replace(/^www\./, ''); } catch { return ''; } })();
+  const needsPremium = SB_PREMIUM_DOMAINS.has(hostname);
+  const result = await sdFetch(url, { premium: needsPremium });
+  if (!result || !result.content) throw new Error('Scrapingdog returned no content');
+
+  const html = result.content;
+  if (isBlocked(html)) throw new Error('Scrapingdog: blocked/challenge page');
+
+  const text = extractTextFromHtml(html, url);
+  if (text && text.length > 500) {
+    return { html, text };
+  }
+  throw new Error(`Scrapingdog: insufficient text (${text?.length || 0} chars)`);
 }
 
 // ============================================================================
@@ -3176,6 +3205,25 @@ function buildTierChain(ctx, review) {
           }
           console.warn(`  ⚠ COOKIE EXPIRED: ${ctx.url} — falling back to lower tiers`);
         }
+      },
+    },
+
+    // TIER 1.9: Scrapingdog (flag-gated cheap tier — spends SD credits before SB's)
+    {
+      id: 'scrapingdog',
+      tierNumber: 1.9,
+      method: 'scrapingdog',
+      label: 'Scrapingdog API',
+      shouldRun: () => {
+        if (ctx.skipDirectScrapers) return false;
+        // Cookie-forwarding domains stay on SB — its Spb-Cookie forwarding is
+        // proven for paywalled sites; SD cookie support is untested there.
+        if (buildCookieHeaderForUrl(url)) return false;
+        return process.env.SCRAPER_USE_SCRAPINGDOG === '1' && !!process.env.SCRAPINGDOG_API_KEY;
+      },
+      execute: (url) => fetchWithScrapingdogTier(url),
+      onFailure: (error) => {
+        ctx.anyTierFailed = true;
       },
     },
 
@@ -5133,7 +5181,7 @@ function loadState() {
         state = saved;
         // Ensure tierBreakdown and all sub-arrays exist (older state files may be missing keys)
         if (!state.tierBreakdown) {
-          state.tierBreakdown = { playwright: [], amp: [], browserbase: [], directCookies: [], scrapingbee: [], brightdata: [], archiveToday: [], archive: [] };
+          state.tierBreakdown = { playwright: [], amp: [], browserbase: [], directCookies: [], scrapingdog: [], scrapingbee: [], brightdata: [], archiveToday: [], archive: [] };
         } else {
           for (const key of ['playwright', 'amp', 'browserbase', 'scrapingbee', 'brightdata', 'archiveToday', 'archive']) {
             if (!state.tierBreakdown[key]) state.tierBreakdown[key] = [];
@@ -6591,6 +6639,7 @@ function generateReport() {
       amp: state.tierBreakdown.amp?.length || 0,
       browserbase: state.tierBreakdown.browserbase?.length || 0,
       directCookies: state.tierBreakdown.directCookies?.length || 0,
+      scrapingdog: state.tierBreakdown.scrapingdog?.length || 0,
       scrapingbee: state.tierBreakdown.scrapingbee?.length || 0,
       brightdata: state.tierBreakdown.brightdata?.length || 0,
       archiveToday: state.tierBreakdown.archiveToday?.length || 0,
@@ -6858,8 +6907,13 @@ async function main() {
   generateReport();
 }
 
-// Run
-main().catch(error => {
-  console.error('Fatal error:', error);
-  closeBrowser().finally(() => process.exit(1));
-});
+// Run (require-guarded so tests can require the tier helpers without
+// kicking off a full collection run)
+if (require.main === module) {
+  main().catch(error => {
+    console.error('Fatal error:', error);
+    closeBrowser().finally(() => process.exit(1));
+  });
+}
+
+module.exports = { fetchWithScrapingdogTier };

--- a/scripts/lib/site-search-discovery.js
+++ b/scripts/lib/site-search-discovery.js
@@ -1021,6 +1021,7 @@ function fetchJSON(url, options = {}, timeoutMs = 15000) {
  * Fetch with ScrapingBee (for JS-rendered search pages)
  */
 function fetchWithScrapingBee(url, timeoutMs = 30000) {
+  const { recordSbCall } = require('./bd-telemetry');
   return new Promise((resolve, reject) => {
     if (!SCRAPINGBEE_KEY) return reject(new Error('No ScrapingBee key'));
     const apiUrl = `https://app.scrapingbee.com/api/v1/?api_key=${SCRAPINGBEE_KEY}&url=${encodeURIComponent(url)}&render_js=true&wait=3000`;
@@ -1028,8 +1029,14 @@ function fetchWithScrapingBee(url, timeoutMs = 30000) {
       let data = '';
       res.on('data', chunk => data += chunk);
       res.on('end', () => {
-        if (res.statusCode === 200) resolve(data);
-        else reject(new Error(`ScrapingBee HTTP ${res.statusCode}`));
+        if (res.statusCode === 200) {
+          recordSbCall({ url, fn: 'site-search-render', success: true, status: 200, credits: 5 });
+          resolve(data);
+        } else {
+          // SB only charges successful (2xx/404) requests; 404 still costs credits.
+          recordSbCall({ url, fn: 'site-search-render', success: false, status: res.statusCode, credits: res.statusCode === 404 ? 5 : 0 });
+          reject(new Error(`ScrapingBee HTTP ${res.statusCode}`));
+        }
       });
       res.on('error', reject);
     });

--- a/scripts/lib/url-discovery.js
+++ b/scripts/lib/url-discovery.js
@@ -18,7 +18,7 @@ const { isUrlYearOutsideWindow, hasTryoutUrlMarker } = require('./content-filter
 const { isLondonMarket } = require('./venue-classification');
 const { urlLooksLikeReview, isSluglessReviewUrl } = require('./review-guards');
 const { validateSerpCandidate } = require('./serp-candidate-validator');
-const { recordBdCall, recordSdCall } = require('./bd-telemetry');
+const { recordBdCall, recordSdCall, recordSbCall } = require('./bd-telemetry');
 
 // Scrapingdog SERP — flag-gated cheap primary ahead of BD/SB SERP. Google Light
 // Search = 5 credits (~$0.45/1k) vs BD SERP (~$1.50/1k). Default OFF.
@@ -324,6 +324,7 @@ async function _serpViaScrapingBee(query, apiKey, log, dateRange) {
       });
       const data = response.data;
       _recordSerpResult(true);
+      recordSbCall({ host: 'serp.scrapingbee', fn: 'serp', success: true, status: 200, credits: 25 });
       return (data.organic_results || data.results || []).map(r => ({
         url: r.url || r.link,
         title: r.title || '',
@@ -333,6 +334,7 @@ async function _serpViaScrapingBee(query, apiKey, log, dateRange) {
       const status = error.response?.status;
       if (status === 401 || status === 403 || status === 429) {
         _scrapingBeeSerpExhausted = true;
+        recordSbCall({ host: 'serp.scrapingbee', fn: 'serp', success: false, status, credits: 0 });
         log(`    ⚠ ScrapingBee SERP exhausted (${status}) — falling back to Bright Data`);
         return null;
       }
@@ -343,6 +345,7 @@ async function _serpViaScrapingBee(query, apiKey, log, dateRange) {
         continue;
       }
       _recordSerpResult(false);
+      recordSbCall({ host: 'serp.scrapingbee', fn: 'serp', success: false, status: status || (error.message || 'error').slice(0, 80), credits: 0 });
       const failCount = _scrapingBeeSerpResults.filter(r => !r).length;
       log(`    ✗ ScrapingBee SERP error (${failCount}/${ROLLING_WINDOW_SIZE} recent failures): ${error.message}`);
       if (_scrapingBeeSerpExhausted) {
@@ -574,11 +577,17 @@ async function _serpWithChain(query, scrapingBeeKey, brightDataKey, log, dateRan
     return { results: cached.results, provider: `${cached.provider}-cached` };
   }
 
-  // Scrapingdog first (flag-gated, ~3x cheaper than BD SERP). On null/empty it
-  // falls through to the existing BD/SB chain, which stays as the safety net.
+  // Scrapingdog first (flag-gated, ~3x cheaper than BD SERP). Only a null
+  // (HTTP error / circuit-breaker open / flag off) falls through to the BD/SB
+  // chain. An empty-but-successful result IS the answer ("no results") —
+  // cascading it to BD/SB re-asks the same question for up to 25 SB credits,
+  // every poll cycle on the opening-night path where empties are never cached
+  // (2026-07-05 SB burn incident: ~2,800 invisible SB SERP calls/day).
+  // Escape hatch: SD_EMPTY_CASCADE=1 restores the old cascade if SD empties
+  // turn out to hide real results on some query class.
   if (USE_SCRAPINGDOG && SCRAPINGDOG_API_KEY) {
     const sdResults = await _serpViaScrapingdog(query, log, dateRange, resolvedGeo);
-    if (sdResults && sdResults.length > 0) {
+    if (sdResults && (sdResults.length > 0 || process.env.SD_EMPTY_CASCADE !== '1')) {
       if (!(preferSpeed && sdResults.length === 0)) {
         _serpCache.set(query, cacheOpts, { results: sdResults, provider: 'scrapingdog' });
       }

--- a/scripts/scrape-show-score-audience.js
+++ b/scripts/scrape-show-score-audience.js
@@ -147,13 +147,17 @@ function fetchViaScrapingBeeSingle(url) {
 
     const apiUrl = `https://app.scrapingbee.com/api/v1/?api_key=${SCRAPINGBEE_KEY}&url=${encodeURIComponent(url)}&render_js=true&premium_proxy=true&wait=3000`;
 
+    const { recordSbCall } = require('./lib/bd-telemetry');
     https.get(apiUrl, { timeout: 60000 }, (res) => {
       let data = '';
       res.on('data', chunk => data += chunk);
       res.on('end', () => {
         if (res.statusCode === 200) {
+          // render_js (5) × premium_proxy (5) = 25 credits per page
+          recordSbCall({ url, fn: 'render-premium', success: true, status: 200, credits: 25 });
           resolve(data);
         } else {
+          recordSbCall({ url, fn: 'render-premium', success: false, status: res.statusCode, credits: res.statusCode === 404 ? 25 : 0 });
           reject(new Error(`ScrapingBee HTTP ${res.statusCode}: ${data.slice(0, 200)}`));
         }
       });
@@ -240,6 +244,23 @@ function fetchViaBrightData(url) {
  * Returns HTML string or throws if all methods fail.
  */
 async function fetchWithFallback(url, retries = 2) {
+  // Scrapingdog first (flag-gated) — ~1/4 the credit price of SB's render_js +
+  // premium_proxy (25 credits/page). Only accept a payload with extractable
+  // data: an unrendered SPA shell would otherwise read as "show has no score"
+  // and skip the update instead of falling through to ScrapingBee.
+  if (process.env.SCRAPER_USE_SCRAPINGDOG === '1' && process.env.SCRAPINGDOG_API_KEY) {
+    try {
+      const { fetchWithScrapingdog } = require('./lib/scraper');
+      const sd = await fetchWithScrapingdog(url, { renderJs: true, premium: true });
+      if (sd && sd.content && (sd.content.includes('aggregateRating') || /class="[^"]*score/i.test(sd.content))) {
+        return sd.content;
+      }
+      if (verbose) console.log('  Scrapingdog returned no extractable payload — falling back to ScrapingBee...');
+    } catch (error) {
+      if (verbose) console.log(`  Scrapingdog failed: ${error.message} — falling back to ScrapingBee...`);
+    }
+  }
+
   // Try ScrapingBee first (with retries) — best for Show Score (render_js + premium_proxy)
   if (SCRAPINGBEE_KEY) {
     for (let attempt = 1; attempt <= retries + 1; attempt++) {

--- a/scripts/test-collect-scrapingdog-tier.js
+++ b/scripts/test-collect-scrapingdog-tier.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Regression test: collect-review-texts.js TIER 1.9 (Scrapingdog before
+ * ScrapingBee). Tests the REAL fetchWithScrapingdogTier via require() with
+ * scraper.js's fetchWithScrapingdog stubbed in require.cache — verifies
+ * accept/fall-through behavior so SD misses cascade to SB instead of
+ * masquerading as successes (or vice versa).
+ */
+
+process.env.SCRAPER_USE_SCRAPINGDOG = '1';
+process.env.SCRAPINGDOG_API_KEY = 'test-key';
+
+// Stub lib/scraper BEFORE collect-review-texts loads. Preserve the real
+// module's other exports (domainMatchesExpected etc.) that collect requires.
+const scraperPath = require.resolve('./lib/scraper');
+const realScraper = require('./lib/scraper');
+let sdResponse = null;
+require.cache[scraperPath].exports = {
+  ...realScraper,
+  fetchWithScrapingdog: async () => sdResponse,
+};
+
+const { fetchWithScrapingdogTier } = require('./collect-review-texts');
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) { console.log(`  ✓ ${name}`); }
+  else { failures++; console.error(`  ✗ ${name}${detail ? ` — ${detail}` : ''}`); }
+}
+
+(async () => {
+  console.log('1. Real article HTML → accepted ({html, text})');
+  const para = `<p>${'Hamilton is a triumph of staging and score, a revolution in musical form. '.repeat(4)}</p>`;
+  const article = `<html><body><article>${para.repeat(8)}</article></body></html>`;
+  sdResponse = { content: article, format: 'html', source: 'scrapingdog' };
+  const r1 = await fetchWithScrapingdogTier('https://example.com/review').catch(e => e);
+  check('returns html+text', r1 && r1.html && r1.text && r1.text.length > 500, r1 instanceof Error ? r1.message : `text len ${r1?.text?.length}`);
+
+  console.log('2. Null (provider off/error) → throws so chain falls through to SB');
+  sdResponse = null;
+  const r2 = await fetchWithScrapingdogTier('https://example.com/review').catch(e => e);
+  check('throws', r2 instanceof Error, JSON.stringify(r2)?.slice(0, 80));
+
+  console.log('3. Challenge page → throws (falls through, not accepted)');
+  sdResponse = { content: '<html><body>Just a moment...<div id="cf_chl_opt"></div></body></html>', format: 'html', source: 'scrapingdog' };
+  const r3 = await fetchWithScrapingdogTier('https://example.com/review').catch(e => e);
+  check('throws on blocked page', r3 instanceof Error, r3?.message);
+
+  console.log('4. Thin content (<500 chars) → throws (falls through)');
+  sdResponse = { content: '<html><body><p>Short stub.</p></body></html>', format: 'html', source: 'scrapingdog' };
+  const r4 = await fetchWithScrapingdogTier('https://example.com/review').catch(e => e);
+  check('throws on thin content', r4 instanceof Error, r4?.message);
+
+  console.log(failures === 0 ? '\nAll tests passed.' : `\n${failures} test(s) FAILED.`);
+  process.exit(failures === 0 ? 0 : 1);
+})();

--- a/scripts/test-sd-serp-short-circuit.js
+++ b/scripts/test-sd-serp-short-circuit.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Regression test: Scrapingdog empty-but-successful SERP results must be
+ * authoritative — they must NOT cascade to the BD/SB chain (2026-07-05 SB burn
+ * incident: SD empties re-asked via ScrapingBee at 25 credits/query, every
+ * poll cycle, invisibly). Also verifies the SD_EMPTY_CASCADE=1 escape hatch
+ * and that _serpViaScrapingBee now emits [SB Call] telemetry.
+ *
+ * Tests the REAL serpQuery/_serpWithChain from url-discovery.js (no copied
+ * logic) by stubbing axios in require.cache before the module loads.
+ */
+
+process.env.SCRAPER_USE_SCRAPINGDOG = '1';
+process.env.SCRAPINGDOG_API_KEY = 'test-sd-key';
+process.env.BD_SERP_CACHE_DISABLED = '1';
+delete process.env.SD_EMPTY_CASCADE;
+
+// ---- Stub axios BEFORE url-discovery loads (it lazily require()s axios) ----
+const calls = [];
+let sdOrganic = [];   // what the fake Scrapingdog returns
+let sbOrganic = [];   // what the fake ScrapingBee returns
+const fakeAxios = {
+  get: async (apiUrl) => {
+    if (apiUrl.includes('scrapingdog.com/google')) {
+      calls.push('sd');
+      return { data: { organic_results: sdOrganic } };
+    }
+    if (apiUrl.includes('scrapingbee.com/api/v1/store/google')) {
+      calls.push('sb');
+      return { data: { organic_results: sbOrganic } };
+    }
+    calls.push(`other:${apiUrl.slice(0, 40)}`);
+    throw new Error('unexpected endpoint');
+  },
+};
+const axiosPath = require.resolve('axios');
+require.cache[axiosPath] = { id: axiosPath, filename: axiosPath, loaded: true, exports: fakeAxios };
+
+const { serpQuery } = require('./lib/url-discovery');
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) { console.log(`  ✓ ${name}`); }
+  else { failures++; console.error(`  ✗ ${name}${detail ? ` — ${detail}` : ''}`); }
+}
+const quiet = () => {};
+
+(async () => {
+  console.log('1. SD empty-success is authoritative (no SB/BD cascade)');
+  calls.length = 0; sdOrganic = [];
+  const r1 = await serpQuery('test empty query one', { scrapingBeeKey: 'test-sb-key', log: quiet, preferSpeed: true });
+  check('returns empty array (not null)', Array.isArray(r1) && r1.length === 0, `got ${JSON.stringify(r1)}`);
+  check('only Scrapingdog was called', calls.join(',') === 'sd', `calls: ${calls.join(',')}`);
+
+  console.log('2. SD non-empty results returned as-is');
+  calls.length = 0; sdOrganic = [{ link: 'https://example.com/review', title: 'A Review' }];
+  const r2 = await serpQuery('test nonempty query two', { scrapingBeeKey: 'test-sb-key', log: quiet });
+  check('returns the SD result', r2?.length === 1 && r2[0].url === 'https://example.com/review', JSON.stringify(r2));
+  check('only Scrapingdog was called', calls.join(',') === 'sd', `calls: ${calls.join(',')}`);
+
+  console.log('3. SD_EMPTY_CASCADE=1 escape hatch restores old cascade');
+  process.env.SD_EMPTY_CASCADE = '1';
+  calls.length = 0; sdOrganic = []; sbOrganic = [{ url: 'https://example.com/sb-hit', title: 'SB Hit' }];
+  const r3 = await serpQuery('test cascade query three', { scrapingBeeKey: 'test-sb-key', log: quiet, preferSpeed: true });
+  check('cascades to ScrapingBee', calls.includes('sb'), `calls: ${calls.join(',')}`);
+  check('returns the SB result', r3?.length === 1 && r3[0].url === 'https://example.com/sb-hit', JSON.stringify(r3));
+  delete process.env.SD_EMPTY_CASCADE;
+
+  console.log('4. SB SERP success emits [SB Call] telemetry (25 credits)');
+  // preferSpeed + SD error (axios throws) → falls through to SB primary
+  const origGet = fakeAxios.get;
+  fakeAxios.get = async (apiUrl) => {
+    if (apiUrl.includes('scrapingdog.com/google')) { calls.push('sd'); throw Object.assign(new Error('boom'), { response: { status: 500 } }); }
+    return origGet(apiUrl);
+  };
+  const lines = [];
+  const origLog = console.log;
+  console.log = (...a) => { lines.push(a.join(' ')); };
+  calls.length = 0; sbOrganic = [{ url: 'https://example.com/sb2', title: 't' }];
+  await serpQuery('test telemetry query four', { scrapingBeeKey: 'test-sb-key', log: quiet, preferSpeed: true });
+  console.log = origLog;
+  fakeAxios.get = origGet;
+  const sbCallLine = lines.find(l => l.startsWith('[SB Call] '));
+  check('[SB Call] line emitted', !!sbCallLine, `lines: ${lines.slice(0, 3).join(' | ')}`);
+  if (sbCallLine) {
+    const rec = JSON.parse(sbCallLine.slice('[SB Call] '.length));
+    check('credits=25, fn=serp, success=true', rec.credits === 25 && rec.fn === 'serp' && rec.success === true, sbCallLine);
+  }
+
+  console.log(failures === 0 ? '\nAll tests passed.' : `\n${failures} test(s) FAILED.`);
+  process.exit(failures === 0 ? 0 : 1);
+})();


### PR DESCRIPTION
## Problem

ScrapingBee burned **162,130 credits in 49 hours** (July 9–12, ~79k/day) — 46% of the 1M monthly plan gone in the first 7 days of the cycle — while every log-based audit read "zero SB usage." Root cause per the 2026-07-05 postmortem (`cloud-memory/feedback_sb_serp_invisible_burn.md`): most SB call paths emit no telemetry, and `_serpViaScrapingBee` logs nothing on success (25 credits/query). Of the postmortem's prescribed fix stack, only `preferSpeed: false` had been applied.

## Changes

**`scripts/lib/url-discovery.js`**
- Scrapingdog empty-but-successful SERP results are now authoritative — they no longer cascade to BD/SB. On the opening-night path empties are never cached, so each SD-empty was re-asked via SB (25 cr) every poll cycle (~2,800 invisible calls/day tracking the opening calendar). `SD_EMPTY_CASCADE=1` restores the old cascade as an escape hatch.
- `_serpViaScrapingBee` now emits `[SB Call]` telemetry (success = 25 cr, failures = 0 cr).

**`scripts/collect-review-texts.js`**
- New TIER 1.9: Scrapingdog before ScrapingBee (flag-gated on `SCRAPER_USE_SCRAPINGDOG=1`; the workflow already passes the key). Cookie-forwarding domains stay on SB, whose `Spb-Cookie` forwarding is proven for paywalled sites.
- `[SB Call]` telemetry on its private SB fetcher (standard/premium/stealth tiers).
- `main()` is now require-guarded and the tier helper is exported for tests.

**`scripts/scrape-show-score-audience.js`**
- Scrapingdog attempt before SB's 25 cr/page render+premium fetch. Acceptance is gated on extractable-payload markers (`aggregateRating` / score class) so an unrendered SPA shell falls through to SB instead of reading as "show has no score."
- `[SB Call]` telemetry on the SB path.

**`scripts/lib/site-search-discovery.js`** — `[SB Call]` telemetry on its render fetches.

## Testing

- `scripts/test-sd-serp-short-circuit.js` — 8/8 assertions against the real `serpQuery`/`_serpWithChain` (stubbed axios): SD-empty short-circuits with no SB/BD calls, non-empty passthrough, escape hatch restores cascade, SB success emits `[SB Call]` with credits=25.
- `scripts/test-collect-scrapingdog-tier.js` — 4/4 against the real tier helper: accepts article HTML, throws (falls through to SB) on null/challenge-page/thin content.
- Live run of `scrape-show-score-audience.js --show=hamilton-2015 --dry-run` with the SD flag on: SD tier fires first with telemetry, invalid key degrades gracefully down the chain, existing guard blocks the bad write.
- `node --check` clean on all four modified scripts; no `src/` or config changes (tsc/next-lint unaffected; worktree TS2307s are missing gitignored data files, pre-existing).

## Expected impact

Opening-night SB burn (~50k credits/show per the tuned budget model) should drop to near zero from the SERP path; collect + audience sweeps shift their page fetches to Scrapingdog credits at ~1/4 the per-credit price. All remaining SB spend becomes visible as `[SB Call]` lines for `measure-scraper-usage.js` / the cost report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeKUxCbpS93XMcwZEeRGqa

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeKUxCbpS93XMcwZEeRGqa)_