### PR TITLE
Extract shared usePendingRatingDraft hook

### DIFF
--- a/src/app/diary-show/[id]/DiaryShowClient.tsx
+++ b/src/app/diary-show/[id]/DiaryShowClient.tsx
@@ -7,12 +7,12 @@ import dynamic from 'next/dynamic';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUserReviews } from '@/hooks/useUserReviews';
 import { supabaseRestInsert, supabaseRestUpdate } from '@/lib/supabase-rest';
-import { savePendingAction, getPendingAction, clearPendingAction } from '@/lib/deferred-auth';
+import { usePendingRatingDraft } from '@/hooks/usePendingRatingDraft';
 import { useToastSafe } from '@/components/ui/Toast';
 import RatingEditor, { type RatingEditorSaveData } from '@/components/user/RatingEditor';
 import StarRating from '@/components/user/StarRating';
 import ShowImage from '@/components/ShowImage';
-import type { UserReview, PendingAction } from '@/types/user';
+import type { UserReview } from '@/types/user';
 import { marketLabel, type DiaryShowDetail } from '@/lib/diary-show-types';
 
 const ShowPageWatchlistButton = dynamic(() => import('@/components/user/ShowPageWatchlistButton'), { ssr: false });
@@ -33,16 +33,11 @@ function Inner({ show }: { show: DiaryShowDetail }) {
   const searchParams = useSearchParams();
   const [ratePanelOpen, setRatePanelOpen] = useState(false);
   const [editingReview, setEditingReview] = useState<UserReview | null>(null);
-  // Draft carried across sign-in (rating + typed note + date + target review
-  // id) — without this, a signed-out user's typed rating/notes vanish the
-  // moment they complete sign-in (ship-check finding, 2026-07-14).
-  const [pendingDraft, setPendingDraft] = useState<PendingAction | null>(null);
   // Distinct from useUserReviews' `loading` (which only flips true once the
   // fetch has actually started) — this tracks "has the initial sync settled
   // at least once" so ?edit=1 doesn't race into "new rating" mode against an
   // empty `reviews` array on the very first render.
   const [reviewsSynced, setReviewsSynced] = useState(false);
-  const hasExecutedPending = useRef(false);
   const hasHandledQueryParam = useRef(false);
 
   useEffect(() => {
@@ -52,19 +47,17 @@ function Inner({ show }: { show: DiaryShowDetail }) {
 
   const latestReview = reviews[0] || null;
 
-  // Consume a rating pending from a deferred sign-in (mirrors ShowHeroRedesign).
-  useEffect(() => {
-    if (!isAuthenticated || !user || hasExecutedPending.current) return;
-    const pending = getPendingAction();
-    if (!pending || pending.showId !== show.id) return;
-    hasExecutedPending.current = true;
-    clearPendingAction();
-    if (pending.type === 'rating') {
+  // Draft carried across sign-in (rating + typed note + date + target review
+  // id) — without this, a signed-out user's typed rating/notes vanish the
+  // moment they complete sign-in (ship-check finding, 2026-07-14).
+  const { pendingDraft, setPendingDraft, hasExecutedPending, saveDraft } = usePendingRatingDraft(show.id, {
+    isAuthenticated,
+    user,
+    onResumeRatingDraft: () => {
       setEditingReview(null);
-      setPendingDraft(pending);
       setRatePanelOpen(true);
-    }
-  }, [isAuthenticated, user, show.id]);
+    },
+  });
 
   // ?rate=1 / ?edit=1 — deep-link targets from My Shows card CTAs. ?edit=1
   // waits for the user's reviews to finish loading so it doesn't race into
@@ -76,12 +69,7 @@ function Inner({ show }: { show: DiaryShowDetail }) {
     if (!wantsRate && !wantsEdit) return;
     if (!isAuthenticated) {
       hasHandledQueryParam.current = true;
-      savePendingAction({
-        type: 'rating',
-        showId: show.id,
-        returnUrl: window.location.pathname,
-        timestamp: Date.now(),
-      });
+      saveDraft({});
       showSignIn('rating');
       return;
     }
@@ -90,23 +78,14 @@ function Inner({ show }: { show: DiaryShowDetail }) {
     setEditingReview(wantsEdit ? latestReview : null);
     setPendingDraft(null);
     setRatePanelOpen(true);
-  }, [searchParams, authLoading, isAuthenticated, reviewsSynced, show.id, latestReview, showSignIn]);
+  }, [searchParams, authLoading, isAuthenticated, reviewsSynced, show.id, latestReview, showSignIn, saveDraft, hasExecutedPending, setPendingDraft]);
 
   const handleSaveReview = useCallback(async (data: RatingEditorSaveData) => {
     if (!user) {
       if (authLoading) {
         throw new Error('Still restoring your session — tap Retry in a moment.');
       }
-      savePendingAction({
-        type: 'rating',
-        showId: show.id,
-        rating: data.rating,
-        ...(data.reviewText ? { reviewText: data.reviewText } : {}),
-        ...(data.dateSeen ? { dateSeen: data.dateSeen } : {}),
-        ...(data.reviewId ? { reviewId: data.reviewId } : {}),
-        returnUrl: window.location.pathname,
-        timestamp: Date.now(),
-      });
+      saveDraft(data);
       showSignIn('rating');
       return 'auth-gated';
     }
@@ -133,7 +112,7 @@ function Inner({ show }: { show: DiaryShowDetail }) {
       showToast?.(<>Added to <a href="/my-shows" className="underline hover:text-white/90">My Ratings &amp; Reviews</a></>, 'success');
     }
     await getReviewsForShow(show.id);
-  }, [user, authLoading, show.id, getReviewsForShow, showSignIn, showToast]);
+  }, [user, authLoading, show.id, getReviewsForShow, showSignIn, showToast, saveDraft]);
 
   const handleRateClick = () => {
     setEditingReview(null);

--- a/src/components/show-page/ShowHeroRedesign.tsx
+++ b/src/components/show-page/ShowHeroRedesign.tsx
@@ -51,7 +51,8 @@ import { useUserReviews } from '@/hooks/useUserReviews';
 import { useWatchlist } from '@/hooks/useWatchlist';
 import { useUserLists } from '@/hooks/useUserLists';
 import { useToastSafe } from '@/components/ui/Toast';
-import { savePendingAction, getPendingAction, clearPendingAction } from '@/lib/deferred-auth';
+import { savePendingAction } from '@/lib/deferred-auth';
+import { usePendingRatingDraft } from '@/hooks/usePendingRatingDraft';
 import { invalidateRatingsCache } from '@/hooks/useMyRating';
 import { supabaseRestInsert, supabaseRestUpdate } from '@/lib/supabase-rest';
 import { featureFlags } from '@/config/feature-flags';
@@ -123,9 +124,6 @@ function Inner({
 
   const [ratePanelOpen, setRatePanelOpen] = useState(false);
   const [editingReview, setEditingReview] = useState<UserReview | null>(null);
-  // Draft carried across sign-in (rating + typed note + date + target review id).
-  const [pendingDraft, setPendingDraft] = useState<PendingAction | null>(null);
-  const hasExecutedPending = useRef(false);
   const rateBtnRef = useRef<HTMLButtonElement>(null);
   // Return focus to the rate button when the editor closes — the inline
   // (desktop) editor is not a Modal, so nothing else restores focus and it
@@ -183,26 +181,23 @@ function Inner({
     }
   }, [isAuthenticated, user, show.id, getReviewsForShow, getWatchlist, getLists]);
 
-  // Consume pending action after deferred auth
-  useEffect(() => {
-    if (!isAuthenticated || !user || hasExecutedPending.current) return;
-    const pending = getPendingAction();
-    if (!pending || pending.showId !== show.id) return;
-    hasExecutedPending.current = true;
-    clearPendingAction();
-
-    if (pending.type === 'rating') {
-      // Resume the draft the user was mid-editing before we gated on sign-in.
+  // Draft carried across sign-in (rating + typed note + date + target review id).
+  const { pendingDraft, setPendingDraft, hasExecutedPending, saveDraft } = usePendingRatingDraft(show.id, {
+    isAuthenticated,
+    user,
+    // Resume the draft the user was mid-editing before we gated on sign-in.
+    onResumeRatingDraft: () => {
       setEditingReview(null);
-      setPendingDraft(pending);
       setRatePanelOpen(true);
-    } else if (pending.type === 'watchlist') {
-      addToWatchlist(show.id)
-        .then(() => showToast?.(<>Added to <a href="/my-shows?tab=watchlist" className="underline hover:text-white/90">Watchlist</a></>, 'success'))
-        .catch(() => showToast?.('Failed to add to watchlist.', 'error'));
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAuthenticated, user, show.id]);
+    },
+    onOtherPendingAction: (pending) => {
+      if (pending.type === 'watchlist') {
+        addToWatchlist(show.id)
+          .then(() => showToast?.(<>Added to <a href="/my-shows?tab=watchlist" className="underline hover:text-white/90">Watchlist</a></>, 'success'))
+          .catch(() => showToast?.('Failed to add to watchlist.', 'error'));
+      }
+    },
+  });
 
   // ?rate=1 — auto-open rate panel (deferred-auth target for inline-stars CTAs)
   useEffect(() => {
@@ -213,13 +208,7 @@ function Inner({
     // the just-restored draft (typed note included) with a bare stars hint.
     if (hasExecutedPending.current) return;
     if (!isAuthenticated && !authLoading) {
-      savePendingAction({
-        type: 'rating',
-        showId: show.id,
-        ...(autoRateStars != null ? { rating: autoRateStars } : {}),
-        returnUrl: window.location.pathname,
-        timestamp: Date.now(),
-      });
+      saveDraft(autoRateStars != null ? { rating: autoRateStars } : {});
       showSignIn('rating');
     } else {
       // Always a FRESH panel (append), seeded with the ?stars= hint — consistent
@@ -279,7 +268,7 @@ function Inner({
     setEditingReview(null);
     setPendingDraft(null);
     setRatePanelOpen(true);
-  }, []);
+  }, [setPendingDraft]);
 
 
   // NOTE: RatingEditor owns the saving spinner and, critically, keeps the panel
@@ -296,16 +285,7 @@ function Inner({
       // Gate at Save — persist the full draft, then sign in. The editor stays
       // open behind the sign-in modal ('auth-gated'), so cancelling sign-in
       // loses nothing; completing it lets the pending-action effect resume.
-      savePendingAction({
-        type: 'rating',
-        showId: show.id,
-        rating: data.rating,
-        ...(data.reviewText ? { reviewText: data.reviewText } : {}),
-        ...(data.dateSeen ? { dateSeen: data.dateSeen } : {}),
-        ...(data.reviewId ? { reviewId: data.reviewId } : {}),
-        returnUrl: window.location.pathname,
-        timestamp: Date.now(),
-      });
+      saveDraft(data);
       showSignIn('rating');
       return 'auth-gated';
     }
@@ -345,21 +325,21 @@ function Inner({
     }
     await getReviewsForShow(show.id);
     invalidateRatingsCache();
-  }, [user, authLoading, show.id, getReviewsForShow, showToast, showSignIn, isWatchlisted, removeFromWatchlist]);
+  }, [user, authLoading, show.id, getReviewsForShow, showToast, showSignIn, isWatchlisted, removeFromWatchlist, saveDraft]);
 
   const handleRateSaved = useCallback(() => {
     setRatePanelOpen(false);
     setEditingReview(null);
     setPendingDraft(null);
     refocusRateBtn();
-  }, []);
+  }, [setPendingDraft]);
 
   const handleCancelRate = useCallback(() => {
     setRatePanelOpen(false);
     setEditingReview(null);
     setPendingDraft(null);
     refocusRateBtn();
-  }, []);
+  }, [setPendingDraft]);
 
   const handleDeleteRating = useCallback(async () => {
     if (!editingReview) return;
@@ -376,7 +356,7 @@ function Inner({
       setEditingReview(null);
       setPendingDraft(null);
     }
-  }, [editingReview, deleteReview, getReviewsForShow, show.id, showToast]);
+  }, [editingReview, deleteReview, getReviewsForShow, show.id, showToast, setPendingDraft]);
 
   // ─── Render ────────────────────────────────────────────────────────────
 

