### PR TITLE
feat(#510): monitor for 'exactly 1 scheduled email/day' digest-noise regressions

### DIFF
--- a/.cron-health-exempt.txt
+++ b/.cron-health-exempt.txt
@@ -15,6 +15,11 @@ aggregator-url-watcher.yml
 audit-aggregator-coverage.yml
 audit-aggregator-gap.yml
 audit-bww-rr-attributions.yml
+# Digest-noise regression monitor (card #510): self-contained daily check
+# that alerts the owner directly via routeAlert() when it finds a violation.
+# A stale run means at-worst a 1-day-late detection of a noise regression —
+# no user-facing staleness, no paging value.
+monitor-scheduled-email-count.yml
 # Reverse discovery (missing-show detector): candidates surface in the daily
 # digest via health-check.js; a stale run means at-worst 1-day-late candidates.
 audit-reverse-discovery.yml

--- a/.github/workflows/monitor-scheduled-email-count.yml
+++ b/.github/workflows/monitor-scheduled-email-count.yml
@@ -1,0 +1,76 @@
+name: Monitor Scheduled Email Count
+
+# Card #510: verifies the owner's "exactly 1 scheduled digest email/day" goal
+# (cards #364/#497) actually holds, by reading real Resend send history
+# instead of trusting code comments. Runs after every known scheduled digest
+# would have fired: Overnight (~07:30 UTC), opening-digest (11:00 UTC),
+# daily-digest (12:00 UTC), reddit-engagement-digest (13:00 & 01:00 UTC).
+# 15:00 UTC gives margin over all of them.
+on:
+  schedule:
+    - cron: '0 15 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report only, no routeAlert dispatch'
+        required: false
+        default: 'false'
+        type: boolean
+
+concurrency:
+  group: monitor-scheduled-email-count
+  cancel-in-progress: false
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      # routeAlert's disposition='auto' path shells out to notion-brain.js,
+      # which requires @notionhq/client — same gap that broke every
+      # data-health-check.yml auto-dispatch until it was added there.
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Run monitor
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          OWNER_EMAIL: ${{ secrets.OWNER_EMAIL }}
+          NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+        run: |
+          ARGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="--dry-run"
+          fi
+          node scripts/monitor-scheduled-email-count.js $ARGS
+
+      - name: Commit alert ledger
+        if: always()
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add data/audit/alert-ledger.json 2>/dev/null || true
+          git add data/audit/alert-router-attempts.jsonl 2>/dev/null || true
+          if ! git diff --cached --quiet; then
+            git commit -m "data: Update scheduled-email-count monitor state [skip ci]"
+            bash scripts/lib/push-with-retry.sh
+          else
+            echo "No ledger changes to commit"
+          fi
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure
+        with:
+          title: 'Monitor Scheduled Email Count Failed'
+          discord_webhook: ${{ secrets.DISCORD_WEBHOOK_ALERTS }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -584,6 +584,11 @@ on:
       - 'scripts/lib/ticket-ab-monitor-rules.js'
       - 'scripts/lib/ticket-ab-monitor-rules.test.mjs'
       - 'scripts/monitor-ticket-ab.js'
+      # Scheduled-email-count monitor (card #510) — pure classifier/decision
+      # rules + CLI; colocated test runs in the scripts/lib/*.test.mjs glob step.
+      - 'scripts/lib/scheduled-email-count-rules.js'
+      - 'scripts/lib/scheduled-email-count-rules.test.mjs'
+      - 'scripts/monitor-scheduled-email-count.js'
       # Overall email-gate funnel monitor (card #240) — pure rules + runner +
       # analyzer; colocated test runs in the scripts/lib/*.test.mjs glob step.
       - 'scripts/lib/email-gate-funnel-rules.js'

--- a/scripts/lib/scheduled-email-count-rules.js
+++ b/scripts/lib/scheduled-email-count-rules.js
@@ -1,0 +1,110 @@
+/**
+ * scheduled-email-count-rules.js — pure classification/decision logic for
+ * the scheduled-email-count monitor (card #510, scripts/monitor-scheduled-email-count.js).
+ * No I/O here (CLAUDE.md §15 test-extraction pattern).
+ *
+ * Cards #364 and #497 both aimed to fold every scheduled digest onto
+ * autonomous-email.js's single morning send ("exactly 1 scheduled owner
+ * email/day"). Nothing verified that goal kept holding — this module is the
+ * classifier half of that check.
+ *
+ * SCHEDULED_SENDERS is cross-referenced against DIGEST_OR_REVIEWED in
+ * scripts/audit-alert-senders.js:43-53 (the definitive list of scheduled
+ * digest scripts), narrowed to the ones that were confirmed via direct grep
+ * on 2026-07-26 to still POST straight to Resend's send endpoint on their
+ * own cron — discord-notify.js and owner-alert-router.js are excluded even though
+ * audit-alert-senders.js lists them, because they're event-driven alert
+ * plumbing (variable subjects, no fixed cron), not a standalone scheduled
+ * digest. generate-remediation-plan.js is excluded too — it only fires on
+ * `issues: opened` (auto-fix-feedback-bug.yml), not a schedule.
+ *
+ * Each pattern is sourced directly from the sender script's own subject-
+ * building code, not guessed:
+ *   - autonomous-email.js:502-526      → subject always starts "Overnight:"
+ *   - send-daily-digest.js:266-270     → "(⚠️ )?Daily Digest: N change(s)..."
+ *   - send-opening-digest.js:636-696   → buildSubject() joins phrases like
+ *                                         "N needs help", "N broadcast-ready",
+ *                                         "N upcoming this week", or "Quiet week"
+ *   - reddit-engagement-digest.js:571  → "r/Broadway — N thread(s) for you"
+ *   - fantasy-weekly-email.js:274      → "[Action Required] Fantasy weekly draft ready — <week>"
+ *   - health-check.js:1867-1889        → "BSC Daily: ..." / "BSC URGENT (day N): ..."
+ *     (card #364 removed this send path on 2026-07-26 17:29 UTC — kept here
+ *     so a regression or an un-migrated older run still gets classified
+ *     correctly instead of falling into "other").
+ */
+'use strict';
+
+const SCHEDULED_SENDERS = [
+  { key: 'autonomous-email', label: 'Overnight morning email', script: 'scripts/autonomous-email.js', pattern: /^Overnight:/ },
+  { key: 'daily-digest', label: 'Daily Digest (score-drift)', script: 'scripts/send-daily-digest.js', pattern: /Daily Digest:/ },
+  { key: 'opening-digest', label: 'Opening-night admin digest', script: 'scripts/send-opening-digest.js', pattern: /needs help|broadcast-ready|upcoming this week|^Quiet week/ },
+  { key: 'reddit-engagement-digest', label: 'Reddit engagement digest', script: 'scripts/reddit-engagement-digest.js', pattern: /^r\/Broadway —/ },
+  { key: 'fantasy-weekly', label: 'Fantasy weekly draft notice', script: 'scripts/fantasy-weekly-email.js', pattern: /^\[Action Required\] Fantasy weekly draft ready/ },
+  { key: 'health-check-digest', label: 'Health check digest (legacy path)', script: 'scripts/health-check.js', pattern: /^BSC (Daily|URGENT)/ },
+];
+
+function classifySubject(subject) {
+  const s = String(subject || '');
+  for (const sender of SCHEDULED_SENDERS) {
+    if (sender.pattern.test(s)) return sender;
+  }
+  return null;
+}
+
+// Resend `created_at` is always UTC, formatted "YYYY-MM-DD HH:MM:SS[.ffffff]+00".
+function toDate(createdAt) {
+  return new Date(String(createdAt).trim().replace(' ', 'T').replace(/\+00$/, 'Z'));
+}
+
+// America/New_York calendar-date key — the owner is US-based, so "one email
+// today" should mean one email in the day the owner actually experiences,
+// not a UTC day that splits around 8pm ET.
+function dayKeyET(createdAt) {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/New_York', year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(toDate(createdAt));
+}
+
+/**
+ * Filters `emails` (Resend GET /emails `data` rows) to ones addressed to
+ * ownerEmail, classifies each against SCHEDULED_SENDERS, and buckets by ET
+ * calendar day.
+ * @returns {Map<string, {senders: Map<string,{label:string,subjects:string[]}>, other: Array<{subject,created_at}>}>}
+ */
+function buildDailyReport(emails, ownerEmail) {
+  const owner = String(ownerEmail || '').toLowerCase();
+  const days = new Map();
+  for (const e of emails || []) {
+    const to = Array.isArray(e.to) ? e.to : [e.to];
+    if (!to.some((t) => String(t || '').toLowerCase() === owner)) continue;
+
+    const dayKey = dayKeyET(e.created_at);
+    if (!days.has(dayKey)) days.set(dayKey, { senders: new Map(), other: [] });
+    const day = days.get(dayKey);
+
+    const match = classifySubject(e.subject);
+    if (match) {
+      if (!day.senders.has(match.key)) day.senders.set(match.key, { label: match.label, subjects: [] });
+      day.senders.get(match.key).subjects.push(e.subject);
+    } else {
+      day.other.push({ subject: e.subject, created_at: e.created_at });
+    }
+  }
+  return days;
+}
+
+// Pure decision for one day's bucket: violates "exactly 1 scheduled digest
+// sender/day" iff 2+ distinct SCHEDULED_SENDERS fired. Unclassified ("other")
+// owner emails (one-off CRITICAL/ACTION alerts routed via owner-alert-router)
+// are reported for visibility but never count toward this verdict — they're
+// a separate, already-monitored noise class (alert-ledger dedup, E2E canary #374).
+function decideDayViolation(dayBucket) {
+  const senderKeys = [...dayBucket.senders.keys()];
+  return {
+    violation: senderKeys.length > 1,
+    senderCount: senderKeys.length,
+    senders: senderKeys.map((k) => ({ key: k, ...dayBucket.senders.get(k) })),
+  };
+}
+
+module.exports = { SCHEDULED_SENDERS, classifySubject, dayKeyET, buildDailyReport, decideDayViolation };

--- a/scripts/lib/scheduled-email-count-rules.test.mjs
+++ b/scripts/lib/scheduled-email-count-rules.test.mjs
@@ -1,0 +1,91 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifySubject,
+  dayKeyET,
+  buildDailyReport,
+  decideDayViolation,
+} from './scheduled-email-count-rules.js';
+
+test('classifySubject matches each known scheduled sender', () => {
+  assert.equal(classifySubject('Overnight: 3 items awaiting your tap').key, 'autonomous-email');
+  assert.equal(classifySubject('Daily Digest: 12 changes on 2026-07-26').key, 'daily-digest');
+  assert.equal(classifySubject('⚠️ Daily Digest: 25 changes (1 warning) on 2026-07-24').key, 'daily-digest');
+  assert.equal(classifySubject('1 needs help · Jul 26').key, 'opening-digest');
+  assert.equal(classifySubject('1 broadcast-ready · Jul 24').key, 'opening-digest');
+  assert.equal(classifySubject('1 upcoming this week · Jul 25').key, 'opening-digest');
+  assert.equal(classifySubject('Quiet week').key, 'opening-digest');
+  assert.equal(classifySubject('r/Broadway — 2 threads for you').key, 'reddit-engagement-digest');
+  assert.equal(classifySubject('[Action Required] Fantasy weekly draft ready — 2026-07-29').key, 'fantasy-weekly');
+  assert.equal(classifySubject('BSC Daily: All clear (27/27 passed)').key, 'health-check-digest');
+  assert.equal(classifySubject('BSC URGENT (day 8): 2 unresolved errors').key, 'health-check-digest');
+});
+
+test('classifySubject returns null for one-off action/critical alerts', () => {
+  assert.equal(classifySubject('[CRITICAL] Opening Night SLA P0 — 4 review(s) stuck'), null);
+  assert.equal(classifySubject('[ACTION] Tokenless claude launchd job'), null);
+  assert.equal(classifySubject('TestFlight build 54 APPROVED — share link is live'), null);
+});
+
+test('dayKeyET buckets by America/New_York calendar date, not UTC', () => {
+  // 2026-07-26 01:30 UTC is still 2026-07-25 evening in ET.
+  assert.equal(dayKeyET('2026-07-26 01:30:00.000000+00'), '2026-07-25');
+  // 2026-07-26 19:11 UTC is 2026-07-26 afternoon in ET.
+  assert.equal(dayKeyET('2026-07-26 19:11:18.494614+00'), '2026-07-26');
+});
+
+test('buildDailyReport ignores emails not addressed to ownerEmail', () => {
+  const emails = [
+    { to: ['thomas.pryor@gmail.com'], subject: 'Overnight: 1 item', created_at: '2026-07-26 07:36:00.000000+00' },
+    { to: ['someone-else@example.com'], subject: 'Overnight: 1 item', created_at: '2026-07-26 07:37:00.000000+00' },
+    { to: 'thomas.pryor@gmail.com', subject: 'r/Broadway — 2 threads for you', created_at: '2026-07-26 13:39:00.000000+00' },
+  ];
+  const days = buildDailyReport(emails, 'thomas.pryor@gmail.com');
+  assert.equal(days.size, 1);
+  const bucket = days.get('2026-07-26');
+  assert.equal(bucket.senders.size, 2);
+  assert.deepEqual(bucket.other, []);
+});
+
+test('buildDailyReport buckets unclassified owner emails as "other", not a sender', () => {
+  const emails = [
+    { to: ['thomas.pryor@gmail.com'], subject: '[CRITICAL] main test.yml STILL red', created_at: '2026-07-24 04:31:00.000000+00' },
+  ];
+  const days = buildDailyReport(emails, 'thomas.pryor@gmail.com');
+  const bucket = days.get('2026-07-24');
+  assert.equal(bucket.senders.size, 0);
+  assert.equal(bucket.other.length, 1);
+});
+
+test('decideDayViolation: 1 sender is fine, 2+ is a violation', () => {
+  const oneSender = { senders: new Map([['autonomous-email', { label: 'x', subjects: ['a'] }]]), other: [] };
+  assert.equal(decideDayViolation(oneSender).violation, false);
+
+  const twoSenders = {
+    senders: new Map([
+      ['autonomous-email', { label: 'x', subjects: ['a'] }],
+      ['reddit-engagement-digest', { label: 'y', subjects: ['b'] }],
+    ]),
+    other: [],
+  };
+  const decision = decideDayViolation(twoSenders);
+  assert.equal(decision.violation, true);
+  assert.equal(decision.senderCount, 2);
+
+  const zeroSenders = { senders: new Map(), other: [] };
+  assert.equal(decideDayViolation(zeroSenders).violation, false);
+});
+
+test('real-world regression fixture: 2026-07-26 had 3+ distinct scheduled senders (pre-#497 fold)', () => {
+  // Actual subjects observed live via Resend GET /emails on 2026-07-26 (card #510 investigation).
+  const emails = [
+    { to: ['thomas.pryor@gmail.com'], subject: 'Overnight: ⚠️ 10 items stalling the loop — needs your triage', created_at: '2026-07-26 07:36:54.556310+00' },
+    { to: ['thomas.pryor@gmail.com'], subject: 'Daily Digest: 27 changes on 2026-07-26', created_at: '2026-07-26 12:23:27.877524+00' },
+    { to: ['thomas.pryor@gmail.com'], subject: 'r/Broadway — 2 threads for you', created_at: '2026-07-26 13:39:25.938199+00' },
+    { to: ['thomas.pryor@gmail.com'], subject: 'BSC URGENT (day 8): 2 unresolved errors', created_at: '2026-07-26 16:23:12.601517+00' },
+  ];
+  const days = buildDailyReport(emails, 'thomas.pryor@gmail.com');
+  const decision = decideDayViolation(days.get('2026-07-26'));
+  assert.equal(decision.violation, true);
+  assert.equal(decision.senderCount, 4);
+});

--- a/scripts/lint-resend-calls.js
+++ b/scripts/lint-resend-calls.js
@@ -50,6 +50,7 @@ const ALLOWLIST = new Set([
   'scripts/autonomous-deadman.js',
   'scripts/check-secrets-health.js', // GET /domains key-validity probe, not an alert send
   'scripts/newsletter/check-drafts-status.mjs', // GET /broadcasts read-only status probe, never touches /send
+  'scripts/monitor-scheduled-email-count.js', // GET /emails read-only monitor (card #510) — routeAlert() for the actual alert, this is just data collection
   'scripts/send-follow-notifications.js',
   'scripts/newsletter/create-broadcast-draft.mjs',
   'scripts/newsletter/send-test.mjs',

--- a/scripts/monitor-scheduled-email-count.js
+++ b/scripts/monitor-scheduled-email-count.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * monitor-scheduled-email-count.js — card #510.
+ *
+ * Cards #364 and #497 both migrated standalone digest emails onto
+ * autonomous-email.js's single merged morning email, driven by the owner's
+ * explicit goal ("exactly 1 scheduled email/day"). Nothing verified that
+ * goal keeps holding — a future PR could add a new standalone Resend send
+ * (or half-revert one of those migrations) and nobody would notice until
+ * the owner complains again, the same way #352/#409/#475 each had to
+ * re-fight the same noise problem.
+ *
+ * This reads REAL Resend send history (GET /emails), not code comments —
+ * during this card's own investigation, autonomous-email.js's comments
+ * claimed #497 was already folded while send-daily-digest.js and
+ * send-opening-digest.js were still confirmed (via direct grep) to POST to
+ * Resend on their own cron. Classification rules + why each sender is
+ * included: scripts/lib/scheduled-email-count-rules.js.
+ *
+ * Usage:
+ *   node scripts/monitor-scheduled-email-count.js               # live: checks the last complete ET day, routeAlert() on >1 sender
+ *   node scripts/monitor-scheduled-email-count.js --dry-run             # report the last 7 days, no alert, exit 0
+ *   node scripts/monitor-scheduled-email-count.js --dry-run --days=14
+ *
+ * Env: RESEND_API_KEY, OWNER_EMAIL. Live mode's routeAlert('auto') dispatch
+ * additionally needs NOTION_API_KEY (see scripts/lib/owner-alert-router.js).
+ */
+'use strict';
+
+const https = require('https');
+const { buildDailyReport, decideDayViolation, dayKeyET } = require('./lib/scheduled-email-count-rules');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const daysArg = process.argv.find((a) => a.startsWith('--days='));
+// Live mode looks back 2 days so a run anytime after midnight ET still sees
+// the full previous day even though "today" is partial; only complete days
+// (dayKey < today) are eligible to alert — see the filter in main().
+const WINDOW_DAYS = daysArg ? Number(daysArg.split('=')[1]) : (DRY_RUN ? 7 : 2);
+// Broadcast sends (newsletter blasts) pad the feed with hundreds of non-owner
+// rows per send at limit=100/page — cap pagination so a big broadcast day
+// can't turn this into a runaway API loop. 40 pages = 4,000 emails scanned,
+// comfortably more than a multi-day window with the owner's send volume.
+const MAX_PAGES = 40;
+
+const RESEND_API_KEY = process.env.RESEND_API_KEY;
+const OWNER_EMAIL = process.env.OWNER_EMAIL;
+
+function getEmailsPage(after) {
+  return new Promise((resolve, reject) => {
+    const path = '/emails?limit=100' + (after ? `&after=${after}` : '');
+    const req = https.request(
+      {
+        hostname: 'api.resend.com',
+        path,
+        method: 'GET',
+        headers: { Authorization: `Bearer ${RESEND_API_KEY}` },
+        timeout: 20000,
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => { body += chunk; });
+        res.on('end', () => {
+          if (res.statusCode !== 200) return reject(new Error(`HTTP ${res.statusCode}: ${body.slice(0, 200)}`));
+          try { resolve(JSON.parse(body)); } catch (e) { reject(e); }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.on('timeout', () => { req.destroy(new Error('timeout')); });
+    req.end();
+  });
+}
+
+// Paginates GET /emails (newest-first per Resend's API) until the page's
+// oldest row falls before sinceMs, filtering to rows addressed to OWNER_EMAIL.
+async function getEmailsPageWithRetry(after, retries = 2) {
+  try {
+    return await getEmailsPage(after);
+  } catch (err) {
+    if (retries <= 0) throw err;
+    await new Promise((r) => setTimeout(r, 1000));
+    return getEmailsPageWithRetry(after, retries - 1);
+  }
+}
+
+async function fetchOwnerEmailsSince(sinceMs) {
+  const owner = OWNER_EMAIL.toLowerCase();
+  const rows = [];
+  let after = null;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const j = await getEmailsPageWithRetry(after);
+    const data = j.data || [];
+    if (data.length === 0) break;
+    for (const e of data) {
+      const to = Array.isArray(e.to) ? e.to : [e.to];
+      if (to.some((t) => String(t || '').toLowerCase() === owner)) rows.push(e);
+    }
+    const last = data[data.length - 1];
+    const lastMs = new Date(String(last.created_at).replace(' ', 'T').replace(/\+00$/, 'Z')).getTime();
+    if (lastMs < sinceMs || !j.has_more) break;
+    after = last.id;
+  }
+  return rows;
+}
+
+async function main() {
+  if (!RESEND_API_KEY || !OWNER_EMAIL) {
+    console.error('ERROR: RESEND_API_KEY and OWNER_EMAIL must both be set');
+    process.exit(1);
+  }
+
+  const sinceMs = Date.now() - WINDOW_DAYS * 24 * 3600 * 1000;
+  const rows = await fetchOwnerEmailsSince(sinceMs);
+  const days = buildDailyReport(rows, OWNER_EMAIL);
+  const todayKey = dayKeyET(new Date().toISOString());
+
+  const sortedDays = [...days.keys()].sort();
+  const violations = [];
+  for (const dayKey of sortedDays) {
+    const bucket = days.get(dayKey);
+    const decision = decideDayViolation(bucket);
+    const senderList = decision.senders.map((s) => `${s.label} (${s.subjects.length}x)`).join(', ') || '(none)';
+    const partial = dayKey === todayKey ? ' [in progress]' : '';
+    console.log(`${dayKey}${partial}: ${decision.senderCount} scheduled sender${decision.senderCount === 1 ? '' : 's'} — ${senderList}${bucket.other.length ? ` [+${bucket.other.length} unclassified owner email(s)]` : ''}`);
+    if (decision.violation) violations.push({ dayKey, decision });
+  }
+
+  if (DRY_RUN) {
+    console.log(`\n${violations.length} of ${sortedDays.length} day(s) violated the "1 scheduled sender/day" goal.`);
+    return;
+  }
+
+  // Only complete days are eligible to alert — "today" is still accumulating
+  // and a partial-day sender count of 1 doesn't mean the day will stay that way.
+  const completeViolations = violations.filter((v) => v.dayKey < todayKey);
+  if (completeViolations.length === 0) {
+    console.log('No violations on complete days in window.');
+    return;
+  }
+
+  const { routeAlert } = require('./lib/owner-alert-router');
+  for (const { dayKey, decision } of completeViolations) {
+    const subjectLines = decision.senders.map((s) => `- ${s.label}: ${s.subjects.join('; ')}`).join('\n');
+    const result = await routeAlert({
+      conditionKey: `scheduled-email-count:${dayKey}`,
+      title: `Scheduled email count: ${decision.senderCount} distinct digest senders fired on ${dayKey}`,
+      description: `The owner's "exactly 1 scheduled digest email/day" goal (cards #364/#497) was violated on ${dayKey}:\n${subjectLines}`,
+      hint: 'Fold the extra sender(s) onto the autonomous-email.js snapshot pattern (see cards #364/#497/#511 for the established fix shape).',
+      severity: 'warning',
+      disposition: 'auto',
+      fields: decision.senders.map((s) => ({ name: s.label, value: `${s.subjects.length}x` })),
+      cooldownHours: 24,
+    });
+    console.log(`${dayKey}: routeAlert -> ${result.action}${result.cardId ? ` (card ${result.cardId})` : ''}`);
+  }
+}
+
+main().catch((err) => { console.error('Fatal:', err.message); process.exit(1); });


### PR DESCRIPTION
## Summary
- New monitor (`scripts/monitor-scheduled-email-count.js` + `scripts/lib/scheduled-email-count-rules.js`) reads real Resend send history and alerts via `routeAlert()` when 2+ distinct scheduled-digest senders fire on the same ET calendar day.
- Investigation found the #497 fold is not actually complete: `send-daily-digest.js`/`send-opening-digest.js` still POST directly to Resend, and `reddit-engagement-digest.js` (#511) is unmigrated — confirmed via live Resend data (2026-07-26 had 4-5 distinct scheduled senders).
- New daily cron `.github/workflows/monitor-scheduled-email-count.yml` (15:00 UTC, after all known digests would have fired).
- Registered in `.cron-health-exempt.txt` (self-alerting, not real-time-paging-worthy) and `scripts/lint-resend-calls.js` ALLOWLIST (GET-only, not a send).

## Test plan
- [x] `node --test scripts/lib/scheduled-email-count-rules.test.mjs` — 7/7 pass, including a real-world regression fixture from 2026-07-26
- [x] `node scripts/monitor-scheduled-email-count.js --dry-run --days=7` against live Resend data — correctly reports per-day distinct-sender counts, surfaced the current real violation
- [x] `node scripts/lint-resend-calls.js`, `node scripts/audit-cron-health-coverage.js`, `node scripts/audit-workflow-hygiene.js`, `actionlint` — all clean
- [x] Full `scripts/lib/*.test.mjs` suite (1507 tests) — no regressions

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>