### PR TITLE
fix(ci): design-token lint red — UNKNOWN_FORMAT used border-gray-500

### DIFF
--- a/scripts/lib/show-format.js
+++ b/scripts/lib/show-format.js
@@ -56,7 +56,7 @@ const SHOW_FORMATS = {
 const UNKNOWN_FORMAT = {
   label: 'EVENT',
   title: 'Event',
-  colorClass: 'border-gray-500/50 text-gray-400',
+  colorClass: 'border-white/10 text-gray-400',
   textClass: 'text-gray-400',
   emailColor: '#9ca3af',
 };

--- a/src/lib/show-format.ts
+++ b/src/lib/show-format.ts
@@ -90,7 +90,7 @@ export const SHOW_FORMATS: Record<ShowType, ShowFormat> = {
 const UNKNOWN_FORMAT: ShowFormat = {
   label: 'EVENT',
   title: 'Event',
-  colorClass: 'border-gray-500/50 text-gray-400',
+  colorClass: 'border-white/10 text-gray-400',
   textClass: 'text-gray-400',
   emailColor: '#9ca3af',
 };

--- a/tests/unit/show-format-coverage.test.mjs
+++ b/tests/unit/show-format-coverage.test.mjs
@@ -72,6 +72,27 @@ function parseTsFormats() {
   return map;
 }
 
+// UNKNOWN_FORMAT lives outside SHOW_FORMATS, so the map-parity test below never
+// sees it. Parse it separately — otherwise a one-sided edit to the fallback
+// drifts silently, which is exactly how `border-gray-500/50` survived in one
+// copy after the design-token lint forced it out of the other.
+function parseTsUnknown() {
+  const body = tsSource.split('const UNKNOWN_FORMAT')[1];
+  assert.ok(body, 'UNKNOWN_FORMAT not found in src/lib/show-format.ts');
+  const fields = body.split('};')[0];
+  const grab = (name) => {
+    const f = new RegExp(`${name}:\\s*'([^']*)'`).exec(fields);
+    return f ? f[1] : undefined;
+  };
+  return {
+    label: grab('label'),
+    title: grab('title'),
+    colorClass: grab('colorClass'),
+    textClass: grab('textClass'),
+    emailColor: grab('emailColor'),
+  };
+}
+
 const SHOWS_PATH = path.join(REPO, 'data/shows.json');
 
 // data/shows.json is private core data (CLAUDE.md §11): present in CI and the
@@ -173,6 +194,18 @@ describe('show-format parity between src/ and scripts/', () => {
         `UNKNOWN_FORMAT is missing "${field}" — resolveShowFormat(unknown).${field} is undefined`
       );
     }
+  });
+
+  it('the unknown-input fallback matches VALUE-for-value across the two copies', () => {
+    // Presence is not parity: the sibling test above only asserts each declared
+    // field is defined. This one catches a changed value in one copy only.
+    const ts = parseTsUnknown();
+    assert.ok(ts.label, 'failed to parse UNKNOWN_FORMAT from the TS source');
+    assert.deepStrictEqual(
+      ts,
+      js.resolveShowFormat('a-type-that-does-not-exist'),
+      'UNKNOWN_FORMAT differs between src/lib/show-format.ts and scripts/lib/show-format.js'
+    );
   });
 
   it('the TS and JS maps define the same format keys', () => {


### PR DESCRIPTION
Test Suite went red on `5d8d6cf35` from a single design-token violation I introduced: the show-format consolidation shipped `border-gray-500/50` in the UNKNOWN_FORMAT fallback, which trips `lint-design-tokens.js [border-neutral]`. It was the only violation across 462 files.

Swapped to `border-white/10` in **both** copies (`src/lib/show-format.ts` and `scripts/lib/show-format.js`).

## Prevention
The existing parity test deep-compared `SHOW_FORMATS` entries but only checked `UNKNOWN_FORMAT` for **field presence**, not value equality — so a one-sided edit to the fallback drifted silently. That is the same hole that let `textClass` drift earlier. Added a value-for-value parity test (`parseTsUnknown`).

Negative-controlled: drifting the JS copy alone produces exactly `fail 1`; restoring returns 11/11.

## Verification
- `node scripts/lint-design-tokens.js` → clean, 462 files
- `node --test tests/unit/show-format-coverage.test.mjs` → 11/11 pass, 0 skipped
- `npx tsc --noEmit` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)