### PR TITLE
fix(trunk): add --help guard to produce-coverage-digest-snapshot.js (help-flag safety Rule B)

### DIFF
--- a/scripts/produce-coverage-digest-snapshot.js
+++ b/scripts/produce-coverage-digest-snapshot.js
@@ -22,6 +22,7 @@
 const fs = require('fs');
 const path = require('path');
 const { coverageDigestItems } = require('./lib/coverage-digest.js');
+const { hasHelpFlag } = require('./lib/cli-help.js');
 const { coverageGateDisabled } = require('./lib/coverage-gate.js');
 
 const REPO = path.join(__dirname, '..');
@@ -56,7 +57,16 @@ function removeStaleSnapshot() {
   } catch { /* nothing to remove */ }
 }
 
+const USAGE = `produce-coverage-digest-snapshot.js — write the coverage digest snapshot
+  node scripts/produce-coverage-digest-snapshot.js               write the snapshot
+  node scripts/produce-coverage-digest-snapshot.js --dry-run     print, don't write
+  node scripts/produce-coverage-digest-snapshot.js --dry-run --fixture=demo
+  node scripts/produce-coverage-digest-snapshot.js --help, -h    print this usage and exit — no reads/writes
+`;
+
 function main() {
+  // --help/-h checked BEFORE any read/write (help-flag safety Rule B, task #498).
+  if (hasHelpFlag(process.argv.slice(2))) { console.log(USAGE); return; }
   const dryRun = process.argv.includes('--dry-run');
   const fixtureArg = process.argv.find((a) => a.startsWith('--fixture='));
   const nowIso = new Date().toISOString();


### PR DESCRIPTION
Lint Workflows job red on main since the Coverage Verdict S3 merge —
audit-help-flag-safety.js Rule B flags the new snapshot producer for doing
fs writes with no --help check. Pattern from fetch-show-images-auto.js
(task #498). Verified: --help prints usage without touching files;
--dry-run --fixture=demo still renders; audit-help-flag-safety.js now
passes (829 scripts, 0 violations).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
