### PR TITLE
fix: pre-push hook run_audit() temp-file race under concurrent pushes

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -132,17 +132,22 @@ done
 run_audit() {
   local label="$1"
   local script="$2"
-  if ! node "$script" >/tmp/pre-push-audit.out 2>&1; then
+  # PID+random-scoped, not a fixed filename: this repo commonly has many
+  # concurrent local `git push` invocations (parallel worktree sessions), and
+  # a shared /tmp/pre-push-audit.out let one process's rm -f race another's
+  # still-in-flight `cat`, corrupting/blanking the error output it prints.
+  local AUDIT_OUT="/tmp/pre-push-audit.$$.$RANDOM.out"
+  if ! node "$script" >"$AUDIT_OUT" 2>&1; then
     echo ""
     echo "=== PRE-PUSH BLOCKED: $label failed ==="
     echo ""
-    cat /tmp/pre-push-audit.out
+    cat "$AUDIT_OUT"
     echo ""
     echo "(Bypass for emergencies: git push --no-verify)"
-    rm -f /tmp/pre-push-audit.out
+    rm -f "$AUDIT_OUT"
     exit 1
   fi
-  rm -f /tmp/pre-push-audit.out
+  rm -f "$AUDIT_OUT"
 }
 
 # Pure-deletion push (every spec was a delete) — nothing to audit.


### PR DESCRIPTION
## Summary
Found via /what-else on #485. `run_audit()` in `scripts/hooks/pre-push` wrote to a fixed `/tmp/pre-push-audit.out`. This repo routinely has many concurrent local `git push` invocations (parallel worktree sessions) — one process's `rm -f` could race another's still-in-flight `cat`, corrupting/blanking the printed error output exactly when a push gets blocked (the moment clear diagnostics matter most).

Fix: scope the temp file per-invocation with `$$.$RANDOM`.

## Test plan
- [x] `bash -n scripts/hooks/pre-push` — syntax OK
- [x] Manually traced both branches (audit pass / audit fail) — logic unchanged, only the filename is now unique per invocation

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>