### PR TITLE
feat(bsc-next): show the task number in the cmux workspace title

### DIFF
--- a/scripts/bsc-next.js
+++ b/scripts/bsc-next.js
@@ -240,7 +240,7 @@ function buildSeed(task, card, project, model) {
     // the same task goes undetected. The instruction below therefore tells
     // the session to APPEND phase text after the unchanged launch title,
     // never to replace it.
-    project ? `This workspace is named "${buildAutoTitle({ subject: task.subject, project, model })}" — the 🤖 marks it as auto-dispatched (safe to ignore; it reports via cards+email), the model glyph shows which model runs it, "${project}" is its project bucket. If this card has multiple phases/sprints, you may APPEND the current phase after this exact title (never replace or shorten it — the ✅ auto-mark hook and duplicate-dispatch guard match on this title as a prefix): \`cmux workspace-action --action rename --title "${buildAutoTitle({ subject: task.subject, project, model })} — <current phase>"\`.` : null,
+    project ? `This workspace is named "${buildAutoTitle({ subject: task.subject, project, model, taskId: task.id })}" — the 🤖 marks it as auto-dispatched (safe to ignore; it reports via cards+email), the model glyph shows which model runs it, "${project}" is its project bucket. If this card has multiple phases/sprints, you may APPEND the current phase after this exact title (never replace or shorten it — the ✅ auto-mark hook and duplicate-dispatch guard match on this title as a prefix): \`cmux workspace-action --action rename --title "${buildAutoTitle({ subject: task.subject, project, model, taskId: task.id })} — <current phase>"\`.` : null,
     ``,
     // Standing anti-stale-seed instruction (chain break #1, 2026-07-12): a
     // launched session's seed is a snapshot — directives added to the card
@@ -279,7 +279,7 @@ function launchCmux(task, seed, commandOverride, model = 'sonnet', project = nul
   // glyph (leading emoji are stripped by both title matchers, so this stays
   // match-compatible with the pre-existing bare-subject convention).
   const title = project
-    ? buildAutoTitle({ subject: task.subject, project, model })
+    ? buildAutoTitle({ subject: task.subject, project, model, taskId: task.id })
     : `${modelGlyph(model) ? modelGlyph(model) + ' ' : ''}${task.subject.slice(0, 50)}`;
   // --model sonnet: dispatched sessions default to Sonnet, not the user's
   // interactive default (Fable) — 9 Fable workspaces in one night, 2026-07-13.

--- a/scripts/bsc-next.test.mjs
+++ b/scripts/bsc-next.test.mjs
@@ -259,13 +259,13 @@ test('buildSeed always appends the re-read-before-wrap-up instruction', () => {
 
 test('buildSeed: with a project, instructs the session to APPEND (never replace) phase text on rename', () => {
   const seed = buildSeed(TASKS[1], { url: 'https://n/x', notes: 'n', priority: 'P1' }, 'Infra');
-  assert.match(seed, /🤖 Infra·P1 pending/);
+  assert.match(seed, /🤖 Infra·#2 P1 pending/);
   assert.match(seed, /APPEND the current phase after this exact title/);
   assert.match(seed, /never replace or shorten it/);
   // ship-check P1: the rename command must carry the FULL unchanged launch
   // title, not a placeholder — otherwise the ✅ hook / dup-dispatch guard
   // stop matching the moment a session follows this instruction.
-  assert.match(seed, /cmux workspace-action --action rename --title "🤖 Infra·P1 pending — <current phase>"/);
+  assert.match(seed, /cmux workspace-action --action rename --title "🤖 Infra·#2 P1 pending — <current phase>"/);
 });
 
 test('buildSeed: without a project (backward-compat callers), omits the rename instruction entirely', () => {
@@ -367,6 +367,6 @@ test('explicit --model flag is threaded through as opts.explicitFlag unchanged',
 
 test('buildSeed: with a model, the quoted title carries the model glyph (production path)', () => {
   const seed = buildSeed(TASKS[1], { url: 'https://n/x', notes: 'n', priority: 'P1' }, 'Infra', 'sonnet');
-  assert.match(seed, /🤖⚡ Infra·P1 pending/);
-  assert.match(seed, /cmux workspace-action --action rename --title "🤖⚡ Infra·P1 pending — <current phase>"/);
+  assert.match(seed, /🤖⚡ Infra·#2 P1 pending/);
+  assert.match(seed, /cmux workspace-action --action rename --title "🤖⚡ Infra·#2 P1 pending — <current phase>"/);
 });

--- a/scripts/lib/workspace-naming.js
+++ b/scripts/lib/workspace-naming.js
@@ -71,8 +71,20 @@ function modelGlyph(model) {
 
 // Matches bsc-next.js's existing 50-char subject truncation. model is
 // optional — omitted keeps the pre-glyph title shape byte-for-byte.
-function buildAutoTitle({ subject, project, model }) {
-  return `${AUTO_GLYPH}${modelGlyph(model)} ${project}·${String(subject || '').slice(0, 50)}`;
+//
+// taskId (owner request 2026-07-26): the shared-task-list number, rendered as
+// "#485" right after the project bucket. Sessions and reports refer to work by
+// task number ("close #485", "dispatch #500"), but the number appeared NOWHERE
+// in the cmux sidebar, so the owner had no way to map an instruction onto a
+// tab. It sits AFTER "<Project>·" on purpose: both title matchers strip
+// leading non-letter/non-digit chars first, so a leading "#485" would be
+// mangled into "485 Data·…" and break matching. Placing it after the project
+// prefix keeps it inside the first ~12 visible chars (the sidebar truncates
+// around 35) while both strippers skip it — see stripAutoPrefix below and the
+// mirrored cleanTitle() in ~/.claude/hooks/lib/workspace-mark-done.js.
+function buildAutoTitle({ subject, project, model, taskId }) {
+  const num = taskId == null || taskId === '' ? '' : `#${taskId} `;
+  return `${AUTO_GLYPH}${modelGlyph(model)} ${project}·${num}${String(subject || '').slice(0, 50)}`;
 }
 
 // Strips a "<Project>·" prefix from an ALREADY glyph-cleaned title (i.e.
@@ -84,7 +96,12 @@ function buildAutoTitle({ subject, project, model }) {
 // that first; this only knows about the project-prefix layer.
 function stripAutoPrefix(cleanedTitle) {
   const m = new RegExp(`^(?:${PROJECTS.join('|')})·`).exec(cleanedTitle);
-  return m ? cleanedTitle.slice(m[0].length) : cleanedTitle;
+  const afterProject = m ? cleanedTitle.slice(m[0].length) : cleanedTitle;
+  // Then the optional "#<taskId> " token buildAutoTitle emits after the
+  // project bucket, so a numbered title still reduces to the raw task
+  // subject the matchers compare against. Applied even when no project
+  // prefix matched, so a hand-renamed "#485 Fix the thing" also reduces.
+  return afterProject.replace(/^#\d+\s+/, '');
 }
 
 module.exports = { AUTO_GLYPH, PROJECTS, PROJECT_RULES, CATEGORY_DEFAULT, MODEL_GLYPHS, projectOf, modelGlyph, buildAutoTitle, stripAutoPrefix };


### PR DESCRIPTION
## Why
Owner report (2026-07-26): reports and sessions refer to work by task number — "close #485", "dispatch #500", "dead shell 63" — but **none of those appeared anywhere in the cmux sidebar**. Tabs read `🤖⚡ Loop·Lock-staleness cousin bug: jso…`, so an instruction like "close #485" was unactionable: no way to map it onto a tab.

## What
Titles now render `🤖⚡ Loop·#485 Lock-staleness cousin bug: jso…`.

The number sits **after** the `<Project>·` bucket deliberately. Both title matchers strip leading non-letter/non-digit chars first, so a *leading* `#485` would clean to `485 Loop·…` and break matching outright — silently killing the ✅ auto-mark that makes `bsc-prune` safe. After the bucket it lands at ~char 10, comfortably inside the sidebar's ~35-char truncation, and both strippers skip it:

- `stripAutoPrefix` (`scripts/lib/workspace-naming.js`) — duplicate-dispatch guard
- `cleanTitle` (`~/.claude/hooks/lib/workspace-mark-done.js`) — ✅ auto-mark

Those two keep intentionally-duplicated copies of the logic, so they were updated **in lockstep**. The hook change ships outside this repo (private `~/.claude`) and is already applied.

`taskId` is optional — callers that omit it keep the old title byte-for-byte.

## Verification
- 42/42 `scripts/bsc-next.test.mjs` + `bsc-next-model.test.mjs`
- 27/27 hook lib tests, 16/16 hook integration tests
- Live round-trip: a numbered title resolves back to its task through *both* matchers
- 24 existing workspaces retroactively renamed and confirmed in the sidebar

## Note
Opened as a PR rather than a direct push: main moved 4+ times in minutes under ~15 concurrent sessions, and direct merges kept getting lost in the shared working tree. A PR merge is race-free.