### PR TITLE
fix(investigate-alert): ground diagnosis in the actual failed step, not alert-type guesses

### DIFF
--- a/.github/workflows/investigate-alert.yml
+++ b/.github/workflows/investigate-alert.yml
@@ -21,6 +21,12 @@ on:
 jobs:
   investigate:
     runs-on: ubuntu-latest
+    # Explicit rather than repo-default: the failed-steps fetch needs
+    # actions:read, and a future tightening of default token permissions
+    # would otherwise silently regress it to empty output (fail-open hides it).
+    permissions:
+      contents: read
+      actions: read
     steps:
       # Required for the local notify-failure action below
       - name: Checkout repository
@@ -44,7 +50,7 @@ jobs:
           FAILED=""
           if [ -n "$RUN_ID" ]; then
             FAILED=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID/jobs" \
-              --jq '[.jobs[] | .name as $j | (.steps // [])[] | select(.conclusion == "failure") | "\($j) → \(.name)"] | unique | join("; ")' 2>/dev/null || echo "")
+              --jq '[.jobs[] | .name as $j | (.steps // [])[] | select(.conclusion == "failure" or .conclusion == "cancelled") | "\($j) → \(.name) (\(.conclusion))"] | unique | join("; ")' 2>/dev/null || echo "")
           fi
           echo "failed_steps=$FAILED" >> "$GITHUB_OUTPUT"
           echo "Failed steps in source run ${RUN_ID:-unknown}: ${FAILED:-none found}"

--- a/.github/workflows/investigate-alert.yml
+++ b/.github/workflows/investigate-alert.yml
@@ -26,6 +26,29 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Fetch failed steps from the source run
+        id: failedsteps
+        # Ground the diagnosis in what ACTUALLY failed. Dispatchers pass
+        # run_url but historically no context, so the LLM guessed causes from
+        # the alert-type description — 2026-08-03 it blamed "credit exhaustion"
+        # for what was a git push race in "Commit new review files". Failed
+        # step names are cheap (1 API call) and available even while the source
+        # run is still finishing (its failed steps are already concluded).
+        # Fail open to empty: a fetch error must not block the investigation.
+        if: github.event.inputs.run_url != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.event.inputs.run_url }}
+        run: |
+          RUN_ID=$(echo "$RUN_URL" | grep -oE '[0-9]+$' || echo "")
+          FAILED=""
+          if [ -n "$RUN_ID" ]; then
+            FAILED=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID/jobs" \
+              --jq '[.jobs[] | .name as $j | (.steps // [])[] | select(.conclusion == "failure") | "\($j) → \(.name)"] | unique | join("; ")' 2>/dev/null || echo "")
+          fi
+          echo "failed_steps=$FAILED" >> "$GITHUB_OUTPUT"
+          echo "Failed steps in source run ${RUN_ID:-unknown}: ${FAILED:-none found}"
+
       - name: Investigate with Claude and send email
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -36,6 +59,7 @@ jobs:
           ALERT_TITLE: ${{ github.event.inputs.alert_title }}
           ALERT_CONTEXT: ${{ github.event.inputs.alert_context }}
           RUN_URL: ${{ github.event.inputs.run_url }}
+          FAILED_STEPS: ${{ steps.failedsteps.outputs.failed_steps }}
         run: |
           node << 'SCRIPT'
           // ESM imports (not require) — the script uses top-level await, and
@@ -47,6 +71,7 @@ jobs:
           const alertTitle = process.env.ALERT_TITLE || '';
           const alertContext = process.env.ALERT_CONTEXT || '{}';
           const runUrl = process.env.RUN_URL || '';
+          const failedSteps = process.env.FAILED_STEPS || '';
 
           // --- Step 1: Call Claude API for diagnosis ---
 
@@ -61,7 +86,7 @@ jobs:
             '',
             'Alert type guidance:',
             '- vercel_deploy_fail: Build failures (TypeScript error, missing env var) need no-auto-fix. Transient failures (exit code 1 with no code changes, Vercel timeout) can use redeploy.',
-            '- poller_fail: Opening-night review poller. Causes: ScrapingBee/BrightData credit exhaustion, cookie invalidation, network timeout. Always no-auto-fix.',
+            '- poller_fail: Opening-night review poller. If the failed step is a git commit/push step, the cause is push contention between concurrent runs, NOT scrapers. Scraper causes (credit exhaustion, cookie invalidation, network timeout) apply only when a scraping/collection step failed. Always no-auto-fix.',
             '- data_health_fail: Daily data health check. Almost always no-auto-fix — requires investigation.',
             '- opening_night_broadcast_fail: Email broadcast workflow failed. Always no-auto-fix — never auto-retry broadcasts.',
             '',
@@ -79,6 +104,10 @@ jobs:
             'Alert title: ' + alertTitle,
             'Run URL: ' + runUrl,
             'Additional context: ' + alertContext,
+            failedSteps
+              ? 'Failed step(s) in the source run (job → step): ' + failedSteps + '\n' +
+                'Anchor your diagnosis on the named failed step(s). Do NOT list generic possible causes that the failed step name rules out.'
+              : 'Failed step names unavailable — state clearly that the diagnosis is a guess from the alert type alone.',
             '',
             'Diagnose this alert and recommend a fix.',
           ].join('\n');

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -500,7 +500,7 @@ jobs:
               -f alert_type=vercel_deploy_fail \
               -f alert_title="Deploy still broken: 3rd consecutive failure (~15 min)" \
               -f alert_context="{\"streak\":$STREAK,\"note\":\"Deploys have been failing for ~15 min across all parallel sessions. Check Actions tab.\"}" \
-              -f run_url="${{ github.server_url }}/${{ github.repository }}/actions/workflows/vercel-deploy.yml"
+              -f run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           else
             echo "Streak is $STREAK — no escalation needed"
           fi


### PR DESCRIPTION
Tonight's investigation email blamed "ScrapingBee/BrightData credit exhaustion" for what was actually a git push race — the prompt hardcoded a scraper-cause list and dispatchers pass no context, so the LLM guessed.

- New pre-step fetches failed/cancelled step names (job → step) from the source run; fails open. Verified against real failed run 30778603695: returns `poll → Commit new review files (failure)`.
- User prompt anchors the diagnosis on named steps, or explicitly admits it's guessing.
- poller_fail guidance distinguishes push-contention steps from scraper steps.
- Explicit `actions: read` permissions; vercel-deploy streak-3 escalation now passes a real run URL so it gets step context too.
- Benefits all 5 dispatchers with no dispatcher-side changes (except the vercel URL fix).

Second-opinion review: pass (no blockers; its 3 findings are included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)