### PR TITLE
backup: land R2 cold-backup workflow (disk + alerting + monitoring fixes)

### DIFF
--- a/.github/workflows/check-cron-health.yml
+++ b/.github/workflows/check-cron-health.yml
@@ -30,6 +30,13 @@ jobs:
             "opening-night-broadcast.yml|36|Opening Night Broadcast"
             "monitor-gate-ab.yml|184|Weekly A/B Monitors"
             "check-flag-parity.yml|184|Check Flag Parity"
+            # Sunday 06:00 UTC weekly offsite backup. CRITICAL, not digest-only: this is
+            # the ONLY point-in-time recovery that exists. The 3 GitLab mirrors are
+            # replicas, not backups — each does clone --mirror then push --force every
+            # 6h, so destructive changes propagate to them within 6 hours. A backup cron
+            # that silently stops is undetectable until the day you need it.
+            # 184h = weekly cadence + 16h cron-lag cushion.
+            "r2-cold-backup.yml|184|R2 Cold Backup"
             # Monday 07:00 UTC weekly full-history secret scan. Deliberately CRITICAL
             # rather than digest-only: this workflow exists BECAUSE a live Buffer token
             # sat in the public repo ~4 months with nothing scanning for it. A secret

--- a/.github/workflows/r2-cold-backup.yml
+++ b/.github/workflows/r2-cold-backup.yml
@@ -1,0 +1,120 @@
+name: R2 Cold Backup
+
+on:
+  schedule:
+    - cron: '0 6 * * 0'  # Sundays at 6 AM UTC
+  workflow_dispatch:
+
+concurrency:
+  group: r2-cold-backup
+  cancel-in-progress: false
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.BACKUP_R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.BACKUP_R2_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
+      R2_ENDPOINT: https://${{ secrets.BACKUP_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+      R2_BUCKET: ${{ secrets.BACKUP_R2_BUCKET }}
+      GPG_PASSPHRASE: ${{ secrets.BACKUP_GPG_PASSPHRASE }}
+      GH_PAT: ${{ secrets.REVIEW_TEXTS_TOKEN }}
+    steps:
+      - name: Set backup date
+        id: date
+        run: echo "stamp=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Validate required secrets present
+        run: |
+          missing=0
+          for v in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY R2_BUCKET GPG_PASSPHRASE GH_PAT; do
+            if [ -z "${!v}" ]; then
+              echo "::error::Missing required secret: $v"
+              missing=1
+            fi
+          done
+          if [ -z "${{ secrets.BACKUP_R2_ACCOUNT_ID }}" ]; then
+            echo "::error::Missing required secret: BACKUP_R2_ACCOUNT_ID"
+            missing=1
+          fi
+          [ "$missing" -eq 0 ]
+
+      - name: Bundle Broadwayscore (web)
+        run: |
+          git clone --mirror "https://x-access-token:${GH_PAT}@github.com/thomaspryor/Broadwayscore.git" web.git
+          git -C web.git bundle create ../broadwayscore-web.bundle --all
+          git -C web.git bundle verify ../broadwayscore-web.bundle
+          rm -rf web.git   # free the mirror immediately; runner disk is ~14GB and the 3 mirrors alone are ~4.5GB
+          ls -lh broadwayscore-web.bundle
+          df -h / | tail -1
+
+      - name: Bundle broadway-review-texts
+        run: |
+          git clone --mirror "https://x-access-token:${GH_PAT}@github.com/thomaspryor/broadway-review-texts.git" texts.git
+          git -C texts.git bundle create ../broadway-review-texts.bundle --all
+          git -C texts.git bundle verify ../broadway-review-texts.bundle
+          rm -rf texts.git   # free the mirror immediately; runner disk is ~14GB and the 3 mirrors alone are ~4.5GB
+          ls -lh broadway-review-texts.bundle
+          df -h / | tail -1
+
+      - name: Bundle broadway-scorecard-data
+        run: |
+          git clone --mirror "https://x-access-token:${GH_PAT}@github.com/thomaspryor/broadway-scorecard-data.git" data.git
+          git -C data.git bundle create ../broadway-scorecard-data.bundle --all
+          git -C data.git bundle verify ../broadway-scorecard-data.bundle
+          rm -rf data.git   # free the mirror immediately; runner disk is ~14GB and the 3 mirrors alone are ~4.5GB
+          ls -lh broadway-scorecard-data.bundle
+          df -h / | tail -1
+
+      - name: Encrypt bundles (GPG symmetric, AES256)
+        run: |
+          for f in broadwayscore-web broadway-review-texts broadway-scorecard-data; do
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" \
+              --cipher-algo AES256 --symmetric \
+              --output "${f}.bundle.gpg" "${f}.bundle"
+            rm -f "${f}.bundle"
+          done
+          ls -lh *.bundle.gpg
+
+      - name: Compute checksums
+        run: |
+          sha256sum *.bundle.gpg > MANIFEST.sha256
+          cat MANIFEST.sha256
+
+      - name: Upload to Cloudflare R2
+        run: |
+          STAMP="${{ steps.date.outputs.stamp }}"
+          PREFIX="weekly/${STAMP}"
+          for f in *.bundle.gpg MANIFEST.sha256; do
+            aws s3 cp "$f" "s3://${R2_BUCKET}/${PREFIX}/$f" --endpoint-url "$R2_ENDPOINT"
+          done
+          aws s3 cp "MANIFEST.sha256" "s3://${R2_BUCKET}/latest/MANIFEST.sha256" --endpoint-url "$R2_ENDPOINT"
+          echo "Uploaded to s3://${R2_BUCKET}/${PREFIX}/"
+
+      - name: Verify upload by listing
+        run: |
+          STAMP="${{ steps.date.outputs.stamp }}"
+          aws s3 ls "s3://${R2_BUCKET}/weekly/${STAMP}/" --endpoint-url "$R2_ENDPOINT" --human-readable --summarize
+
+      - name: Checkout for notify action
+        if: failure()
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            .github/actions/notify-failure
+            scripts/lib/discord-notify.js
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure
+        with:
+          title: 'R2 Cold Backup Failed'
+          # critical (not warning): notify-failure is a NO-OP for non-critical severities,
+          # so a warning-level backup failure would surface only in the daily digest.
+          # A backup you don't know is broken is not a backup.
+          severity: 'critical'
+          email: 'true'
+          resend_api_key: ${{ secrets.RESEND_API_KEY }}
+          owner_email: ${{ secrets.OWNER_EMAIL }}


