### PR TITLE
images: discard rejected candidates written before verification (ship-check P0)

### DIFF
--- a/scripts/fetch-show-images-auto.js
+++ b/scripts/fetch-show-images-auto.js
@@ -31,7 +31,7 @@ const { loadShows, saveShows } = require('./lib/shows-write-guard');
 const { getMarketSearchKeyword } = require('./lib/market-label');
 const { imageOnDisk, isPlaceholderFile, PLACEHOLDER_FILE_HASHES } = require('./lib/show-images');
 const { resolveMarketSlug } = require('./lib/verify-image');
-const { pruneEmptyShowImageDir } = require('./lib/show-image-coverage');
+const { pruneEmptyShowImageDir, snapshotShowImageDir, discardFailedFetchArtifacts } = require('./lib/show-image-coverage');
 const { hasHelpFlag } = require('./lib/cli-help.js');
 const scraper = require('./lib/scraper');
 const { fetchPage, checkScrapingBeeCredits } = scraper;
@@ -2285,28 +2285,36 @@ async function processOneShow(show, apiLookup, todayTixIds, badImagesOnly, verif
     }
   }
 
+  // Snapshot BEFORE fetching: several source paths write thumbnail.jpg/poster.jpg
+  // to disk before Gemini verifies the candidate, so the failure path has to be
+  // able to tell "art that was already archived" from "a candidate this run
+  // wrote and then had rejected". Only the latter may be removed.
+  const outputBase = dryRunMode ? DRY_RUN_DIR : IMAGES_DIR;
+  const showImageDir = path.join(outputBase, show.id);
+  const dirBefore = snapshotShowImageDir(showImageDir);
+
   // Fetch images: API data → page scrape → IBDB → Google Images → Playbill fallback
   const images = await fetchShowImages(show, todayTixInfo, apiData, verifyCtx);
 
-  // Several source paths mkdir <outputBase>/<id>/ BEFORE they know whether any
-  // candidate will verify (fetchFromGoogleImages, the regional-venue path, …),
-  // so a show whose candidates are ALL rejected is left with an EMPTY directory.
-  // Coverage readers that keyed off directory existence then counted the show as
-  // having art and dropped it from the imageless cohort — that is how a show
-  // reaches the live homepage showing "Images coming soon" (Brainiac Live; The
-  // Gin Game before it).
-  //
-  // Pruned HERE, the single point every caller funnels through, rather than at
-  // end-of-run: a --show=<id> run and the concurrent-batch run take different
-  // paths, and an end-of-run sweep is also skipped by early returns,
-  // process.exit, and timeouts — the exact failure cases it exists for.
-  // Scoped to THIS show (never a sweep of all ~2,800 dirs, which would race a
-  // concurrent fetch mid-write), and pruneEmptyShowImageDir uses rmdir, which
-  // refuses the instant anything is inside — so even a lost race can only
-  // remove a directory holding nothing.
+  // A failed fetch must leave NOTHING that reads as coverage. Two shapes:
+  //   (a) an EMPTY directory, because several paths mkdir before they know any
+  //       candidate will verify;
+  //   (b) a REAL FILE written before verification and then rejected — which is
+  //       worse, because it satisfies every file-based coverage check while
+  //       shows.json still has no image, so the page renders "Images coming
+  //       soon" (Brainiac Live; The Gin Game before it).
+  // Both are undone here — the single point every caller funnels through. An
+  // end-of-run sweep is skipped by early returns (--audit-existing), by
+  // process.exit (--fill-heroes), by throws and by timeouts; a batch-loop hook
+  // missed --show=<id> entirely (verified live: the empty dir survived until
+  // this moved here). Scoped to THIS show, and only to entries that appeared
+  // during this run, so previously archived art can never be destroyed.
   if (!images) {
-    const outputBase = dryRunMode ? DRY_RUN_DIR : IMAGES_DIR;
-    if (pruneEmptyShowImageDir(path.join(outputBase, show.id))) {
+    const { removed, prunedDir } = discardFailedFetchArtifacts(showImageDir, dirBefore);
+    if (removed.length > 0) {
+      console.log(`   🧹 discarded ${removed.length} rejected candidate file(s) for ${show.id} (${removed.join(', ')}) — they would have read as coverage`);
+    }
+    if (prunedDir) {
       console.log(`   🧹 removed empty image dir for ${show.id} (would otherwise read as coverage)`);
     }
   }

--- a/scripts/lib/show-image-coverage.js
+++ b/scripts/lib/show-image-coverage.js
@@ -113,9 +113,72 @@ function pruneEmptyShowImageDir(showDir) {
   }
 }
 
