### PR TITLE
images: coverage from files not directory existence (+3 P0 review fixes)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,14 @@ on:
       - 'scripts/lib/verify-image-prompt.test.mjs'
       - 'scripts/lib/image-audit-action.js'
       - 'scripts/lib/image-audit-action.test.mjs'
+      # Coverage is decided from FILES, not directory existence: the fetcher
+      # mkdir's <id>/ before verification, so a failed fetch leaves an empty dir
+      # that existence-based readers counted as art (2026-08-02).
+      - 'scripts/lib/show-image-coverage.js'
+      - 'scripts/lib/show-image-coverage.test.mjs'
       - 'scripts/fetch-show-images-auto.js'
       - 'scripts/audit-images-llm.js'
+      - 'scripts/process-feedback.js'
       # Diacritic folding across every show-title matcher (task #648). A matcher
       # that strips non-ASCII without folding first shreds "Les Misérables" into
       # ["les","mis","rables"] and matches nothing — confirmed live suppression.

--- a/scripts/fetch-show-images-auto.js
+++ b/scripts/fetch-show-images-auto.js
@@ -31,6 +31,7 @@ const { loadShows, saveShows } = require('./lib/shows-write-guard');
 const { getMarketSearchKeyword } = require('./lib/market-label');
 const { imageOnDisk, isPlaceholderFile, PLACEHOLDER_FILE_HASHES } = require('./lib/show-images');
 const { resolveMarketSlug } = require('./lib/verify-image');
+const { pruneEmptyShowImageDir } = require('./lib/show-image-coverage');
 const { hasHelpFlag } = require('./lib/cli-help.js');
 const scraper = require('./lib/scraper');
 const { fetchPage, checkScrapingBeeCredits } = scraper;
