### PR TITLE
fix(lbo-scraper): budget-check both pagination and per-show loops (#415)

### DIFF
--- a/.github/workflows/update-lbo.yml
+++ b/.github/workflows/update-lbo.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: boolean
         default: false
+      time_budget_min:
+        description: 'Wall-clock budget in minutes (0 = unlimited)'
+        required: false
+        type: string
+        default: '22'
 
 concurrency:
   # Per-run concurrency prevents the orchestrator's back-to-back dispatches from
@@ -58,11 +63,18 @@ jobs:
             DRY_RUN_FLAG="--dry-run"
           fi
 
+          # Exit cleanly before the 30-min job timeout; deferred shows/pages are
+          # picked up next run. Default in bash, not a GHA || expression — the
+          # expression coerces a literal 0 (= unlimited) to falsy.
+          TB="${{ inputs.time_budget_min }}"
+          [ -z "$TB" ] && TB=22
+          TB_FLAG="--time-budget-min=$TB"
+
           if [ -n "${{ inputs.shows }}" ]; then
             IFS=',' read -ra SHOW_IDS <<< "${{ inputs.shows }}"
             for sid in "${SHOW_IDS[@]}"; do
               echo "Running LBO for: $sid"
-              node scripts/scrape-lbo-audience.js --show="$sid" $DRY_RUN_FLAG || true
+              node scripts/scrape-lbo-audience.js --show="$sid" $DRY_RUN_FLAG $TB_FLAG || true
             done
             exit 0
           fi
@@ -71,7 +83,7 @@ jobs:
           if [ -n "${{ inputs.show }}" ]; then
             ARGS="$ARGS --show=${{ inputs.show }}"
           fi
-          ARGS="$ARGS $DRY_RUN_FLAG"
+          ARGS="$ARGS $DRY_RUN_FLAG $TB_FLAG"
 
           # shellcheck disable=SC2086
           node scripts/scrape-lbo-audience.js $ARGS

--- a/scripts/scrape-lbo-audience.js
+++ b/scripts/scrape-lbo-audience.js
@@ -12,7 +12,11 @@
  * Fetch strategy: plain https.get first (free), BrightData fallback (cheap).
  *
  * Usage:
- *   node scripts/scrape-lbo-audience.js [--show=hamilton-west-end-2021] [--dry-run]
+ *   node scripts/scrape-lbo-audience.js [--show=hamilton-west-end-2021] [--dry-run] [--time-budget-min=N]
+ *
+ * --time-budget-min=N: wall-clock budget in minutes (0 or omitted = unlimited).
+ * Exits cleanly once exceeded instead of running into the job timeout; deferred
+ * Feefo pages / shows are picked up on the next run.
  *
  * Environment variables:
  *   BRIGHTDATA_TOKEN - BrightData API token (fallback, optional)

--- a/scripts/scrape-lbo-audience.js
+++ b/scripts/scrape-lbo-audience.js
@@ -26,6 +26,7 @@ const { calculateCombinedScore, getDesignation } = require('./lib/audience-weigh
 const { isLondonMarket } = require('./lib/venue-classification');
 const { buildLondonSlugVariants } = require('./lib/show-matching');
 const { batchDiscoverSlugs } = require('./lib/serp-slug-discovery');
+const { parseTimeBudgetMin, createRunBudget } = require('./lib/run-budget');
 
 const BRIGHTDATA_TOKEN = process.env.BRIGHTDATA_TOKEN;
 const BRIGHTDATA_ZONE = process.env.BRIGHTDATA_ZONE || 'web_unlocker2';
@@ -59,6 +60,7 @@ function fetchWithBrightData(url) {
 const args = process.argv.slice(2);
 const showFilter = args.find(a => a.startsWith('--show='))?.split('=')[1];
 const dryRun = args.includes('--dry-run');
+const timeBudget = createRunBudget(parseTimeBudgetMin(args));
 
 const RATE_LIMIT_MS = 2000;
 const CHECKPOINT_EVERY = 10;
@@ -232,6 +234,13 @@ async function fetchAllFeefoReviews() {
   console.log('📡 Fetching Feefo reviews...');
 
   while (page <= totalPages) {
+    // Feefo pagination can run to 16+ pages; without this check it can burn
+    // the whole run budget before the per-show loop's own check ever runs,
+    // pushing the script past the job's timeout-minutes (same class as #369).
+    if (timeBudget.exceeded()) {
+      console.log(`\n⏱ Time budget (${timeBudget.minutes} min) reached during Feefo pagination — ${page - 1} of ${totalPages} pages fetched. Next run restarts pagination from page 1.`);
+      break;
+    }
     try {
       const res = await httpsGet(`${FEEFO_BASE}&page=${page}`);
       const data = JSON.parse(res.body);
@@ -323,11 +332,23 @@ async function main() {
   // Fetch all Feefo reviews once (16 API calls, free)
   const feefoByProduct = dryRun ? {} : await fetchAllFeefoReviews();
 
-  const stats = { processed: 0, found: 0, notFound: 0, errors: 0, skipped: 0 };
+  const stats = { processed: 0, found: 0, notFound: 0, errors: 0, skipped: 0, unprocessedShows: 0, budgetExit: false };
   const missedShows = [];
   const anchorResults = {};
 
   for (let i = 0; i < toProcess.length; i++) {
+    // Per-show fetches can each burn up to MAX_RETRIES BrightData calls (30s
+    // timeout) across every URL variant when plain HTTP is blocked — without
+    // this check that can blow the job's timeout-minutes before the loop
+    // ever finishes (same class as #369; LBO's per-show loop had no budget
+    // check at all, unlike WET's which already existed pre-#369).
+    if (timeBudget.exceeded()) {
+      stats.unprocessedShows = toProcess.length - i;
+      stats.budgetExit = true;
+      console.log(`\n⏱ Time budget (${timeBudget.minutes} min) reached — ${stats.unprocessedShows} shows deferred to next run.`);
+      break;
+    }
+
     const show = toProcess[i];
     const title = show.title;
     stats.processed++;
@@ -515,8 +536,13 @@ async function main() {
   console.log(`  Not found: ${stats.notFound}`);
   console.log(`  Skipped:   ${stats.skipped} (title mismatch)`);
   console.log(`  Errors:    ${stats.errors}`);
+  if (stats.budgetExit) {
+    console.log(`  ⏱ Unprocessed (time budget): ${stats.unprocessedShows}`);
+  }
 
-  if (stats.found === 0 && toProcess.length > 3) {
+  // Skip when the budget exit fired early — that's a clean deferral, not a
+  // URL-pattern-change signal (same exemption as #369's pagination fix).
+  if (stats.found === 0 && toProcess.length > 3 && !stats.budgetExit) {
     console.error('\n❌ ZERO shows matched — possible URL pattern change. Aborting.');
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- scrape-lbo-audience.js had zero run-budget protection (same bug class as #369): both the Feefo pagination loop and the per-show scrape loop could burn the full 30-min job timeout with no clean exit (GitHub kills the job — `cancelled`, not green).
- Adds a budget check at the top of both loops, mirroring `scripts/scrape-westendtheatre-roundups.js`'s existing pattern (already fixed for #369).
- Exempts the zero-shows-matched guard from firing on a budget-triggered early exit.
- Wires `--time-budget-min` into `update-lbo.yml` (default 22, leaving ~8min headroom under `timeout-minutes: 30`).

## Test plan
- [x] `node --check` + `eslint` clean
- [x] `actionlint` clean on the workflow
- [x] Live-tested against real LBO/Feefo traffic, 4 cases: near-zero budget exits cleanly after 1 show; near-zero budget on the full 399-show catalog exits before any show is found (confirms the zero-guard exemption doesn't false-positive); a 0.001min budget mid a single-show run exits cleanly during Feefo pagination; a 5-min budget lets pagination + fetch complete normally (no regression).
- [x] Codex adversarial review run on the diff; one real finding (usage docstring missing the new flag) fixed in a follow-up commit.
- [x] ship-check verdict recorded (`review-gate.mjs`)

Task #415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)