+/**
+ * Snapshot the entry names in a show's image directory.
+ *
+ * Taken BEFORE a fetch so the failure path can tell "art that was already
+ * archived" (must survive) from "a candidate this run wrote and then had
+ * rejected" (must not survive as fake coverage).
+ *
+ * @param {string} showDir
+ * @returns {Set<string>} entry names; empty when the directory does not exist
+ */
+function snapshotShowImageDir(showDir) {
+  try {
+    return new Set(fs.readdirSync(showDir));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Undo the files a FAILED fetch left behind, then drop the directory if that
+ * empties it.
+ *
+ * WHY (2026-08-02, second adversarial review):
+ * Several source paths write thumbnail.jpg/poster.jpg to disk BEFORE Gemini
+ * verifies the candidate (fetch-show-images-auto.js writes at ~1753, verifies
+ * at ~1888). When verification then rejects, the fetch returns null and no URL
+ * is recorded in shows.json — but the written file stays. Pruning only EMPTY
+ * directories therefore missed this case entirely: the show has a real file on
+ * disk (so every coverage reader says "has art") and no shows.json entry (so
+ * the page still renders "Images coming soon"). That is the same live symptom
+ * this module exists to prevent, reached by a different route.
+ *
+ * Only entries absent from `before` are removed, so pre-existing archived art
+ * is never touched — the failure path must not be able to destroy a previously
+ * good poster. Directories are left alone (we only ever write flat files).
+ *
+ * @param {string} showDir
+ * @param {Set<string>} before result of snapshotShowImageDir taken pre-fetch
+ * @returns {{removed: string[], prunedDir: boolean}}
+ */
+function discardFailedFetchArtifacts(showDir, before) {
+  const removed = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(showDir, { withFileTypes: true });
+  } catch {
+    return { removed, prunedDir: false };
+  }
+  for (const e of entries) {
+    if (!e.isFile()) continue;      // never recurse into a nested archive
+    if (before.has(e.name)) continue; // pre-existing — not ours to delete
+    try {
+      fs.unlinkSync(path.join(showDir, e.name));
+      removed.push(e.name);
+    } catch {
+      // Another process may have moved it; leaving it is the safe direction.
+    }
+  }
+  return { removed, prunedDir: pruneEmptyShowImageDir(showDir) };
+}
+
 module.exports = {
   hasArchivedShowImages,
   listShowIdsWithImages,
   pruneEmptyShowImageDir,
+  snapshotShowImageDir,
+  discardFailedFetchArtifacts,
   dirHasImageFiles,
 };

--- a/scripts/lib/show-image-coverage.test.mjs
+++ b/scripts/lib/show-image-coverage.test.mjs
@@ -26,6 +26,8 @@ const {
   hasArchivedShowImages,
   listShowIdsWithImages,
   pruneEmptyShowImageDir,
+  snapshotShowImageDir,
+  discardFailedFetchArtifacts,
   dirHasImageFiles,
 } = require('./show-image-coverage.js');
 
@@ -164,4 +166,71 @@ test('dirHasImageFiles is case-insensitive on the extension', () => {
   const root = makeRoot();
   const dir = seed(root, 'shouty', ['POSTER.WEBP']);
   assert.equal(dirHasImageFiles(dir), true);
+});
+
+// ---------------------------------------------------------------------------
+// Second adversarial review (Codex, 2026-08-02) found the empty-dir prune was
+// blind to the WORSE shape of the same bug: several fetch paths write
+// thumbnail.jpg to disk BEFORE Gemini verifies it, so a rejected candidate
+// leaves a real file. That file satisfies every file-based coverage check while
+// shows.json still records no image — so the page renders "Images coming soon"
+// on a show the system believes is covered.
+// ---------------------------------------------------------------------------
+
+test('a rejected candidate written pre-verification is discarded, dir pruned', () => {
+  const root = makeRoot();
+  const dir = path.join(root, 'rejected-show');
+  fs.mkdirSync(dir, { recursive: true });
+  const before = snapshotShowImageDir(dir);          // taken pre-fetch: empty
+  fs.writeFileSync(path.join(dir, 'thumbnail.jpg'), 'x'); // written, then rejected
+
+  assert.equal(hasArchivedShowImages(root, 'rejected-show'), true, 'precondition: it DOES read as coverage');
+  const { removed, prunedDir } = discardFailedFetchArtifacts(dir, before);
+  assert.deepEqual(removed, ['thumbnail.jpg']);
+  assert.equal(prunedDir, true);
+  assert.equal(hasArchivedShowImages(root, 'rejected-show'), false);
+});
+
+test('pre-existing archived art SURVIVES a failed refetch', () => {
+  // The failure path must never be able to destroy a previously good poster.
+  const root = makeRoot();
+  const dir = seed(root, 'has-good-art', ['poster.webp', 'thumbnail.webp']);
+  const before = snapshotShowImageDir(dir);
+  fs.writeFileSync(path.join(dir, 'thumbnail.jpg'), 'x'); // this run's reject
+
+  const { removed, prunedDir } = discardFailedFetchArtifacts(dir, before);
+  assert.deepEqual(removed, ['thumbnail.jpg'], 'only this run’s file removed');
+  assert.equal(prunedDir, false, 'dir kept — it still holds real art');
+  assert.deepEqual(fs.readdirSync(dir).sort(), ['poster.webp', 'thumbnail.webp']);
+  assert.equal(hasArchivedShowImages(root, 'has-good-art'), true);
+});
+
+test('discard never recurses into a nested archive directory', () => {
+  const root = makeRoot();
+  const dir = path.join(root, 'nested');
+  fs.mkdirSync(path.join(dir, 'originals'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'originals', 'poster.webp'), 'x');
+  const before = snapshotShowImageDir(dir); // contains 'originals'
+  fs.writeFileSync(path.join(dir, 'thumbnail.jpg'), 'x');
+
+  const { removed } = discardFailedFetchArtifacts(dir, before);
+  assert.deepEqual(removed, ['thumbnail.jpg']);
+  assert.equal(fs.existsSync(path.join(dir, 'originals', 'poster.webp')), true);
+});
+
+test('a NEW nested dir is not deleted either (only files are)', () => {
+  const root = makeRoot();
+  const dir = path.join(root, 'newnested');
+  fs.mkdirSync(dir, { recursive: true });
+  const before = snapshotShowImageDir(dir);
+  fs.mkdirSync(path.join(dir, 'tmp'), { recursive: true });
+  const { removed, prunedDir } = discardFailedFetchArtifacts(dir, before);
+  assert.deepEqual(removed, []);
+  assert.equal(prunedDir, false, 'rmdir refuses: something is inside');
+  assert.equal(fs.existsSync(path.join(dir, 'tmp')), true);
+});
+
+test('discard on a missing dir is a no-op, not a throw', () => {
+  const r = discardFailedFetchArtifacts(path.join(makeRoot(), 'nope'), new Set());
+  assert.deepEqual(r, { removed: [], prunedDir: false });
 });


### PR DESCRIPTION
Ship-check adversarial pass found the empty-dir prune was blind to the worse shape of the same bug.

Several source paths write `thumbnail.jpg` to disk BEFORE Gemini verifies the candidate (`fetch-show-images-auto.js` writes ~1753, verifies ~1888). On rejection the fetch returns null and shows.json gets nothing — but the file stays, satisfying every file-based coverage check while the page still renders "Images coming soon".

`processOneShow` now snapshots the dir before fetching and, on failure, removes only entries that appeared during this run, then prunes if empty. Scoping to the snapshot is what makes it safe: a failed refetch can never destroy previously archived art.

Tests 16 → 21. Verified live: real failing fetch left zero residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)