### PR TITLE
fix: opening-night babysitter runs headless (card #650) + ship-check follow-ups

### DIFF
--- a/scripts/opening-night-monitor-launch.js
+++ b/scripts/opening-night-monitor-launch.js
@@ -378,7 +378,16 @@ async function main(argv = process.argv.slice(2)) {
     // it for THIS spawned process only (falsy, so claude's own has-a-key
     // check falls through to the stored login) without touching process.env
     // for anything else in this run that reads it (e.g. preflightAuth).
-    env: { ANTHROPIC_API_KEY: '' },
+    // RESEND_API_KEY/OWNER_EMAIL are forwarded explicitly: strippedEnv's
+    // fixed allowlist (PATH/HOME/TERM/LANG/LC_ALL/ANTHROPIC_API_KEY/
+    // CLAUDE_CODE_OAUTH_TOKEN) does not include them, so without this the
+    // in-pass session's own parity/escalation report (monitor-v2.md step 2-3,
+    // routeAlert via owner-alert-router.js) would silently no-op inside the
+    // spawned child every time — the exact "RESEND_API_KEY or OWNER_EMAIL not
+    // set, skipping email alert" failure this session's #457 fix (commit
+    // 288e31efd69) already fixed for the LAUNCHER's own alerts, but never
+    // extended to the pass it launches.
+    env: { ANTHROPIC_API_KEY: '', RESEND_API_KEY: process.env.RESEND_API_KEY || '', OWNER_EMAIL: process.env.OWNER_EMAIL || '' },
     logFile: path.join(MON_DIR, `session-log-${key}-a${attemptNum}.log`),
   });
 

--- a/tests/unit/opening-night-monitor-launch.test.mjs
+++ b/tests/unit/opening-night-monitor-launch.test.mjs
@@ -79,8 +79,24 @@ test('usdTonight accumulates across passes on both the success and failure write
 // the whole file).
 test('the headless pass explicitly clears ANTHROPIC_API_KEY so it bills the subscription login, not the API key', () => {
   const src = readFileSync(new URL('../../scripts/opening-night-monitor-launch.js', import.meta.url), 'utf8');
-  const callBlock = src.slice(src.indexOf('const result = await runMonitorPass({'), src.indexOf('const result = await runMonitorPass({') + 800);
-  assert.match(callBlock, /env:\s*\{\s*ANTHROPIC_API_KEY:\s*['"]{2}\s*\}/, 'runMonitorPass must be called with env: { ANTHROPIC_API_KEY: \'\' } to clear the leaked .env key for this spawn only');
+  const callStart = src.indexOf('const result = await runMonitorPass({');
+  const callBlock = src.slice(callStart, src.indexOf('logFile:', callStart) + 100);
+  assert.match(callBlock, /ANTHROPIC_API_KEY:\s*['"]{2}/, 'runMonitorPass must clear ANTHROPIC_API_KEY (empty string) to avoid the leaked .env key for this spawn only');
+});
+
+// monitor-v2.md instructs the IN-PASS session to send its own parity/
+// escalation report via routeAlert (owner-alert-router.js), which needs
+// RESEND_API_KEY/OWNER_EMAIL. strippedEnv's fixed allowlist in claude-cli.js
+// does not include either, so without explicit forwarding here the report
+// would silently no-op inside the spawned child on every real opening night
+// — the exact failure class #457 already fixed for the launcher's own
+// alerts (commit 288e31efd69), but not yet for the pass it launches.
+test('the headless pass forwards RESEND_API_KEY and OWNER_EMAIL so the in-pass report email can send', () => {
+  const src = readFileSync(new URL('../../scripts/opening-night-monitor-launch.js', import.meta.url), 'utf8');
+  const callStart = src.indexOf('const result = await runMonitorPass({');
+  const callBlock = src.slice(callStart, src.indexOf('logFile:', callStart) + 100);
+  assert.match(callBlock, /RESEND_API_KEY:\s*process\.env\.RESEND_API_KEY/, 'runMonitorPass must forward RESEND_API_KEY from the launcher process into the spawned child');
+  assert.match(callBlock, /OWNER_EMAIL:\s*process\.env\.OWNER_EMAIL/, 'runMonitorPass must forward OWNER_EMAIL from the launcher process into the spawned child');
 });
 
 // Card #568: LOCK_DIR is the atomic test-and-set (mkdir, before the launch


### PR DESCRIPTION
## Summary
- cmux refused connections from launchd-parented process ancestry — the babysitter never launched a session in 344 ticks. Runs headless via claude-cli.js instead.
- Ship-check follow-ups: restore nightly $ spend cap (consecutiveFailures redesign had silently dropped it), clear leaked ANTHROPIC_API_KEY from the spawned pass, forward RESEND_API_KEY/OWNER_EMAIL so the in-pass report email can actually send.

## Test plan
- [x] `node --test scripts/lib/opening-night-monitor.test.mjs scripts/lib/opening-night-windows.test.mjs tests/unit/opening-night-monitor-launch.test.mjs` — 45/45 pass
- [x] Live-verified: launchd tick fired post-deploy with no cmux "Access denied"/"Broken pipe" errors

🤖 Generated with Claude Code