--- a/src/hooks/usePendingRatingDraft.ts
+++ b/src/hooks/usePendingRatingDraft.ts
@@ -1,0 +1,67 @@
+'use client';
+
+/**
+ * Deferred-auth rating draft: a signed-out user types a rating/note, we save
+ * it to localStorage and gate on sign-in, then resume it once they land back
+ * on the page authenticated. Shared by ShowHeroRedesign and DiaryShowClient
+ * so the resume flow (and the "forgot to include data.rating" class of bug)
+ * only has one place to get wrong.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { savePendingAction, getPendingAction, clearPendingAction } from '@/lib/deferred-auth';
+import type { PendingAction } from '@/types/user';
+
+interface SaveDraftInput {
+  rating?: number;
+  reviewText?: string | null;
+  dateSeen?: string | null;
+  reviewId?: string;
+}
+
+interface UsePendingRatingDraftOptions {
+  isAuthenticated: boolean;
+  user: unknown;
+  /** Called synchronously (same effect pass) when a rating draft is resumed. */
+  onResumeRatingDraft: (pending: PendingAction) => void;
+  /** Called for any pending action of a different type (e.g. 'watchlist'). */
+  onOtherPendingAction?: (pending: PendingAction) => void;
+}
+
+export function usePendingRatingDraft(showId: string, options: UsePendingRatingDraftOptions) {
+  const { isAuthenticated, user, onResumeRatingDraft, onOtherPendingAction } = options;
+  const [pendingDraft, setPendingDraft] = useState<PendingAction | null>(null);
+  const hasExecutedPending = useRef(false);
+
+  // Consume pending action after deferred auth.
+  useEffect(() => {
+    if (!isAuthenticated || !user || hasExecutedPending.current) return;
+    const pending = getPendingAction();
+    if (!pending || pending.showId !== showId) return;
+    hasExecutedPending.current = true;
+    clearPendingAction();
+
+    if (pending.type === 'rating') {
+      setPendingDraft(pending);
+      onResumeRatingDraft(pending);
+    } else {
+      onOtherPendingAction?.(pending);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated, user, showId]);
+
+  const saveDraft = useCallback((data: SaveDraftInput) => {
+    savePendingAction({
+      type: 'rating',
+      showId,
+      ...(data.rating != null ? { rating: data.rating } : {}),
+      ...(data.reviewText ? { reviewText: data.reviewText } : {}),
+      ...(data.dateSeen ? { dateSeen: data.dateSeen } : {}),
+      ...(data.reviewId ? { reviewId: data.reviewId } : {}),
+      returnUrl: window.location.pathname,
+      timestamp: Date.now(),
+    });
+  }, [showId]);
+
+  return { pendingDraft, setPendingDraft, hasExecutedPending, saveDraft };
+}


### PR DESCRIPTION
## Summary
- Extracts the duplicated deferred-auth pending-rating-draft flow (pendingDraft state, hasExecutedPending ref, resume-on-auth effect, savePendingAction construction) from ShowHeroRedesign.tsx and DiaryShowClient.tsx into src/hooks/usePendingRatingDraft.ts
- Both call sites now use the shared hook; net LOC decreases in both files (-41 net across the two)
- Pure logic refactor — no JSX/markup changed

## Test plan
- [x] tsc/lint/build clean, zero new warnings
- [x] Verified in browser: rate-while-signed-out on /show/the-lost-boys writes correct bsc_pending_action to localStorage
- [x] Verified in browser: rate-while-signed-out on /diary-show/[id] writes correct bsc_pending_action to localStorage
- [x] /ship-check: Claude (sonnet) + Codex adversarial review, both SHIP verdict
- [x] Codex flagged a pre-existing latent race (add-to-list pending clobbered) — confirmed identical in pre-refactor code, carded separately for follow-up (not introduced by this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)