### PR TITLE
fix(#510): help-flag-safety guard fix for monitor-scheduled-email-count.js

### DIFF
--- a/scripts/monitor-scheduled-email-count.js
+++ b/scripts/monitor-scheduled-email-count.js
@@ -28,7 +28,16 @@
 'use strict';
 
 const https = require('https');
+const { hasHelpFlag } = require('./lib/cli-help.js');
 const { buildDailyReport, decideDayViolation, dayKeyET } = require('./lib/scheduled-email-count-rules');
+
+const USAGE = `Usage: node scripts/monitor-scheduled-email-count.js [--dry-run] [--days=N]
+
+  --dry-run   report the last 7 days (or --days=N), no alert, exit 0
+  --days=N    override the lookback window (default: 7 with --dry-run, 2 live)
+
+Live mode (no flags) checks the last complete ET day and calls routeAlert()
+when 2+ distinct scheduled digest senders fired. Env: RESEND_API_KEY, OWNER_EMAIL.`;
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const daysArg = process.argv.find((a) => a.startsWith('--days='));
@@ -104,6 +113,10 @@ async function fetchOwnerEmailsSince(sinceMs) {
 }
 
 async function main() {
+  // --help/-h checked BEFORE any network work (cousin of #260/#263/#264/#266
+  // — see scripts/lib/cli-help.js).
+  if (hasHelpFlag(process.argv.slice(2))) { console.log(USAGE); return; }
+
   if (!RESEND_API_KEY || !OWNER_EMAIL) {
     console.error('ERROR: RESEND_API_KEY and OWNER_EMAIL must both be set');
     process.exit(1);


### PR DESCRIPTION
## Summary
PR #487 (card #510) merged the scheduled-email-count monitor, but CI's Test Suite caught a real gap post-merge: the `Lint Workflows` job's help-flag-safety guard (card #498) correctly flagged `scripts/monitor-scheduled-email-count.js` — it takes CLI args and makes a real network call (Resend `GET /emails`) with no `--help`/`-h` check anywhere.

Fixed by checking `hasHelpFlag(argv)` as the first statement inside `main()`, matching the established pattern (`collect-review-texts.js` etc.) — the guard's ordering check is windowed to start at `main()`, so a check placed at module scope (my first attempt) didn't satisfy it.

## Test plan
- [x] `node scripts/monitor-scheduled-email-count.js --help` prints usage and exits 0
- [x] `node scripts/audit-help-flag-safety.js` — 0 violations (was 1)
- [x] `node --test scripts/lib/scheduled-email-count-rules.test.mjs` — 7/7 pass
- [x] `node scripts/lint-resend-calls.js`, `node scripts/audit-cron-health-coverage.js` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>