### PR TITLE
fix(#485): json-write-guard + notion-tasks-sync lock staleness use acquiredAt, not fs mtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,6 +290,9 @@ on:
       - 'scripts/lib/shows-write-guard.js'
       - 'scripts/lib/atomic-shows-write.js'
       - 'scripts/lib/json-write-guard.js'
+      # #485 lock-staleness fix (acquiredAt not mtime) — colocated test runs
+      # in the lib-test glob; path-listed so a solo edit triggers CI.
+      - 'scripts/lib/json-write-guard.test.mjs'
       - 'scripts/lib/commercial-write-guard.js'
       - 'scripts/lib/audience-buzz-write-guard.js'
       # Write-routing lint shared by CI (Lint Workflows job) + local pre-push

--- a/scripts/lib/json-write-guard.js
+++ b/scripts/lib/json-write-guard.js
@@ -78,6 +78,15 @@ function isLockStale(lockDir, now = Date.now()) {
   try {
     const owner = JSON.parse(fs.readFileSync(ownerPath, 'utf8'));
     acquiredAt = Date.parse(owner.acquiredAt);
+    // A present-but-unparseable acquiredAt (e.g. a future refactor drops
+    // .toISOString() and writes a raw number) silently falls back to the
+    // exact mtime anti-pattern this function exists to avoid — warn so a
+    // format regression is observable instead of quietly reintroducing #476.
+    if (!Number.isFinite(acquiredAt) && owner.acquiredAt !== undefined) {
+      console.warn(
+        `json-write-guard: ${ownerPath} has an unparseable acquiredAt (${JSON.stringify(owner.acquiredAt)}) — falling back to mtime staleness`
+      );
+    }
   } catch {
     acquiredAt = NaN;
   }

--- a/scripts/lib/json-write-guard.js
+++ b/scripts/lib/json-write-guard.js
@@ -58,6 +58,35 @@ function lockOwnerPath(lockDir) {
 }
 
 /**
+ * Whether the lock at lockDir has been held longer than LOCK_STALE_MS.
+ * Judged off owner.json's own `acquiredAt` field — NEVER fs mtime, which any
+ * unrelated process touching/stat-ing the lock dir (a smoketest, an `ls`/
+ * `find` sweep) can silently reset. That's the exact bug class #476 fixed
+ * for monitor.lock (see monitor-lock-staleness.js): mtime looks like a
+ * reasonable proxy but is trivially reset by code that never touches the
+ * lock's actual owner.
+ *
+ * Falls back to mtime ONLY when owner.json is unreadable, corrupt, or
+ * (old-format) missing `acquiredAt` — an unreadable file can't tell us
+ * anything else. Throws if owner.json doesn't exist at all, same as a bare
+ * statSync would; callers treat that as "can't tell, don't break the lock"
+ * rather than as stale (a concurrent acquirer's mkdir may be mid-flight).
+ */
+function isLockStale(lockDir, now = Date.now()) {
+  const ownerPath = lockOwnerPath(lockDir);
+  let acquiredAt = NaN;
+  try {
+    const owner = JSON.parse(fs.readFileSync(ownerPath, 'utf8'));
+    acquiredAt = Date.parse(owner.acquiredAt);
+  } catch {
+    acquiredAt = NaN;
+  }
+  if (Number.isFinite(acquiredAt)) return now - acquiredAt > LOCK_STALE_MS;
+  const stat = fs.statSync(ownerPath); // throws if owner.json is missing entirely
+  return now - stat.mtimeMs > LOCK_STALE_MS;
+}
+
+/**
  * Acquires the lock and returns a unique token identifying THIS acquisition.
  * releaseLock() must be called with that exact token, and only removes the
  * lock if it still owns it — see shows-write-guard.js's docstring for the
@@ -79,8 +108,7 @@ function acquireLock(lockDir) {
 
       // Break a stale lock (crashed holder never released it).
       try {
-        const stat = fs.statSync(lockOwnerPath(lockDir));
-        if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
+        if (isLockStale(lockDir)) {
           fs.rmSync(lockDir, { recursive: true, force: true });
           continue; // retry immediately, no sleep
         }
@@ -315,4 +343,7 @@ module.exports = {
   mergeArrayRecords,
   mergeMapRecords,
   recordCount,
+  isLockStale,
+  lockOwnerPath,
+  LOCK_STALE_MS,
 };

--- a/scripts/lib/json-write-guard.test.mjs
+++ b/scripts/lib/json-write-guard.test.mjs
@@ -1,0 +1,98 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const { isLockStale, lockOwnerPath, LOCK_STALE_MS, createJsonWriteGuard } = require('./json-write-guard.js');
+
+function mkLockDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'json-write-guard-lock-'));
+}
+
+function writeOwner(dir, obj) {
+  fs.writeFileSync(lockOwnerPath(dir), JSON.stringify(obj));
+}
+
+test('#485 repro: a stale acquiredAt is judged stale even when the lock dir/file mtime was touched just now', () => {
+  const dir = mkLockDir();
+  writeOwner(dir, { pid: 1, token: 'a', acquiredAt: new Date(Date.now() - LOCK_STALE_MS - 5000).toISOString() });
+  fs.utimesSync(dir, new Date(), new Date()); // simulate an unrelated process touching the lock dir
+  fs.utimesSync(lockOwnerPath(dir), new Date(), new Date()); // and the owner.json file itself
+  assert.equal(isLockStale(dir), true);
+});
+
+test('a fresh acquiredAt reads not-stale', () => {
+  const dir = mkLockDir();
+  writeOwner(dir, { pid: 1, token: 'a', acquiredAt: new Date().toISOString() });
+  assert.equal(isLockStale(dir), false);
+});
+
+test('exactly at the boundary is not stale; just past it is stale', () => {
+  const dir = mkLockDir();
+  writeOwner(dir, { pid: 1, token: 'a', acquiredAt: new Date(Date.now() - LOCK_STALE_MS + 1000).toISOString() });
+  assert.equal(isLockStale(dir), false);
+  writeOwner(dir, { pid: 1, token: 'a', acquiredAt: new Date(Date.now() - LOCK_STALE_MS - 1000).toISOString() });
+  assert.equal(isLockStale(dir), true);
+});
+
+test('missing owner.json throws — caller treats that as "cannot tell, do not break the lock"', () => {
+  const dir = mkLockDir();
+  assert.throws(() => isLockStale(dir));
+});
+
+test('corrupt owner.json content falls back to mtime: old mtime reads stale', () => {
+  const dir = mkLockDir();
+  fs.writeFileSync(lockOwnerPath(dir), 'not json');
+  const old = new Date(Date.now() - LOCK_STALE_MS - 5000);
+  fs.utimesSync(lockOwnerPath(dir), old, old);
+  assert.equal(isLockStale(dir), true);
+});
+
+test('corrupt owner.json content falls back to mtime: fresh mtime reads not stale', () => {
+  const dir = mkLockDir();
+  fs.writeFileSync(lockOwnerPath(dir), 'not json');
+  assert.equal(isLockStale(dir), false);
+});
+
+test('owner.json missing the acquiredAt field (old format) falls back to mtime', () => {
+  const dir = mkLockDir();
+  writeOwner(dir, { pid: 1, token: 'a' });
+  const old = new Date(Date.now() - LOCK_STALE_MS - 5000);
+  fs.utimesSync(lockOwnerPath(dir), old, old);
+  assert.equal(isLockStale(dir), true);
+});
+
+test('a malformed acquiredAt string falls back to mtime instead of throwing', () => {
+  const dir = mkLockDir();
+  writeOwner(dir, { pid: 1, token: 'a', acquiredAt: 'not-a-date' });
+  assert.doesNotThrow(() => isLockStale(dir));
+});
+
+test('a nonexistent lock dir throws (same as a bare statSync would)', () => {
+  assert.throws(() => isLockStale('/tmp/does-not-exist-json-write-guard-485'));
+});
+
+test('integration: createJsonWriteGuard.save() breaks a stale lock via acquiredAt even though the dir mtime was just touched', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'json-write-guard-int-'));
+  const filePath = path.join(tmpDir, 'data.json');
+  fs.writeFileSync(filePath, JSON.stringify({ shows: [], _meta: {} }));
+  const lockDir = `${filePath}.lock`;
+  fs.mkdirSync(lockDir);
+  writeOwner(lockDir, {
+    pid: 999999,
+    token: 'dead-holder',
+    acquiredAt: new Date(Date.now() - LOCK_STALE_MS - 5000).toISOString(),
+  });
+  fs.utimesSync(lockDir, new Date(), new Date()); // an unrelated touch — must not keep this lock alive
+
+  const guard = createJsonWriteGuard(filePath, { shape: 'array' });
+  const data = guard.load();
+  data.shows.push({ id: 'x', foo: 1 });
+  assert.doesNotThrow(() => guard.save(data));
+
+  const written = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  assert.equal(written.shows.length, 1);
+});

--- a/scripts/notion-action-poll.js
+++ b/scripts/notion-action-poll.js
@@ -86,23 +86,41 @@ function acquireLock() {
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
       const fd = fs.openSync(LOCK_FILE, 'wx');
-      fs.writeSync(fd, String(process.pid));
+      fs.writeSync(fd, JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() }));
       fs.closeSync(fd);
       return true;
     } catch {
       try {
         // Liveness first: a dead holder's lock is stale immediately, and a
         // LIVE holder's lock is never stolen — a Fix pipeline can legitimately
-        // hold it for hours (4 stages × 30 min). Age is only the fallback for
-        // unreadable/foreign PIDs.
-        const holderPid = parseInt(fs.readFileSync(LOCK_FILE, 'utf8'), 10);
+        // hold it for hours (4 stages × 30 min). When the PID can't be
+        // checked (corrupt/old-format lock content), fall back to the lock's
+        // own embedded acquiredAt rather than fs mtime — mtime is trivially
+        // reset by any unrelated process touching the lock file (the
+        // #476/#485 bug class). mtime is the LAST-resort fallback, used only
+        // when acquiredAt itself is also unreadable/missing (old bare-PID
+        // format written before this fix).
+        const raw = fs.readFileSync(LOCK_FILE, 'utf8');
+        let holderPid = NaN;
+        let acquiredAt = NaN;
+        try {
+          const content = JSON.parse(raw);
+          holderPid = content.pid;
+          acquiredAt = Date.parse(content.acquiredAt);
+        } catch {
+          holderPid = parseInt(raw, 10); // old-format: bare PID string
+        }
         let holderAlive = false;
         if (Number.isFinite(holderPid) && holderPid > 0) {
           try { process.kill(holderPid, 0); holderAlive = true; } catch { holderAlive = false; }
         }
         if (holderAlive) return false;
-        const age = Date.now() - fs.statSync(LOCK_FILE).mtimeMs;
-        if (!Number.isFinite(holderPid) && age < 150 * 60 * 1000) return false; // unreadable PID: age fallback
+        if (!Number.isFinite(holderPid)) {
+          const age = Number.isFinite(acquiredAt)
+            ? Date.now() - acquiredAt
+            : Date.now() - fs.statSync(LOCK_FILE).mtimeMs; // unreadable PID + no acquiredAt: mtime fallback
+          if (age < 150 * 60 * 1000) return false;
+        }
         fs.unlinkSync(LOCK_FILE);
         continue; // stale — retry acquisition once
       } catch { continue; } // lock vanished between open and stat — retry

--- a/scripts/notion-tasks-sync.js
+++ b/scripts/notion-tasks-sync.js
@@ -198,6 +198,9 @@ function acquireLock(dir) {
       try {
         const content = JSON.parse(fs.readFileSync(lock, 'utf8'));
         acquiredAt = Date.parse(content.acquiredAt);
+        if (!Number.isFinite(acquiredAt) && content.acquiredAt !== undefined) {
+          console.warn(`notion-tasks-sync: ${lock} has an unparseable acquiredAt (${JSON.stringify(content.acquiredAt)}) — falling back to mtime staleness`);
+        }
       } catch {
         acquiredAt = NaN;
       }

--- a/scripts/notion-tasks-sync.js
+++ b/scripts/notion-tasks-sync.js
@@ -181,16 +181,29 @@ function allocateFreeId(dir, startId) {
 
 // Best-effort cross-process lock so N Cmux panes pulling at once don't race.
 // Stale locks (>2 min) are stolen. Returns a release() fn or null if held.
+// Age is judged off the lock file's own embedded `acquiredAt`, not fs mtime
+// — mtime is trivially reset by any unrelated process that touches/stats
+// the file (the #476 bug class; see monitor-lock-staleness.js). mtime is
+// kept only as a fallback for an old-format (bare-PID) or corrupt lock file.
 function acquireLock(dir) {
   const lock = path.join(dir, '.sync-lock');
   try {
     const fd = fs.openSync(lock, 'wx'); // O_EXCL: fails if it already exists
-    fs.writeSync(fd, String(process.pid));
+    fs.writeSync(fd, JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() }));
     fs.closeSync(fd);
     return () => { try { fs.unlinkSync(lock); } catch {} };
   } catch {
     try {
-      const age = Date.now() - fs.statSync(lock).mtimeMs;
+      let acquiredAt = NaN;
+      try {
+        const content = JSON.parse(fs.readFileSync(lock, 'utf8'));
+        acquiredAt = Date.parse(content.acquiredAt);
+      } catch {
+        acquiredAt = NaN;
+      }
+      const age = Number.isFinite(acquiredAt)
+        ? Date.now() - acquiredAt
+        : Date.now() - fs.statSync(lock).mtimeMs; // old-format (bare pid) or corrupt — mtime fallback
       if (age > 120000) { fs.unlinkSync(lock); return acquireLock(dir); }
     } catch {}
     return null;
@@ -351,4 +364,4 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { parseArgs, mapStatus, mergeStatus, mapCardToTask, planPull, nextId, allocateFreeId, taskBelongsTo, notionMarker, writeTask, readHwm, writeHwm };
+module.exports = { parseArgs, mapStatus, mergeStatus, mapCardToTask, planPull, nextId, allocateFreeId, taskBelongsTo, notionMarker, writeTask, readHwm, writeHwm, acquireLock };

--- a/scripts/notion-tasks-sync.test.mjs
+++ b/scripts/notion-tasks-sync.test.mjs
@@ -5,7 +5,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 const require = createRequire(import.meta.url);
-const { mapStatus, mapCardToTask, planPull, allocateFreeId, taskBelongsTo, notionMarker, writeTask, readHwm, writeHwm } = require('./notion-tasks-sync.js');
+const { mapStatus, mapCardToTask, planPull, allocateFreeId, taskBelongsTo, notionMarker, writeTask, readHwm, writeHwm, acquireLock } = require('./notion-tasks-sync.js');
 
 function tmpDir() { return fs.mkdtempSync(path.join(os.tmpdir(), 'nts-')); }
 
@@ -124,4 +124,42 @@ test('executor claim: a card flipped to In progress mirrors as in_progress, neve
   assert.equal(mergeStatus('pending', 'in_progress'), 'in_progress');
   assert.equal(mergeStatus('pending', 'completed'), 'completed');
   assert.equal(mergeStatus(undefined, 'pending'), 'pending');
+});
+
+// ── #485: .sync-lock staleness must use its own acquiredAt, not fs mtime ────
+// Same bug class as json-write-guard.js and #476's monitor.lock: mtime is
+// trivially reset by any unrelated process touching the lock file.
+
+test('#485: a live lock (fresh acquiredAt) is NOT stolen even if its mtime is old', () => {
+  const dir = tmpDir();
+  const lockPath = path.join(dir, '.sync-lock');
+  fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() }));
+  const old = new Date(Date.now() - 10 * 60 * 1000); // 10 min old mtime, well past the 2-min TTL
+  fs.utimesSync(lockPath, old, old);
+  const release = acquireLock(dir);
+  assert.equal(release, null, 'a fresh acquiredAt must block acquisition regardless of stale mtime');
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('#485: a stale lock (old acquiredAt) is stolen even if its mtime was just touched', () => {
+  const dir = tmpDir();
+  const lockPath = path.join(dir, '.sync-lock');
+  fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, acquiredAt: new Date(Date.now() - 3 * 60 * 1000).toISOString() }));
+  fs.utimesSync(lockPath, new Date(), new Date()); // unrelated touch resets mtime to "now"
+  const release = acquireLock(dir);
+  assert.ok(typeof release === 'function', 'a stale acquiredAt must be stolen despite a fresh mtime');
+  release();
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('#485: an old-format lock (bare PID, no acquiredAt) falls back to mtime staleness', () => {
+  const dir = tmpDir();
+  const lockPath = path.join(dir, '.sync-lock');
+  fs.writeFileSync(lockPath, String(process.pid)); // pre-fix format
+  const old = new Date(Date.now() - 3 * 60 * 1000);
+  fs.utimesSync(lockPath, old, old);
+  const release = acquireLock(dir);
+  assert.ok(typeof release === 'function', 'old-format lock past the mtime TTL must still be stealable');
+  release();
+  fs.rmSync(dir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- json-write-guard.js's stale-lock check used fs mtime instead of owner.json's own `acquiredAt` — the same anti-pattern #476 fixed for monitor.lock. Any unrelated process touching the lock dir could silently reset the clock and make a genuinely-stale lock look fresh forever.
- notion-tasks-sync.js's `.sync-lock` was bare-PID-only with pure-mtime staleness — now embeds `acquiredAt` too, same fallback pattern.
- notion-action-poll.js spot-checked (already liveness-first); its corrupt/unreadable-PID fallback had the identical mtime exposure (rarer precondition) — closed too.
- Added a warning when a present-but-unparseable `acquiredAt` silently falls back to mtime, so a future format regression is observable.

## Test plan
- [x] `node --test scripts/lib/json-write-guard.test.mjs` — 10/10 pass (new file)
- [x] `node --test tests/unit/json-write-guard.test.mjs` — 20/20 pass (existing, no regressions)
- [x] `node --test scripts/notion-tasks-sync.test.mjs` — 14/14 pass (3 new cases)
- [x] `bash scripts/lint-write-routing.sh` — all 5 checks pass
- [x] `npx eslint` on all changed files — clean
- [x] ship-check: codebase-aware adversarial review run, 2 real findings fixed inline

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>