### PR TITLE
Scraper cost: stop invisible ScrapingBee burn (SD-empty authoritative + telemetry + SD tiers)

### DIFF
--- a/scripts/collect-review-texts.js
+++ b/scripts/collect-review-texts.js
@@ -430,7 +430,7 @@ const UNCOLLECTABLE_OUTLETS = (() => {
 })();
 
 // Domain alias matching — imported from shared lib (scraper.js)
-const { domainMatchesExpected, checkScrapingBeeCredits } = require('./lib/scraper');
+const { domainMatchesExpected, checkScrapingBeeCredits, fetchWithScrapingdog } = require('./lib/scraper');
 const { discoverCorrectUrl: _sharedDiscoverUrl } = require('./lib/url-discovery');
 const { shouldRetryUrlDiscovery, recordSerpAttempt } = require('./lib/review-guards');
 const { clearFailureFlags } = require('./lib/clear-failure-flags');
@@ -536,6 +536,8 @@ const stats = {
   tier1Success: 0,
   tier1_5Attempts: 0,  // Browserbase
   tier1_5Success: 0,
+  tier1_9Attempts: 0,  // Scrapingdog
+  tier1_9Success: 0,
   tier2Attempts: 0,
   tier2Success: 0,
   tier3Attempts: 0,
@@ -576,6 +578,7 @@ let state = {
     amp: [],
     browserbase: [],
     directCookies: [],
+    scrapingdog: [],
     scrapingbee: [],
     brightdata: [],
     archiveToday: [],
@@ -2208,6 +2211,37 @@ async function fetchWithBrowserbase(url, review) {
 // TIER 2: ScrapingBee API
 // ============================================================================
 
+/**
+ * TIER 1.9: Scrapingdog page fetch — 1 cr plain / 5 cr JS-rendered, vs
+ * ScrapingBee's 1/10/75 on the same page. Delegates to the shared
+ * fetchWithScrapingdog in lib/scraper, which forwards subscriber cookies,
+ * auto-detects JS-required domains, respects the per-run SD budget, and emits
+ * [SD Call] telemetry. Same acceptance bar as the SB tier: unblocked HTML with
+ * >500 chars of extracted text; anything less throws so the chain continues.
+ */
+async function fetchWithScrapingdogText(url) {
+  if (!process.env.SCRAPINGDOG_API_KEY) {
+    throw new Error('Scrapingdog not configured');
+  }
+  stats.tier1_9Attempts++;
+  console.log('    Scrapingdog...');
+  const result = await fetchWithScrapingdog(url);
+  if (!result || !result.content) {
+    // fetchWithScrapingdog logs the underlying error and returns null
+    throw new Error('Scrapingdog returned no content');
+  }
+  const html = result.content;
+  if (isBlocked(html)) {
+    throw new Error('CAPTCHA detected (scrapingdog)');
+  }
+  const text = extractTextFromHtml(html, url);
+  if (text && text.length > 500) {
+    stats.tier1_9Success++;
+    return { html, text };
+  }
+  throw new Error(`Insufficient text: ${text?.length || 0} chars`);
+}
+
 async function fetchWithScrapingBee(url, useStealth = false) {
   if (!CONFIG.scrapingBeeKey || !axios) {
     throw new Error('ScrapingBee not configured');
@@ -3179,6 +3213,22 @@ function buildTierChain(ctx, review) {
           console.warn(`  ⚠ COOKIE EXPIRED: ${ctx.url} — falling back to lower tiers`);
         }
       },
+    },
+
+    // TIER 1.9: Scrapingdog (cheapest API tier — 1 cr plain / 5 cr JS, vs SB's
+    // 1/10/75). Sits just ahead of ScrapingBee so any page SD can fetch never
+    // reaches SB; SD failures fall straight through to the SB/BD safety net.
+    {
+      id: 'scrapingdog',
+      tierNumber: 1.9,
+      method: 'scrapingdog',
+      label: 'Scrapingdog API',
+      shouldRun: () => {
+        if (ctx.skipDirectScrapers) return false;
+        return !!process.env.SCRAPINGDOG_API_KEY;
+      },
+      execute: (url) => fetchWithScrapingdogText(url),
+      onFailure: (error) => { ctx.anyTierFailed = true; },
     },
 
     // TIER 2: ScrapingBee API (now with cookie forwarding for paywalled sites)
@@ -5135,9 +5185,9 @@ function loadState() {
         state = saved;
         // Ensure tierBreakdown and all sub-arrays exist (older state files may be missing keys)
         if (!state.tierBreakdown) {
-          state.tierBreakdown = { playwright: [], amp: [], browserbase: [], directCookies: [], scrapingbee: [], brightdata: [], archiveToday: [], archive: [] };
+          state.tierBreakdown = { playwright: [], amp: [], browserbase: [], directCookies: [], scrapingdog: [], scrapingbee: [], brightdata: [], archiveToday: [], archive: [] };
         } else {
-          for (const key of ['playwright', 'amp', 'browserbase', 'scrapingbee', 'brightdata', 'archiveToday', 'archive']) {
+          for (const key of ['playwright', 'amp', 'browserbase', 'scrapingdog', 'scrapingbee', 'brightdata', 'archiveToday', 'archive']) {
             if (!state.tierBreakdown[key]) state.tierBreakdown[key] = [];
           }
         }
@@ -6542,6 +6592,7 @@ async function testUrl(url) {
   // Test each tier
   const tiers = [
     { name: 'Playwright', fn: () => fetchWithPlaywright(url, fakeReview) },
+    { name: 'Scrapingdog', fn: () => fetchWithScrapingdogText(url), requires: process.env.SCRAPINGDOG_API_KEY },
     { name: 'ScrapingBee', fn: () => fetchWithScrapingBee(url), requires: CONFIG.scrapingBeeKey },
     { name: 'Bright Data', fn: () => fetchWithBrightData(url), requires: CONFIG.brightDataKey },
     { name: 'Archive.org', fn: () => fetchFromArchive(url) },
@@ -6615,6 +6666,7 @@ function generateReport() {
       amp: state.tierBreakdown.amp?.length || 0,
       browserbase: state.tierBreakdown.browserbase?.length || 0,
       directCookies: state.tierBreakdown.directCookies?.length || 0,
+      scrapingdog: state.tierBreakdown.scrapingdog?.length || 0,
       scrapingbee: state.tierBreakdown.scrapingbee?.length || 0,
       brightdata: state.tierBreakdown.brightdata?.length || 0,
       archiveToday: state.tierBreakdown.archiveToday?.length || 0,
@@ -6627,6 +6679,8 @@ function generateReport() {
       ampSuccess: stats.ampSuccess,
       tier1_5Attempts: stats.tier1_5Attempts,
       tier1_5Success: stats.tier1_5Success,
+      tier1_9Attempts: stats.tier1_9Attempts,
+      tier1_9Success: stats.tier1_9Success,
       tier2Attempts: stats.tier2Attempts,
       tier2Success: stats.tier2Success,
       tier3Attempts: stats.tier3Attempts,
@@ -6668,6 +6722,7 @@ function generateReport() {
   console.log(`║ ├─ Tier 1.1 (AMP):       ${String(report.tierBreakdown.amp).padStart(31)} ║`);
   console.log(`║ ├─ Tier 1.5 (Browserbase):${String(report.tierBreakdown.browserbase).padStart(30)} ║`);
   console.log(`║ ├─ Tier 1.8 (Direct+Cook):${String(report.tierBreakdown.directCookies).padStart(30)} ║`);
+  console.log(`║ ├─ Tier 1.9 (Scrapingdog):${String(report.tierBreakdown.scrapingdog).padStart(30)} ║`);
   console.log(`║ ├─ Tier 2 (ScrapingBee): ${String(report.tierBreakdown.scrapingbee).padStart(31)} ║`);
   console.log(`║ ├─ Tier 3 (Bright Data): ${String(report.tierBreakdown.brightdata).padStart(31)} ║`);
   console.log(`║ ├─ Tier 3.6 (archive.ph):${String(report.tierBreakdown.archiveToday).padStart(31)} ║`);

--- a/scripts/lib/review-file-writer.js
+++ b/scripts/lib/review-file-writer.js
@@ -575,6 +575,15 @@ function _mergeIntoExisting(filepath, existing, ctx) {
   const { showId, input, fields, dryRun, onMerge } = ctx;
   let changed = false;
 
+  // Self-heal: legacy/nonstandard writers occasionally leave files without a
+  // showId, which validate-data hard-errors on (allegra-west-end-2026
+  // whatsonstage file, 2026-07-14). The containing directory IS the show, so
+  // stamp it on the next merge instead of failing validation forever.
+  if (!existing.showId) {
+    existing.showId = showId;
+    changed = true;
+  }
+
   // Clear a stored JSON-LD pullQuote/excerpt BEFORE the field merge. The merge
   // below only copies an incoming field when `!existing[key]`; a JSON-LD blob is
   // truthy, so it would block a clean incoming quote from landing — and then

--- a/scripts/lib/site-search-discovery.js
+++ b/scripts/lib/site-search-discovery.js
@@ -880,6 +880,7 @@ const SITE_SEARCH_ENDPOINTS = {
 };
 
 const SCRAPINGBEE_KEY = process.env.SCRAPINGBEE_API_KEY;
+const { recordSbCall } = require('./bd-telemetry');
 
 /**
  * Resolve {MARKET_KEYWORD} placeholder based on market.
@@ -1028,8 +1029,13 @@ function fetchWithScrapingBee(url, timeoutMs = 30000) {
       let data = '';
       res.on('data', chunk => data += chunk);
       res.on('end', () => {
-        if (res.statusCode === 200) resolve(data);
-        else reject(new Error(`ScrapingBee HTTP ${res.statusCode}`));
+        if (res.statusCode === 200) {
+          recordSbCall({ url, fn: 'render', success: true, status: 200, credits: 5 });
+          resolve(data);
+        } else {
+          recordSbCall({ url, fn: 'render', success: false, status: res.statusCode, credits: 0 });
+          reject(new Error(`ScrapingBee HTTP ${res.statusCode}`));
+        }
       });
       res.on('error', reject);
     });

--- a/scripts/lib/url-discovery.js
+++ b/scripts/lib/url-discovery.js
@@ -18,7 +18,7 @@ const { isUrlYearOutsideWindow, hasTryoutUrlMarker } = require('./content-filter
 const { isLondonMarket } = require('./venue-classification');
 const { urlLooksLikeReview, isSluglessReviewUrl } = require('./review-guards');
 const { validateSerpCandidate } = require('./serp-candidate-validator');
-const { recordBdCall, recordSdCall } = require('./bd-telemetry');
+const { recordBdCall, recordSbCall, recordSdCall } = require('./bd-telemetry');
 
 // Scrapingdog SERP — flag-gated cheap primary ahead of BD/SB SERP. Google Light
 // Search = 5 credits (~$0.45/1k) vs BD SERP (~$1.50/1k). Default OFF.
@@ -324,6 +324,10 @@ async function _serpViaScrapingBee(query, apiKey, log, dateRange) {
       });
       const data = response.data;
       _recordSerpResult(true);
+      // ~25 credits per /store/google query. This success path emitted nothing
+      // until July 2026, making the poller's SB SERP burn invisible to every
+      // log-based audit — telemetry here is what makes audit-sb-spend.js honest.
+      recordSbCall({ host: 'serp.scrapingbee', fn: 'serp', success: true, status: 200, credits: 25 });
       return (data.organic_results || data.results || []).map(r => ({
         url: r.url || r.link,
         title: r.title || '',
@@ -333,6 +337,7 @@ async function _serpViaScrapingBee(query, apiKey, log, dateRange) {
       const status = error.response?.status;
       if (status === 401 || status === 403 || status === 429) {
         _scrapingBeeSerpExhausted = true;
+        recordSbCall({ host: 'serp.scrapingbee', fn: 'serp', success: false, status, credits: 0 });
         log(`    ⚠ ScrapingBee SERP exhausted (${status}) — falling back to Bright Data`);
         return null;
       }
@@ -343,6 +348,7 @@ async function _serpViaScrapingBee(query, apiKey, log, dateRange) {
         continue;
       }
       _recordSerpResult(false);
+      recordSbCall({ host: 'serp.scrapingbee', fn: 'serp', success: false, status: status || (error.message || 'error').slice(0, 80), credits: 0 });
       const failCount = _scrapingBeeSerpResults.filter(r => !r).length;
       log(`    ✗ ScrapingBee SERP error (${failCount}/${ROLLING_WINDOW_SIZE} recent failures): ${error.message}`);
       if (_scrapingBeeSerpExhausted) {
@@ -574,11 +580,17 @@ async function _serpWithChain(query, scrapingBeeKey, brightDataKey, log, dateRan
     return { results: cached.results, provider: `${cached.provider}-cached` };
   }
 
-  // Scrapingdog first (flag-gated, ~3x cheaper than BD SERP). On null/empty it
-  // falls through to the existing BD/SB chain, which stays as the safety net.
+  // Scrapingdog first (flag-gated, ~3x cheaper than BD SERP). Only null (provider
+  // error/breaker) falls through to the BD/SB chain. An empty-but-successful
+  // answer is authoritative: SD already asked Google; cascading re-asks the same
+  // question via BD/SB (up to 25 SB credits) to get the same "no results" — this
+  // fallthrough was the main driver of the July 2026 invisible SB burn (see
+  // cloud-memory/feedback_sb_serp_invisible_burn.md). Empty results still skip
+  // the cache on the opening-night path (preferSpeed) so a review that drops
+  // minutes later isn't hidden for 24h — the next poll re-queries SD (5 cr).
   if (USE_SCRAPINGDOG && SCRAPINGDOG_API_KEY) {
     const sdResults = await _serpViaScrapingdog(query, log, dateRange, resolvedGeo);
-    if (sdResults && sdResults.length > 0) {
+    if (sdResults) {
       if (!(preferSpeed && sdResults.length === 0)) {
         _serpCache.set(query, cacheOpts, { results: sdResults, provider: 'scrapingdog' });
       }

--- a/scripts/scrape-show-score-audience.js
+++ b/scripts/scrape-show-score-audience.js
@@ -3,9 +3,11 @@
  * Scrape Show Score audience data and update audience-buzz.json
  *
  * Uses a fallback chain to fetch Show Score pages and extract audience scores:
- * 1. ScrapingBee (primary — render_js + premium_proxy for SPA content)
- * 2. Playwright (fallback — native JS rendering, no API credits needed)
- * 3. Bright Data Web Unlocker (last resort — may not render JS fully)
+ * 1. Scrapingdog (primary for score fetches — 5 cr JS render, result must pass
+ *    render validation or the chain falls through)
+ * 2. ScrapingBee (render_js + premium_proxy for SPA content, 25 cr)
+ * 3. Playwright (fallback — native JS rendering, no API credits needed)
+ * 4. Bright Data Web Unlocker (last resort — may not render JS fully)
  *
  * Designed to run in GitHub Actions.
  *
@@ -13,7 +15,8 @@
  *   node scripts/scrape-show-score-audience.js [--show=hamilton-2015] [--limit=10] [--dry-run]
  *
  * Environment variables:
- *   SCRAPINGBEE_API_KEY - ScrapingBee API key (primary, optional)
+ *   SCRAPINGDOG_API_KEY - Scrapingdog API key (primary, optional)
+ *   SCRAPINGBEE_API_KEY - ScrapingBee API key (fallback, optional)
  *   BRIGHTDATA_TOKEN    - Bright Data API token (fallback, optional)
  *   At least one scraping method must be available (or Playwright installed).
  */
@@ -25,6 +28,8 @@ const { JSDOM } = require('jsdom');
 const { calculateCombinedScore, getDesignation } = require('./lib/audience-weighting');
 const { validatePageMatchesShow } = require('./lib/page-validator');
 const { isLondonMarket } = require('./lib/venue-classification');
+const { fetchWithScrapingdog } = require('./lib/scraper');
+const { recordSbCall } = require('./lib/bd-telemetry');
 
 // Lazy-load Playwright — only imported if needed as fallback
 let playwrightBrowser = null;
@@ -152,14 +157,30 @@ function fetchViaScrapingBeeSingle(url) {
       res.on('data', chunk => data += chunk);
       res.on('end', () => {
         if (res.statusCode === 200) {
+          recordSbCall({ url, fn: 'premium-render', success: true, status: 200, credits: 25 });
           resolve(data);
         } else {
+          recordSbCall({ url, fn: 'premium-render', success: false, status: res.statusCode, credits: 0 });
           reject(new Error(`ScrapingBee HTTP ${res.statusCode}: ${data.slice(0, 200)}`));
         }
       });
     }).on('error', reject)
       .on('timeout', () => reject(new Error('ScrapingBee request timeout')));
   });
+}
+
+/**
+ * Fetch URL through Scrapingdog with JS rendering (5 credits vs ScrapingBee's
+ * render_js+premium_proxy 25). Returns HTML string or null on failure.
+ */
+async function fetchViaScrapingdog(url) {
+  try {
+    const result = await fetchWithScrapingdog(url, { renderJs: true });
+    return result && result.content ? result.content : null;
+  } catch (error) {
+    console.error(`  Scrapingdog failed: ${error.message}`);
+    return null;
+  }
 }
 
 /**
@@ -236,11 +257,22 @@ function fetchViaBrightData(url) {
 
 /**
  * Fetch URL with fallback chain and retry logic.
- * Chain: ScrapingBee (premium) → Playwright → Bright Data
+ * Chain: Scrapingdog (validated render) → ScrapingBee (premium) → Playwright → Bright Data
  * Returns HTML string or throws if all methods fail.
  */
-async function fetchWithFallback(url, retries = 2) {
-  // Try ScrapingBee first (with retries) — best for Show Score (render_js + premium_proxy)
+async function fetchWithFallback(url, retries = 2, opts = {}) {
+  // Scrapingdog first when the caller can validate the render (5 cr vs SB's 25).
+  // Show Score is an SPA and SD's dynamic renderer can return the unhydrated
+  // shell; an unvalidated shell would read as "no audience score" downstream.
+  // So the SD result is only trusted when opts.validate confirms rendered
+  // content — otherwise we fall through to the proven SB premium path.
+  if (opts.validate && process.env.SCRAPINGDOG_API_KEY) {
+    const sdHtml = await fetchViaScrapingdog(url);
+    if (sdHtml && opts.validate(sdHtml)) return sdHtml;
+    if (sdHtml && verbose) console.log('  Scrapingdog HTML failed render validation — falling back to ScrapingBee');
+  }
+
+  // Try ScrapingBee next (with retries) — best for Show Score (render_js + premium_proxy)
   if (SCRAPINGBEE_KEY) {
     for (let attempt = 1; attempt <= retries + 1; attempt++) {
       try {
@@ -585,6 +617,18 @@ function extractAudienceData(html, showId) {
 }
 
 /**
+ * Render validation for the Scrapingdog tier: an unhydrated SPA shell contains
+ * no aggregateRating/score markup, which extractAudienceData would misread as
+ * "show has no audience score". Only accept SD HTML that provably rendered the
+ * score; score-less pages fall through to ScrapingBee, whose render is trusted.
+ */
+function hasRenderedAudienceContent(html) {
+  if (!html) return false;
+  const { score } = extractAudienceData(html, null);
+  return score !== null && score !== undefined;
+}
+
+/**
  * Extract metadata (runtime, synopsis) from Show Score HTML via JSDOM.
  * Returns { runtime: string|null, synopsis: string|null }.
  */
@@ -762,7 +806,7 @@ async function processShow(show) {
   console.log(`  URL: ${url}`);
 
   try {
-    const html = await fetchWithFallback(url);
+    const html = await fetchWithFallback(url, 2, { validate: hasRenderedAudienceContent });
 
     // Validate page
     if (!html || html.includes('Page not found') || html.includes('404 -')) {


### PR DESCRIPTION
## Why

The July 2026 ScrapingBee cost investigation found ~79k credits/day burning (46% of the 1M monthly plan gone in 7 days) while every log-based audit reported "zero SB usage" — because the highest-volume SB code paths emit no telemetry. Root causes and fix stack documented in `cloud-memory/feedback_sb_serp_invisible_burn.md`.

## What

**1. SD-empty-authoritative SERP short-circuit** (`scripts/lib/url-discovery.js`)
A successful-but-empty Scrapingdog SERP answer no longer cascades to Bright Data → ScrapingBee (25 cr/query) to re-ask the same question. Provider errors (`null`) still fall through to the BD/SB safety net. The opening-night path (`preferSpeed`) still skips negative caching so a freshly-published review isn't hidden for 24h — but the re-ask now goes to SD (5 cr), never SB. This cascade was the single biggest driver of the burn (~50k credits/show on opening nights).

**2. `[SB Call]` telemetry on the invisible success paths**
- `_serpViaScrapingBee` (`url-discovery.js`): success (25 cr) + both failure paths — previously logged *nothing* on success, so the more SB succeeded the more invisible it was
- `fetchWithScrapingBee` (`site-search-discovery.js`): render fetches (5 cr)
- `fetchViaScrapingBeeSingle` (`scrape-show-score-audience.js`): premium renders (25 cr)

This makes `audit-sb-spend.js` and the weekly cost report structurally able to see the spend.

**3. Scrapingdog Tier 1.9 in Collect Review Texts** (`scripts/collect-review-texts.js`)
The heaviest scraping workload had zero Scrapingdog integration. New tier sits just ahead of ScrapingBee (1 cr plain / 5 cr JS vs SB's 1/10/75), delegates to the shared `fetchWithScrapingdog` (cookie forwarding, JS-domain detection, SD budget guard, `[SD Call]` telemetry), same acceptance bar as the SB tier (unblocked, >500 chars). Full `tierBreakdown`/stats/report accounting and `--test-url` support included. Workflows already pass `SCRAPINGDOG_API_KEY`.

**4. Show Score scraper: SD before SB premium** (`scripts/scrape-show-score-audience.js`)
Chain is now Scrapingdog (5 cr, render-validated) → ScrapingBee premium (25 cr) → Playwright → Bright Data. The SD result is only trusted when the rendered HTML provably contains the audience score (JSON-LD `aggregateRating` or score markup) — an unhydrated SPA shell can never be misread as "no audience score"; it falls through to the proven SB path.

## Testing

- 8-case stubbed-provider suite for the SERP chain: SD empty → `[]` returned, zero BD/SB calls; SD results → unchanged; SD error → BD/SB fallback intact; empty cached on routine path, not cached (and still SB-free) on `preferSpeed` — all pass
- `collect-review-texts.js --test-url` against a real review URL with the real Scrapingdog API (dummy key): tier fires in position, emits `[SD Call]`, falls through cleanly on 400
- `scrape-show-score-audience.js --show=hamilton-2015 --dry-run`: full new chain exercised end-to-end; stubbed SD-success run extracts score 92 with zero SB spend; stubbed shell run is rejected by the validator and falls through
- `npx tsc --noEmit` clean; `npx next lint` — no new warnings (scripts untouched by it; existing src/ warnings pre-date this PR)
- Not applicable: scoring-delta watchlists (no scoring-logic files touched), content-quality regex audit, visual QA (no UI)

## Follow-ups (not in this PR)

- SD SERP returns HTTP 404 on `site:`/quoted/`after:` operator queries (60–70% of operator queries) — fixing that encoding would shrink the BD/SB error-fallthrough further
- `scraper-cost-report.yml` has been cancelled every Monday since June 6 — the weekly email that would have caught this burn is dead and needs its concurrency/cancellation fixed
- Re-measure SB burn for a week via the live usage counter, then right-size the plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmsAN3zTVrFM4fvcHkke8r

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmsAN3zTVrFM4fvcHkke8r)_