### PR DESCRIPTION
Lands the R2 cold-backup workflow recovered from the stranded `worktree-r2-cold-backup` branch, with three defects fixed first.

**Context:** the 3 GitLab mirror workflows are **replicas, not backups** — each does `git clone --mirror` then `git push --force` every 6 hours, explicitly unprotecting the branch. Destructive changes propagate to them within 6h. There is currently **no point-in-time recovery anywhere**, and a force-push incident of exactly this class already occurred (task #208).

## Fixes applied before landing

1. **Disk exhaustion.** The 3 mirrors total ~4.5GB and were never removed after bundling. Mirrors + bundles + encrypted copies would peak ~13.5GB on a ~14GB runner. Each mirror is now `rm -rf`'d as soon as its bundle verifies, with `df -h` logged per step.
2. **Silent failure.** `severity: warning` — but `notify-failure` is a documented no-op for non-critical severities, so a failed backup would only have appeared in the daily digest. Now `critical` + `email: true`.
3. **No staleness monitoring.** Registered in `check-cron-health` CRITICAL_CRONS at 184h. A backup cron that silently stops is undetectable until the day you need it.

## Safe to land before setup

The `Validate required secrets present` step fails fast if any `BACKUP_R2_*` secret is missing, so merging this before the Cloudflare bucket exists cannot do damage — the scheduled run just errors cleanly.

## Verified
`actionlint`, YAML parse, `audit-cron-health-coverage.js` (0 uncovered, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)