### PR TITLE
fix: add --help safety check to verify-merge-landed.js

### DIFF
--- a/scripts/verify-merge-landed.js
+++ b/scripts/verify-merge-landed.js
@@ -32,6 +32,14 @@
 'use strict';
 
 const { execFileSync } = require('child_process');
+const { hasHelpFlag } = require('./lib/cli-help.js');
+
+const USAGE = `Usage: verify-merge-landed.js --sha=<sha> --branch=<branch> [--label=<label>] [--delays=<sec,sec,...>]
+
+Delayed re-check that a merge pushed by merge-worktree-to-main.sh is still
+reachable from origin's tip minutes later (task #668). Intended to be
+launched fire-and-forget right after a successful push+verify; see the file
+header for the full incident context.`;
 
 function sh(cmd, args) {
   return execFileSync(cmd, args, { encoding: 'utf8' }).trim();
@@ -103,6 +111,7 @@ async function fileAlert(repoInfo, sha, branch, label, status) {
 }
 
 async function main() {
+  if (hasHelpFlag(process.argv.slice(2))) { console.log(USAGE); return; }
   const args = parseArgs(process.argv.slice(2));
   const sha = args.sha;
   const branch = args.branch || 'main';


### PR DESCRIPTION
## Summary
- \`scripts/verify-merge-landed.js\` (task #668, landed earlier tonight) was missing the repo's \`hasHelpFlag\` guard — tripping \`audit-help-flag-safety.js\` and reddening main's Lint Workflows job.
- Not part of card #650, but blocking the same shared main this session's own merge (PR #498) landed on; fixed opportunistically per the established pattern (task #498).

## Test plan
- [x] \`node scripts/verify-merge-landed.js --help\` prints usage, exits clean
- [x] \`node scripts/audit-help-flag-safety.js\` — 0 violations (794 scripts checked)

🤖 Generated with Claude Code