@@ -2836,6 +2837,31 @@ async function main() {
     fs.writeFileSync(reportPath, JSON.stringify(report, null, 2) + '\n');
     console.log(`\nDry-run report: ${reportPath}`);
     generateComparisonPage(dryRunResults);
+  }
+
+  // Several fetch paths mkdir public/images/shows/<id>/ BEFORE they know whether
+  // any candidate will verify, so a show whose candidates are all rejected is
+  // left with an EMPTY directory. Every downstream "has this show got art?"
+  // reader used directory existence, so those empty dirs made imageless shows
+  // read as covered and vanish from the missing cohort — that is how a show
+  // reaches the live homepage showing "Images coming soon". Sweep them here so
+  // the cleanup covers every failure path, present and future, rather than
+  // being threaded through each mkdir site individually.
+  const prunedDirs = [];
+  for (const root of [IMAGES_DIR, DRY_RUN_DIR]) {
+    let names;
+    try {
+      names = fs.readdirSync(root, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const d of names) {
+      if (!d.isDirectory()) continue;
+      if (pruneEmptyShowImageDir(path.join(root, d.name))) prunedDirs.push(d.name);
+    }
+  }
+  if (prunedDirs.length > 0) {
+    console.log(`\n🧹 Removed ${prunedDirs.length} empty image dir(s) left by failed fetches (they would have read as coverage): ${prunedDirs.join(', ')}`);
   }
 
   // Summary

--- a/scripts/fetch-show-images-auto.js
+++ b/scripts/fetch-show-images-auto.js
@@ -2287,6 +2287,30 @@ async function processOneShow(show, apiLookup, todayTixIds, badImagesOnly, verif
 
   // Fetch images: API data → page scrape → IBDB → Google Images → Playbill fallback
   const images = await fetchShowImages(show, todayTixInfo, apiData, verifyCtx);
+
+  // Several source paths mkdir <outputBase>/<id>/ BEFORE they know whether any
+  // candidate will verify (fetchFromGoogleImages, the regional-venue path, …),
+  // so a show whose candidates are ALL rejected is left with an EMPTY directory.
+  // Coverage readers that keyed off directory existence then counted the show as
+  // having art and dropped it from the imageless cohort — that is how a show
+  // reaches the live homepage showing "Images coming soon" (Brainiac Live; The
+  // Gin Game before it).
+  //
+  // Pruned HERE, the single point every caller funnels through, rather than at
+  // end-of-run: a --show=<id> run and the concurrent-batch run take different
+  // paths, and an end-of-run sweep is also skipped by early returns,
+  // process.exit, and timeouts — the exact failure cases it exists for.
+  // Scoped to THIS show (never a sweep of all ~2,800 dirs, which would race a
+  // concurrent fetch mid-write), and pruneEmptyShowImageDir uses rmdir, which
+  // refuses the instant anything is inside — so even a lost race can only
+  // remove a directory holding nothing.
+  if (!images) {
+    const outputBase = dryRunMode ? DRY_RUN_DIR : IMAGES_DIR;
+    if (pruneEmptyShowImageDir(path.join(outputBase, show.id))) {
+      console.log(`   🧹 removed empty image dir for ${show.id} (would otherwise read as coverage)`);
+    }
+  }
+
   return { show, images, apiSourced: !!apiData };
 }
 
@@ -2837,31 +2861,6 @@ async function main() {
     fs.writeFileSync(reportPath, JSON.stringify(report, null, 2) + '\n');
     console.log(`\nDry-run report: ${reportPath}`);
     generateComparisonPage(dryRunResults);
-  }
-
-  // Several fetch paths mkdir public/images/shows/<id>/ BEFORE they know whether
-  // any candidate will verify, so a show whose candidates are all rejected is
-  // left with an EMPTY directory. Every downstream "has this show got art?"
-  // reader used directory existence, so those empty dirs made imageless shows
-  // read as covered and vanish from the missing cohort — that is how a show
-  // reaches the live homepage showing "Images coming soon". Sweep them here so
-  // the cleanup covers every failure path, present and future, rather than
-  // being threaded through each mkdir site individually.
-  const prunedDirs = [];
-  for (const root of [IMAGES_DIR, DRY_RUN_DIR]) {
-    let names;
-    try {
-      names = fs.readdirSync(root, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const d of names) {
-      if (!d.isDirectory()) continue;
-      if (pruneEmptyShowImageDir(path.join(root, d.name))) prunedDirs.push(d.name);
-    }
-  }
-  if (prunedDirs.length > 0) {
-    console.log(`\n🧹 Removed ${prunedDirs.length} empty image dir(s) left by failed fetches (they would have read as coverage): ${prunedDirs.join(', ')}`);
   }
 
   // Summary

--- a/scripts/lib/show-image-coverage.js
+++ b/scripts/lib/show-image-coverage.js
@@ -19,11 +19,11 @@ const fs = require('fs');
 const path = require('path');
 
 // The archiver writes .webp; historical archives may still hold the source
-// format. Anything else in the directory (.json sidecars, .DS_Store) is NOT
-// key art and must not count as coverage.
+// format. Anything else in the directory (.json sidecars, .DS_Store, partial
+// .tmp downloads) is NOT key art and must not count as coverage.
 const IMAGE_EXTENSIONS = new Set(['.webp', '.jpg', '.jpeg', '.png', '.avif', '.gif']);
 
-function isImageFile(name) {
+function hasImageExtension(name) {
   return IMAGE_EXTENSIONS.has(path.extname(name).toLowerCase());
 }
 
@@ -32,17 +32,21 @@ function isImageFile(name) {
  * A missing directory and an empty/junk-only directory are both false — the
  * distinction the old existsSync check could not make.
  *
+ * Requires a REGULAR file: a directory or dangling symlink named "poster.webp"
+ * is not key art, and treating it as such would both misreport coverage and
+ * (worse) protect a junk directory from cleanup.
+ *
  * @param {string} showDir absolute or relative path to public/images/shows/<id>
  * @returns {boolean}
  */
 function dirHasImageFiles(showDir) {
   let entries;
   try {
-    entries = fs.readdirSync(showDir);
+    entries = fs.readdirSync(showDir, { withFileTypes: true });
   } catch {
     return false; // missing, or unreadable — either way, no proven coverage
   }
-  return entries.some(isImageFile);
+  return entries.some((e) => e.isFile() && hasImageExtension(e.name));
 }
 
 /**
@@ -59,16 +63,20 @@ function hasArchivedShowImages(imagesRoot, showId) {
  * Set of show ids under imagesRoot that have at least one real image file.
  * Replaces `new Set(fs.readdirSync(imagesRoot))`, which counted empty dirs.
  *
+ * THROWS if imagesRoot itself is unreadable. That is deliberate: callers use
+ * this to compute "which shows are MISSING art", so degrading to an empty set
+ * would declare the entire catalogue imageless. Callers already distinguish
+ * "unknown" (null) from "known missing" — let their catch keep that distinction
+ * rather than manufacturing a confident wrong answer here.
+ * Per-show-directory read errors are still tolerated (that show reads as
+ * uncovered, which is the safe direction for one show).
+ *
  * @param {string} imagesRoot path to public/images/shows
  * @returns {Set<string>}
+ * @throws if imagesRoot cannot be read
  */
 function listShowIdsWithImages(imagesRoot) {
-  let dirents;
-  try {
-    dirents = fs.readdirSync(imagesRoot, { withFileTypes: true });
-  } catch {
-    return new Set();
-  }
+  const dirents = fs.readdirSync(imagesRoot, { withFileTypes: true });
   const covered = new Set();
   for (const d of dirents) {
     if (!d.isDirectory()) continue;
@@ -78,26 +86,30 @@ function listShowIdsWithImages(imagesRoot) {
 }
 
 /**
- * Remove a show's image directory if it holds no image files. Called on the
+ * Remove a show's image directory ONLY if it is completely empty. Called on the
  * failure path of a fetch so a rejected show does not leave behind a directory
- * that later reads as coverage. Never removes a directory holding real art.
+ * that later reads as coverage.
+ *
+ * Deliberately NOT recursive, and deliberately not "no image files" —
+ * `fs.rmdirSync` fails on a non-empty directory, which is the safety property
+ * we want. A dir holding real art, a nested originals/ folder, a sidecar, or a
+ * partially-written .tmp download is left strictly alone. The only thing that
+ * can be removed is a directory with zero entries, which carries no data and
+ * only ever misleads coverage readers.
+ *
+ * (An unlink-then-rmdir variant would be a TOCTOU hazard: a concurrent fetch
+ * could create the file between our listing and our delete. rmdir is atomic
+ * against exactly that — it refuses the moment anything is inside.)
  *
  * @param {string} showDir
  * @returns {boolean} true if a directory was removed
  */
 function pruneEmptyShowImageDir(showDir) {
-  let entries;
   try {
-    entries = fs.readdirSync(showDir);
-  } catch {
-    return false; // nothing there to prune
-  }
-  if (entries.some(isImageFile)) return false; // real art — leave it alone
-  try {
-    fs.rmSync(showDir, { recursive: true, force: true });
+    fs.rmdirSync(showDir); // throws ENOTEMPTY if anything at all is inside
     return true;
   } catch {
-    return false;
+    return false; // non-empty, missing, or not removable — all fine to skip
   }
 }
 

--- a/scripts/lib/show-image-coverage.js
+++ b/scripts/lib/show-image-coverage.js
@@ -1,0 +1,109 @@
+/**
+ * show-image-coverage.js
+ *
+ * Single answer to "does this show actually have archived key art?"
+ *
+ * WHY THIS EXISTS (2026-08-02):
+ * Coverage was decided by directory EXISTENCE — `public/images/shows/<id>/`.
+ * But fetch-show-images-auto.js mkdir's that directory BEFORE it knows whether
+ * any candidate will pass verification, so a show whose every candidate is
+ * rejected is left with an empty directory. Every existence-based reader then
+ * reports the show as covered, and it is silently dropped from the imageless
+ * cohort — which is exactly how imageless shows reach the live homepage showing
+ * "Images coming soon" (Brainiac Live, The Gin Game).
+ *
+ * Directory existence is a claim. A file on disk is evidence. Read the files.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// The archiver writes .webp; historical archives may still hold the source
+// format. Anything else in the directory (.json sidecars, .DS_Store) is NOT
+// key art and must not count as coverage.
+const IMAGE_EXTENSIONS = new Set(['.webp', '.jpg', '.jpeg', '.png', '.avif', '.gif']);
+
+function isImageFile(name) {
+  return IMAGE_EXTENSIONS.has(path.extname(name).toLowerCase());
+}
+
+/**
+ * True when showDir holds at least one real image file.
+ * A missing directory and an empty/junk-only directory are both false — the
+ * distinction the old existsSync check could not make.
+ *
+ * @param {string} showDir absolute or relative path to public/images/shows/<id>
+ * @returns {boolean}
+ */
+function dirHasImageFiles(showDir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(showDir);
+  } catch {
+    return false; // missing, or unreadable — either way, no proven coverage
+  }
+  return entries.some(isImageFile);
+}
+
+/**
+ * @param {string} imagesRoot path to public/images/shows
+ * @param {string} showId
+ * @returns {boolean}
+ */
+function hasArchivedShowImages(imagesRoot, showId) {
+  if (!showId) return false;
+  return dirHasImageFiles(path.join(imagesRoot, showId));
+}
+
+/**
+ * Set of show ids under imagesRoot that have at least one real image file.
+ * Replaces `new Set(fs.readdirSync(imagesRoot))`, which counted empty dirs.
+ *
+ * @param {string} imagesRoot path to public/images/shows
+ * @returns {Set<string>}
+ */
+function listShowIdsWithImages(imagesRoot) {
+  let dirents;
+  try {
+    dirents = fs.readdirSync(imagesRoot, { withFileTypes: true });
+  } catch {
+    return new Set();
+  }
+  const covered = new Set();
+  for (const d of dirents) {
+    if (!d.isDirectory()) continue;
+    if (dirHasImageFiles(path.join(imagesRoot, d.name))) covered.add(d.name);
+  }
+  return covered;
+}
+
+/**
+ * Remove a show's image directory if it holds no image files. Called on the
+ * failure path of a fetch so a rejected show does not leave behind a directory
+ * that later reads as coverage. Never removes a directory holding real art.
+ *
+ * @param {string} showDir
+ * @returns {boolean} true if a directory was removed
+ */
+function pruneEmptyShowImageDir(showDir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(showDir);
+  } catch {
+    return false; // nothing there to prune
+  }
+  if (entries.some(isImageFile)) return false; // real art — leave it alone
+  try {
+    fs.rmSync(showDir, { recursive: true, force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = {
+  hasArchivedShowImages,
+  listShowIdsWithImages,
+  pruneEmptyShowImageDir,
+  dirHasImageFiles,
+};

--- a/scripts/lib/show-image-coverage.test.mjs
+++ b/scripts/lib/show-image-coverage.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * show-image-coverage.test.mjs
+ *
+ * Locks down the empty-directory coverage blind spot (2026-08-02).
+ *
+ * fetch-show-images-auto.js mkdir's public/images/shows/<id>/ before it knows
+ * whether any candidate will pass verification. A show whose candidates are all
+ * rejected therefore leaves an EMPTY directory behind. Readers that decided
+ * coverage from directory existence — process-feedback.js's content router did —
+ * then counted that show as having art and dropped it from the imageless cohort.
+ * That is how an imageless show reaches the live homepage showing "Images coming
+ * soon" (Brainiac Live at the Garrick; The Gin Game before it).
+ *
+ * These assert on the REAL exported functions, against real directories on disk.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  hasArchivedShowImages,
+  listShowIdsWithImages,
+  pruneEmptyShowImageDir,
+  dirHasImageFiles,
+} = require('./show-image-coverage.js');
+
+function makeRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'img-coverage-'));
+}
+function seed(root, showId, files) {
+  const dir = path.join(root, showId);
+  fs.mkdirSync(dir, { recursive: true });
+  for (const f of files) fs.writeFileSync(path.join(dir, f), 'x');
+  return dir;
+}
+
+test('an EMPTY show dir is NOT coverage (the whole bug)', () => {
+  const root = makeRoot();
+  seed(root, 'brainiac-live-west-end-2026', []); // failed fetch left the dir
+  assert.equal(hasArchivedShowImages(root, 'brainiac-live-west-end-2026'), false);
+  // existsSync would have said true — that is precisely the regression.
+  assert.equal(fs.existsSync(path.join(root, 'brainiac-live-west-end-2026')), true);
+});
+
+test('a dir holding real art IS coverage', () => {
+  const root = makeRoot();
+  seed(root, 'hamilton', ['poster.webp', 'thumbnail.webp', 'hero.webp']);
+  assert.equal(hasArchivedShowImages(root, 'hamilton'), true);
+});
+
+test('a missing dir is not coverage, and does not throw', () => {
+  const root = makeRoot();
+  assert.equal(hasArchivedShowImages(root, 'never-fetched'), false);
+  assert.equal(hasArchivedShowImages(root, ''), false);
+  assert.equal(hasArchivedShowImages(root, undefined), false);
+});
+
+test('non-image junk does not count as coverage', () => {
+  const root = makeRoot();
+  // A sidecar or a macOS turd must not make an imageless show read as covered.
+  seed(root, 'the-holes-off-broadway-2026', ['.DS_Store', 'attempt.json']);
+  assert.equal(hasArchivedShowImages(root, 'the-holes-off-broadway-2026'), false);
+});
+
+test('legacy non-webp archives still count', () => {
+  const root = makeRoot();
+  seed(root, 'old-show', ['thumbnail.jpg']);
+  assert.equal(hasArchivedShowImages(root, 'old-show'), true);
+});
+
+test('listShowIdsWithImages excludes empty dirs — the process-feedback.js fix', () => {
+  const root = makeRoot();
+  seed(root, 'has-art', ['poster.webp']);
+  seed(root, 'empty-after-failed-fetch', []);
+  seed(root, 'junk-only', ['.DS_Store']);
+  const covered = listShowIdsWithImages(root);
+  assert.deepEqual([...covered].sort(), ['has-art']);
+  // The pre-fix implementation was `new Set(fs.readdirSync(root))`, which would
+  // have returned all three. Assert that specific wrong answer is not produced.
+  assert.equal(covered.has('empty-after-failed-fetch'), false);
+  assert.equal(covered.has('junk-only'), false);
+});
+
+test('listShowIdsWithImages on a missing root returns empty, not a throw', () => {
+  assert.equal(listShowIdsWithImages(path.join(makeRoot(), 'nope')).size, 0);
+});
+
+test('pruneEmptyShowImageDir removes an empty dir', () => {
+  const root = makeRoot();
+  const dir = seed(root, 'failed', []);
+  assert.equal(pruneEmptyShowImageDir(dir), true);
+  assert.equal(fs.existsSync(dir), false);
+});
+
+test('pruneEmptyShowImageDir NEVER deletes real key art', () => {
+  const root = makeRoot();
+  const dir = seed(root, 'brainiac-live-west-end-2026', ['poster.webp', 'thumbnail.webp', 'hero.webp']);
+  assert.equal(pruneEmptyShowImageDir(dir), false);
+  assert.equal(fs.existsSync(dir), true);
+  assert.deepEqual(fs.readdirSync(dir).sort(), ['hero.webp', 'poster.webp', 'thumbnail.webp']);
+});
+
+test('pruneEmptyShowImageDir clears a junk-only dir (it is not coverage either)', () => {
+  const root = makeRoot();
+  const dir = seed(root, 'junk', ['.DS_Store']);
+  assert.equal(pruneEmptyShowImageDir(dir), true);
+  assert.equal(fs.existsSync(dir), false);
+});
+
+test('pruneEmptyShowImageDir on a nonexistent path is a no-op, not a throw', () => {
+  assert.equal(pruneEmptyShowImageDir(path.join(makeRoot(), 'nope')), false);
+});
+
+test('dirHasImageFiles is case-insensitive on the extension', () => {
+  const root = makeRoot();
+  const dir = seed(root, 'shouty', ['POSTER.WEBP']);
+  assert.equal(dirHasImageFiles(dir), true);
+});

--- a/scripts/lib/show-image-coverage.test.mjs
+++ b/scripts/lib/show-image-coverage.test.mjs
@@ -86,8 +86,20 @@ test('listShowIdsWithImages excludes empty dirs — the process-feedback.js fix'
   assert.equal(covered.has('junk-only'), false);
 });
 
-test('listShowIdsWithImages on a missing root returns empty, not a throw', () => {
-  assert.equal(listShowIdsWithImages(path.join(makeRoot(), 'nope')).size, 0);
+test('listShowIdsWithImages THROWS on an unreadable root — never a confident empty set', () => {
+  // Returning an empty Set here would make process-feedback.js declare EVERY
+  // show in the catalogue imageless. Its caller keeps showIdsMissingImages null
+  // ("unknown") only because this throws.
+  assert.throws(() => listShowIdsWithImages(path.join(makeRoot(), 'does-not-exist')));
+});
+
+test('one unreadable show dir does not poison the whole listing', () => {
+  const root = makeRoot();
+  seed(root, 'has-art', ['poster.webp']);
+  seed(root, 'empty', []);
+  const covered = listShowIdsWithImages(root);
+  assert.equal(covered.has('has-art'), true);
+  assert.equal(covered.has('empty'), false);
 });
 
 test('pruneEmptyShowImageDir removes an empty dir', () => {
@@ -105,15 +117,47 @@ test('pruneEmptyShowImageDir NEVER deletes real key art', () => {
   assert.deepEqual(fs.readdirSync(dir).sort(), ['hero.webp', 'poster.webp', 'thumbnail.webp']);
 });
 
-test('pruneEmptyShowImageDir clears a junk-only dir (it is not coverage either)', () => {
+test('pruneEmptyShowImageDir leaves a NESTED image folder alone', () => {
+  // Codex P0: a recursive delete would have destroyed originals/ archives.
+  // rmdir refuses a non-empty directory, so nesting is safe by construction.
   const root = makeRoot();
-  const dir = seed(root, 'junk', ['.DS_Store']);
-  assert.equal(pruneEmptyShowImageDir(dir), true);
-  assert.equal(fs.existsSync(dir), false);
+  const dir = path.join(root, 'nested');
+  fs.mkdirSync(path.join(dir, 'originals'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'originals', 'poster.webp'), 'x');
+  assert.equal(pruneEmptyShowImageDir(dir), false);
+  assert.equal(fs.existsSync(path.join(dir, 'originals', 'poster.webp')), true);
+});
+
+test('pruneEmptyShowImageDir leaves an in-flight partial download alone', () => {
+  // A concurrent writer mid-download has a .tmp/partial file in the dir. Even
+  // though that is not coverage, deleting it would corrupt another run.
+  const root = makeRoot();
+  const dir = seed(root, 'downloading', ['poster.webp.tmp']);
+  assert.equal(pruneEmptyShowImageDir(dir), false);
+  assert.equal(fs.existsSync(path.join(dir, 'poster.webp.tmp')), true);
+});
+
+test('a junk-only dir is NOT coverage but is also NOT deleted', () => {
+  // Two separate properties. Coverage must be false (that is the bug fix);
+  // deletion must be false (we do not destroy files we did not write).
+  const root = makeRoot();
+  const dir = seed(root, 'junk', ['.DS_Store', 'attempt.json']);
+  assert.equal(hasArchivedShowImages(root, 'junk'), false);
+  assert.equal(pruneEmptyShowImageDir(dir), false);
+  assert.equal(fs.existsSync(dir), true);
 });
 
 test('pruneEmptyShowImageDir on a nonexistent path is a no-op, not a throw', () => {
   assert.equal(pruneEmptyShowImageDir(path.join(makeRoot(), 'nope')), false);
+});
+
+test('a DIRECTORY named poster.webp is not key art', () => {
+  // Guards the isFile() check: a non-regular entry with an image extension must
+  // not fake coverage (and must not shield a junk dir from cleanup).
+  const root = makeRoot();
+  fs.mkdirSync(path.join(root, 'weird', 'poster.webp'), { recursive: true });
+  assert.equal(hasArchivedShowImages(root, 'weird'), false);
+  assert.equal(listShowIdsWithImages(root).has('weird'), false);
 });
 
 test('dirHasImageFiles is case-insensitive on the extension', () => {

--- a/scripts/process-feedback.js
+++ b/scripts/process-feedback.js
@@ -20,6 +20,7 @@ const { CLAUDE_SONNET } = require('./lib/models');
 const { loadPendingDiagnoses, mergePendingDiagnoses } = require('./lib/pending-diagnoses.js');
 const { buildCategorizationPrompt, parseCategorizedResponse } = require('./lib/feedback-categorize.js');
 const { planContentRequestActions } = require('./lib/content-request-routing.js');
+const { listShowIdsWithImages } = require('./lib/show-image-coverage.js');
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -440,8 +441,13 @@ async function main() {
         );
       }
       try {
-        const dirs = new Set(fs.readdirSync(path.join(__dirname, '../public/images/shows')));
-        showIdsMissingImages = new Set(shows.filter((s) => s && s.id && !dirs.has(s.id)).map((s) => s.id));
+        // Files, not directory names: the fetcher creates <id>/ before it knows
+        // whether any candidate will verify, so a failed show leaves an EMPTY
+        // directory. Counting that as coverage hides the show from this router —
+        // the same blind spot that let Brainiac Live reach the live homepage
+        // with "Images coming soon". See scripts/lib/show-image-coverage.js.
+        const covered = listShowIdsWithImages(path.join(__dirname, '../public/images/shows'));
+        showIdsMissingImages = new Set(shows.filter((s) => s && s.id && !covered.has(s.id)).map((s) => s.id));
       } catch (err) {
         console.error(`Could not read image dirs for content routing: ${err.message}`);
       }

--- a/scripts/process-feedback.js
+++ b/scripts/process-feedback.js
@@ -449,7 +449,12 @@ async function main() {
         const covered = listShowIdsWithImages(path.join(__dirname, '../public/images/shows'));
         showIdsMissingImages = new Set(shows.filter((s) => s && s.id && !covered.has(s.id)).map((s) => s.id));
       } catch (err) {
-        console.error(`Could not read image dirs for content routing: ${err.message}`);
+        // Leaves showIdsMissingImages null = "unknown", which the router turns
+        // into imageAbsenceVerified:null. listShowIdsWithImages THROWS rather
+        // than returning {} on an unreadable root precisely so this stays
+        // unknown — degrading to an empty covered-set would declare every show
+        // in the catalogue imageless.
+        console.error(`Could not read image dirs for content routing: ${err.message} — image absence stays UNVERIFIED for this run.`);
       }
     }
 


### PR DESCRIPTION
Second root cause behind owner-reported "Images coming soon" on live shows.

`fetch-show-images-auto.js` mkdir's `public/images/shows/<id>/` **before** it knows whether any candidate will verify, so a failed fetch leaves an EMPTY directory. `process-feedback.js` decided image coverage with `new Set(fs.readdirSync(imagesRoot))`, so empty dirs counted as art and the show vanished from the imageless cohort — how Brainiac Live (Garrick) and The Gin Game reached the live homepage with no poster.

- `scripts/lib/show-image-coverage.js` (new) — coverage requires a real image FILE
- `process-feedback.js` — uses `listShowIdsWithImages`
- `fetch-show-images-auto.js` — prunes the empty dir inside `processOneShow`, the one point every caller funnels through
- 16 tests, path-listed in test.yml

Adversarial Codex review found 3 P0s in the first attempt (recursive delete destroying nested/partial files, whole-root sweep racing concurrent writers, dry-run mutating production) — all fixed in the second commit.

Verified live: `🧹 removed empty image dir for loves-labours-lost-off-west-end-2026` fired on a real failing fetch; 0 empty dirs remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)