### PR TITLE
feat(reconcile): stalled-task sweep — close the loop on terminated fix sessions

### DIFF
--- a/scripts/bsc-reconcile.js
+++ b/scripts/bsc-reconcile.js
@@ -269,6 +269,14 @@ function reconcileTaskSessions({ dryRun = false, deps = {} } = {}) {
 // dead.
 const STALL_EVENT = 'stall-sweep-attempted';
 const STALL_COOLDOWN_MS = 30 * 60 * 1000; // let a just-finished session's task-status writes land first
+// Codex pre-ship catch: deadAttemptsForTask counts only failures/orphans, so a
+// job that keeps ending job-DONE without ever completing its task would re-arm
+// the sweep every cooldown — one task could burn ~48 sessions/day forever.
+// Total stall redispatches per task are therefore capped by counting the
+// task's own stall markers: past the cap it gets ONE task-stall-exhausted
+// report per re-arm (which lands in the digest's stuck bucket) and no more
+// sessions until a human intervenes.
+const MAX_STALL_ATTEMPTS_PER_TASK = 2;
 
 function reconcileStalledTasks({ dryRun = false, deps = {} } = {}) {
   const {
@@ -301,7 +309,8 @@ function reconcileStalledTasks({ dryRun = false, deps = {} } = {}) {
     const tsOf = (e) => Date.parse(e.ts || '') || 0;
     const lastActivity = Math.max(...taskEntries.filter(e => e.event !== STALL_EVENT).map(tsOf));
     if (!lastActivity || nowFn() - lastActivity < STALL_COOLDOWN_MS) continue; // still settling
-    const lastMarker = Math.max(0, ...taskEntries.filter(e => e.event === STALL_EVENT).map(tsOf));
+    const markers = taskEntries.filter(e => e.event === STALL_EVENT);
+    const lastMarker = Math.max(0, ...markers.map(tsOf));
     if (lastMarker >= lastActivity) continue; // this stall already attempted/surfaced — new activity re-arms
 
     // Classify how the last dispatch ended, purely for the report line.
@@ -315,6 +324,11 @@ function reconcileStalledTasks({ dryRun = false, deps = {} } = {}) {
     reportFn({ kind: 'task-stalled', taskId: id, detail: `in_progress task #${id} "${task.subject}" has no live session or job (${how}) — nothing is actually working on it` });
     if (dryRun) continue;
 
+    if (markers.length >= MAX_STALL_ATTEMPTS_PER_TASK) {
+      appendLedgerFn({ event: STALL_EVENT, taskId: id });
+      reportFn({ kind: 'task-stall-exhausted', taskId: id, detail: `#${id} has already been stall-redispatched ${markers.length}x and is stalled AGAIN — a session keeps ending without completing it; needs a human look, no further automatic sessions` });
+      continue;
+    }
     if (ledger.deadAttemptsForTask(id, entries).length >= ledger.DEAD_ATTEMPT_LIMIT) {
       // Marker stamped: this verdict is stable, so surface it once per stall,
       // not every 5-minute tick.
@@ -451,4 +465,4 @@ if (require.main === module) {
   main().catch(err => { console.error('bsc-reconcile crashed:', err); process.exit(1); });
 }
 
-module.exports = { main, retriesInLast24h, reconcileTaskSessions, reconcileStalledTasks, redispatchArgv, stallRedispatchArgv, STALL_EVENT, STALL_COOLDOWN_MS, USAGE, REPORT_PATH, MAX_RETRIES_PER_TICK, MAX_RETRIES_PER_DAY, MAX_REDISPATCH_PER_TICK };
+module.exports = { main, retriesInLast24h, reconcileTaskSessions, reconcileStalledTasks, redispatchArgv, stallRedispatchArgv, STALL_EVENT, STALL_COOLDOWN_MS, MAX_STALL_ATTEMPTS_PER_TASK, USAGE, REPORT_PATH, MAX_RETRIES_PER_TICK, MAX_RETRIES_PER_DAY, MAX_REDISPATCH_PER_TICK };

--- a/scripts/bsc-reconcile.js
+++ b/scripts/bsc-reconcile.js
@@ -48,8 +48,9 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 const USAGE = `Usage: node scripts/bsc-reconcile.js [--dry-run]
 Marks headless jobs whose process died as orphaned, sweeps stale leases,
-re-dispatches in_progress tasks whose cmux tab died, queues digest lines.
-Retry of orphaned headless jobs requires BSC_RECONCILE_RETRY=1.`;
+re-dispatches in_progress tasks whose cmux tab died, re-dispatches stalled
+in_progress tasks whose last job/tab terminated without completing them,
+queues digest lines. Retry of orphaned headless jobs requires BSC_RECONCILE_RETRY=1.`;
 
 // --help before ANY side effect (house rule: --help fall-through incidents).
 if (process.argv.includes('--help') || process.argv.includes('-h')) {
@@ -109,6 +110,16 @@ function sleepMs(ms) { spawnSync('sleep', [String(ms / 1000)]); }
 // below — is directly testable without invoking a real spawnSync).
 function redispatchArgv(taskId) {
   return [path.join(REPO, 'scripts', 'bsc-next.js'), '--id', String(taskId), '--force'];
+}
+
+// Stalled-task redispatch deliberately does NOT carry --force: unlike the
+// dead-tab case above there is no live-looking workspace for the
+// duplicate-dispatch guard to false-match on (the whole trigger is that the
+// ledger shows nothing open), so every bsc-next guard — parked, dead-attempt,
+// duplicate — should stay armed and be the honest reason a redispatch is
+// refused.
+function stallRedispatchArgv(taskId) {
+  return [path.join(REPO, 'scripts', 'bsc-next.js'), '--id', String(taskId)];
 }
 
 // ── In-progress task session reconciler (task #883) ────────────────────────
@@ -240,6 +251,105 @@ function reconcileTaskSessions({ dryRun = false, deps = {} } = {}) {
   return { checked: tasks.length, dead: dead.map(d => d.task.id), redispatched };
 }
 
+// ── Stalled-task sweep (owner mandate 2026-08-03: "close the loop") ────────
+// The 2026-08-03 digest claimed four issues were "being fixed by a session
+// right now" (#733/#807/#808/#935); in reality every one had been dispatched
+// as a headless job that TERMINATED hours earlier (job-failed for two,
+// job-done without the task ever being completed for the other two) while the
+// task sat in_progress. That state was invisible to both sweeps above: the
+// orphan sweep only watches OPEN jobs, and reconcileTaskSessions only watches
+// open WORKSPACE launches. This sweep owns the leftover shape: an in_progress
+// task whose ledger holds SOME dispatch history but nothing open — no live
+// tab, no live job. It redispatches once per stall through bsc-next's normal
+// guarded path (no --force — see stallRedispatchArgv), and stamps a
+// stall-sweep marker either way so a refused/parked task is surfaced once,
+// not re-attempted every 5-minute tick. Tasks with NO ledger history at all
+// are skipped on purpose — same rationale as reconcileTaskSessions: a
+// hand-claimed interactive session is invisible to us and not ours to declare
+// dead.
+const STALL_EVENT = 'stall-sweep-attempted';
+const STALL_COOLDOWN_MS = 30 * 60 * 1000; // let a just-finished session's task-status writes land first
+
+function reconcileStalledTasks({ dryRun = false, deps = {} } = {}) {
+  const {
+    loadTasksFn = bscNext.loadTasks,
+    tasksDir = bscNext.TASKS_DIR,
+    readLedgerEntriesFn = ledger.readEntries,
+    appendLedgerFn = ledger.appendEntry,
+    dispatchFn = (taskId) => spawnSync('node', stallRedispatchArgv(taskId), { encoding: 'utf8', cwd: REPO, timeout: DISPATCH_TIMEOUT_MS }),
+    reportFn = report,
+    nowFn = Date.now,
+  } = deps;
+
+  const tasks = loadTasksFn(tasksDir).filter(t => t.status === 'in_progress');
+  if (!tasks.length) return { checked: 0, stalled: [], redispatched: [] };
+
+  const entries = readLedgerEntriesFn();
+  const openLaunches = ledger.openTaskWorkspaceLaunches(entries);
+  const openJobTasks = new Set(ledger.openJobs(entries).map(j => String(j.taskId)));
+
+  const stalled = [];
+  const redispatched = [];
+  let dispatchBudget = MAX_REDISPATCH_PER_TICK;
+
+  for (const task of tasks) {
+    const id = String(task.id);
+    if (openLaunches.has(id) || openJobTasks.has(id)) continue; // something is (believed) live — other sweeps own it
+    const taskEntries = entries.filter(e => String(e.taskId) === id);
+    if (!taskEntries.length) continue; // never dispatcher-managed — invisible on purpose
+
+    const tsOf = (e) => Date.parse(e.ts || '') || 0;
+    const lastActivity = Math.max(...taskEntries.filter(e => e.event !== STALL_EVENT).map(tsOf));
+    if (!lastActivity || nowFn() - lastActivity < STALL_COOLDOWN_MS) continue; // still settling
+    const lastMarker = Math.max(0, ...taskEntries.filter(e => e.event === STALL_EVENT).map(tsOf));
+    if (lastMarker >= lastActivity) continue; // this stall already attempted/surfaced — new activity re-arms
+
+    // Classify how the last dispatch ended, purely for the report line.
+    const jobs = [...ledger.foldJobs(taskEntries).values()].sort((a, b) => tsOf(a) - tsOf(b));
+    const lastJob = jobs[jobs.length - 1];
+    const how = lastJob
+      ? (lastJob.event === ledger.JOB_EVENTS.DONE ? 'last job reported done but the task was never completed' : `last job ended ${lastJob.event}`)
+      : 'last workspace launch is terminal';
+
+    stalled.push(id);
+    reportFn({ kind: 'task-stalled', taskId: id, detail: `in_progress task #${id} "${task.subject}" has no live session or job (${how}) — nothing is actually working on it` });
+    if (dryRun) continue;
+
+    if (ledger.deadAttemptsForTask(id, entries).length >= ledger.DEAD_ATTEMPT_LIMIT) {
+      // Marker stamped: this verdict is stable, so surface it once per stall,
+      // not every 5-minute tick.
+      appendLedgerFn({ event: STALL_EVENT, taskId: id });
+      reportFn({ kind: 'task-stall-blocked', taskId: id, detail: `#${id} already died ${ledger.DEAD_ATTEMPT_LIMIT}+ times — needs a human look, not another automatic retry` });
+      continue;
+    }
+    if (dispatchBudget <= 0) {
+      // NO marker on throttle: the budget is per-tick, so the next tick must
+      // pick this task up again — a backlog drains at MAX_REDISPATCH_PER_TICK
+      // per tick instead of stalling forever behind a spent budget.
+      reportFn({ kind: 'task-stall-throttled', taskId: id, detail: `#${id} deferred — this tick's stall budget (${MAX_REDISPATCH_PER_TICK}) is spent` });
+      continue;
+    }
+    // Marker stamped before the attempt: whether bsc-next accepts or refuses
+    // (parked card, card-gate rejection), the outcome is recorded once and the
+    // report line is the surface — a refusal must not re-fire every tick.
+    appendLedgerFn({ event: STALL_EVENT, taskId: id });
+    dispatchBudget--;
+    let r;
+    try { r = dispatchFn(id); } catch (e) { r = { status: 1, stderr: e.message }; }
+    const ok = r && r.status === 0;
+    reportFn({
+      kind: ok ? 'task-stall-redispatched' : 'task-stall-refused',
+      taskId: id,
+      detail: ok
+        ? `re-dispatched stalled #${id} via bsc-next --id`
+        : `bsc-next refused stalled #${id}: ${String((r && (r.stderr || r.stdout)) || 'unknown error').trim().split('\n').slice(-1)[0]}`,
+    });
+    if (ok) redispatched.push(id);
+  }
+
+  return { checked: tasks.length, stalled, redispatched };
+}
+
 async function main() {
   const entries = ledger.readEntries();
   const open = ledger.openJobs(entries);
@@ -327,10 +437,18 @@ async function main() {
   } catch (e) {
     console.error(`[bsc-reconcile] task-session sweep crashed (non-fatal): ${e.message}`);
   }
+
+  // Owner mandate 2026-08-03: stalled-task sweep, same best-effort isolation.
+  try {
+    const stallSweep = reconcileStalledTasks({ dryRun: DRY });
+    console.log(`[bsc-reconcile] stalled checked=${stallSweep.checked} stalled=${stallSweep.stalled.length} redispatched=${stallSweep.redispatched.length}${DRY ? ' (dry-run)' : ''}`);
+  } catch (e) {
+    console.error(`[bsc-reconcile] stalled-task sweep crashed (non-fatal): ${e.message}`);
+  }
 }
 
 if (require.main === module) {
   main().catch(err => { console.error('bsc-reconcile crashed:', err); process.exit(1); });
 }
 
-module.exports = { main, retriesInLast24h, reconcileTaskSessions, redispatchArgv, USAGE, REPORT_PATH, MAX_RETRIES_PER_TICK, MAX_RETRIES_PER_DAY };
+module.exports = { main, retriesInLast24h, reconcileTaskSessions, reconcileStalledTasks, redispatchArgv, stallRedispatchArgv, STALL_EVENT, STALL_COOLDOWN_MS, USAGE, REPORT_PATH, MAX_RETRIES_PER_TICK, MAX_RETRIES_PER_DAY, MAX_REDISPATCH_PER_TICK };

--- a/scripts/bsc-reconcile.test.mjs
+++ b/scripts/bsc-reconcile.test.mjs
@@ -358,3 +358,41 @@ test('dryRun reports but never stamps or dispatches', () => {
   assert.deepEqual(h.dispatched, []);
   assert.deepEqual(h.appended, []);
 });
+
+test('Codex catch: the job-done 48-sessions/day loop is capped — after MAX_STALL_ATTEMPTS_PER_TASK markers, exhausted, no dispatch', () => {
+  const { MAX_STALL_ATTEMPTS_PER_TASK } = require('./bsc-reconcile.js');
+  // Two prior stall cycles, each: marker → redispatch → job-done without completion.
+  const h = stallHarness({
+    tasks: [inProgressTask(920)],
+    entries: [
+      jobSpawned(920, 'k1', hoursAgo(20)), jobEnd(920, 'k1', 'job-done', hoursAgo(19)),
+      { event: STALL_EVENT, taskId: '920', ts: hoursAgo(18) },
+      jobSpawned(920, 'k2', hoursAgo(17)), jobEnd(920, 'k2', 'job-done', hoursAgo(16)),
+      { event: STALL_EVENT, taskId: '920', ts: hoursAgo(15) },
+      jobSpawned(920, 'k3', hoursAgo(14)), jobEnd(920, 'k3', 'job-done', hoursAgo(13)),
+    ],
+  });
+  assert.equal(MAX_STALL_ATTEMPTS_PER_TASK, 2);
+  const r = reconcileStalledTasks({ deps: h.deps });
+  assert.deepEqual(r.stalled, ['920'], 'still reported stalled (honest surface)');
+  assert.deepEqual(h.dispatched, [], 'but NO further session is spawned');
+  assert.ok(h.reported.some(l => l.kind === 'task-stall-exhausted'));
+  assert.ok(h.appended.some(e => e.event === STALL_EVENT), 'exhausted verdict stamps a marker so it reports once per re-arm, not every tick');
+});
+
+test('exhausted verdict is silenced by its own marker on the following tick', () => {
+  const h = stallHarness({
+    tasks: [inProgressTask(921)],
+    entries: [
+      jobSpawned(921, 'm1', hoursAgo(20)), jobEnd(921, 'm1', 'job-done', hoursAgo(19)),
+      { event: STALL_EVENT, taskId: '921', ts: hoursAgo(18) },
+      jobSpawned(921, 'm2', hoursAgo(17)), jobEnd(921, 'm2', 'job-done', hoursAgo(16)),
+      { event: STALL_EVENT, taskId: '921', ts: hoursAgo(15) },
+      jobSpawned(921, 'm3', hoursAgo(14)), jobEnd(921, 'm3', 'job-done', hoursAgo(13)),
+      { event: STALL_EVENT, taskId: '921', ts: hoursAgo(12) }, // the exhausted stamp
+    ],
+  });
+  const r = reconcileStalledTasks({ deps: h.deps });
+  assert.deepEqual(r.stalled, [], 'marker newer than last activity — quiet until new activity');
+  assert.deepEqual(h.dispatched, []);
+});

--- a/scripts/bsc-reconcile.test.mjs
+++ b/scripts/bsc-reconcile.test.mjs
@@ -214,3 +214,147 @@ test('reconcileTaskSessions: a failed cmux listing is reported and returns clean
   assert.deepEqual(r.dead, []);
   assert.ok(r.error);
 });
+
+// ── reconcileStalledTasks (owner mandate 2026-08-03: close the loop) ────────
+const { reconcileStalledTasks, stallRedispatchArgv, STALL_EVENT, STALL_COOLDOWN_MS } = require('./bsc-reconcile.js');
+
+const NOW = Date.parse('2026-08-03T12:00:00.000Z');
+const hoursAgo = (h) => new Date(NOW - h * 3600 * 1000).toISOString();
+const jobSpawned = (taskId, jobId, ts) => ({ event: 'job-spawned', taskId: String(taskId), jobId, ts });
+const jobEnd = (taskId, jobId, event, ts) => ({ event, taskId: String(taskId), jobId, ts });
+
+function stallHarness({ tasks = [], entries = [], dispatchStatus = 0 } = {}) {
+  const reported = [];
+  const dispatched = [];
+  const appended = [];
+  const deps = {
+    loadTasksFn: () => tasks,
+    tasksDir: '/fake/dir',
+    readLedgerEntriesFn: () => entries,
+    appendLedgerFn: (e) => appended.push({ ts: new Date(NOW).toISOString(), ...e }),
+    dispatchFn: (taskId) => { dispatched.push(String(taskId)); return { status: dispatchStatus, stderr: 'guard: refused' }; },
+    reportFn: (l) => reported.push(l),
+    nowFn: () => NOW,
+  };
+  return { deps, reported, dispatched, appended };
+}
+
+test('stallRedispatchArgv deliberately carries NO --force — every bsc-next guard stays armed', () => {
+  const argv = stallRedispatchArgv('733');
+  assert.ok(argv.includes('--id') && argv.includes('733'));
+  assert.ok(!argv.includes('--force'), 'stalled redispatch must go through the fully-guarded path');
+});
+
+test('the 2026-08-03 shape: terminal job-failed + in_progress task → reported stalled and redispatched', () => {
+  const h = stallHarness({
+    tasks: [inProgressTask(733, 'Fix: Test Suite repeat-failure')],
+    entries: [jobSpawned(733, 'j1', hoursAgo(6)), jobEnd(733, 'j1', 'job-failed', hoursAgo(5))],
+  });
+  const r = reconcileStalledTasks({ deps: h.deps });
+  assert.deepEqual(r.stalled, ['733']);
+  assert.deepEqual(h.dispatched, ['733']);
+  assert.ok(h.reported.some(l => l.kind === 'task-stalled' && /job-failed/.test(l.detail)));
+  assert.ok(h.appended.some(e => e.event === STALL_EVENT && e.taskId === '733'), 'marker stamped');
+});
+
+test('job-done but task still in_progress → stalled, with the never-completed wording', () => {
+  const h = stallHarness({
+    tasks: [inProgressTask(808, 'BSC Daily: Audience coverage')],
+    entries: [jobSpawned(808, 'j2', hoursAgo(6)), jobEnd(808, 'j2', 'job-done', hoursAgo(5))],
+  });
+  reconcileStalledTasks({ deps: h.deps });
+  assert.ok(h.reported.some(l => l.kind === 'task-stalled' && /never completed/.test(l.detail)));
+});
+
+test('open headless job → NOT stalled (orphan sweep owns it)', () => {
+  const h = stallHarness({
+    tasks: [inProgressTask(900)],
+    entries: [jobSpawned(900, 'j3', hoursAgo(6))],
+  });
+  const r = reconcileStalledTasks({ deps: h.deps });
+  assert.deepEqual(r.stalled, []);
+  assert.deepEqual(h.dispatched, []);
+});
+
+test('open workspace launch → NOT stalled (tab sweep owns it)', () => {
+  const h = stallHarness({
+    tasks: [inProgressTask(901)],
+    entries: [launch(901, 'workspace:9')],
+  });
+  assert.deepEqual(reconcileStalledTasks({ deps: h.deps }).stalled, []);
+});
+
+test('no ledger history at all → skipped (hand-claimed sessions are invisible on purpose)', () => {
+  const h = stallHarness({ tasks: [inProgressTask(902)], entries: [] });
+  assert.deepEqual(reconcileStalledTasks({ deps: h.deps }).stalled, []);
+});
+
+test('cooldown: terminal event younger than STALL_COOLDOWN_MS → not yet stalled', () => {
+  const freshTs = new Date(NOW - STALL_COOLDOWN_MS / 2).toISOString();
+  const h = stallHarness({
+    tasks: [inProgressTask(903)],
+    entries: [jobSpawned(903, 'j4', hoursAgo(1)), jobEnd(903, 'j4', 'job-failed', freshTs)],
+  });
+  assert.deepEqual(reconcileStalledTasks({ deps: h.deps }).stalled, []);
+});
+
+test('marker newer than last activity → stall already handled, no re-attempt every tick', () => {
+  const h = stallHarness({
+    tasks: [inProgressTask(904)],
+    entries: [
+      jobSpawned(904, 'j5', hoursAgo(8)), jobEnd(904, 'j5', 'job-failed', hoursAgo(7)),
+      { event: STALL_EVENT, taskId: '904', ts: hoursAgo(6) },
+    ],
+  });
+  const r = reconcileStalledTasks({ deps: h.deps });
+  assert.deepEqual(r.stalled, []);
+  assert.deepEqual(h.dispatched, []);
+});
+
+test('new activity after the marker re-arms the stall', () => {
+  const h = stallHarness({
+    tasks: [inProgressTask(905)],
+    entries: [
+      jobSpawned(905, 'j6', hoursAgo(9)), jobEnd(905, 'j6', 'job-failed', hoursAgo(8)),
+      { event: STALL_EVENT, taskId: '905', ts: hoursAgo(7) },
+      jobSpawned(905, 'j7', hoursAgo(3)), jobEnd(905, 'j7', 'job-failed', hoursAgo(2)),
+    ],
+  });
+  assert.deepEqual(reconcileStalledTasks({ deps: h.deps }).stalled, ['905']);
+});
+
+test('refused dispatch still stamps the marker and reports task-stall-refused (no every-tick spam)', () => {
+  const h = stallHarness({
+    tasks: [inProgressTask(906)],
+    entries: [jobSpawned(906, 'j8', hoursAgo(6)), jobEnd(906, 'j8', 'job-failed', hoursAgo(5))],
+    dispatchStatus: 1,
+  });
+  const r = reconcileStalledTasks({ deps: h.deps });
+  assert.deepEqual(r.redispatched, []);
+  assert.ok(h.reported.some(l => l.kind === 'task-stall-refused'));
+  assert.ok(h.appended.some(e => e.event === STALL_EVENT && e.taskId === '906'));
+});
+
+test('per-tick budget throttles the third stalled task WITHOUT a marker (retries next tick)', () => {
+  const mk = (id, job) => [jobSpawned(id, job, hoursAgo(6)), jobEnd(id, job, 'job-failed', hoursAgo(5))];
+  const h = stallHarness({
+    tasks: [inProgressTask(910), inProgressTask(911), inProgressTask(912)],
+    entries: [...mk(910, 'a'), ...mk(911, 'b'), ...mk(912, 'c')],
+  });
+  const r = reconcileStalledTasks({ deps: h.deps });
+  assert.equal(r.stalled.length, 3);
+  assert.equal(h.dispatched.length, 2);
+  assert.ok(h.reported.some(l => l.kind === 'task-stall-throttled' && l.taskId === '912'));
+  assert.ok(!h.appended.some(e => e.event === STALL_EVENT && e.taskId === '912'), 'throttled task must NOT be marker-stamped');
+});
+
+test('dryRun reports but never stamps or dispatches', () => {
+  const h = stallHarness({
+    tasks: [inProgressTask(913)],
+    entries: [jobSpawned(913, 'j9', hoursAgo(6)), jobEnd(913, 'j9', 'job-failed', hoursAgo(5))],
+  });
+  const r = reconcileStalledTasks({ dryRun: true, deps: h.deps });
+  assert.deepEqual(r.stalled, ['913']);
+  assert.deepEqual(h.dispatched, []);
+  assert.deepEqual(h.appended, []);
+});


### PR DESCRIPTION
Owner mandate 2026-08-03 ("make it happen — time to be passive"): the morning digest claimed 4 issues were "being fixed by a session right now" when every one had been dispatched as a headless job that terminated hours earlier. Terminated-but-incomplete tasks were invisible to both existing reconcile sweeps.

- New `reconcileStalledTasks()` on the same 5-min launchd tick: in_progress task + ledger history + nothing open + 30-min cooldown → redispatch via bsc-next's fully-guarded path (no --force).
- `stall-sweep-attempted` markers: refusals surface once (into the digest stuck bucket), not every tick; new ledger activity re-arms; throttled tasks retry next tick unmarked.
- Codex review catch fixed: total stall redispatches capped at 2 per task (job-done-without-completion isn't a "dead attempt", so it was otherwise an uncapped ~48 sessions/day loop) — past the cap, `task-stall-exhausted` and no more sessions.
- Dry-run against the real ledger: 18 stalled tasks found, including all 4 from today's digest, each classified.
- 14 new tests (28/28 suite green). Reviews: Claude codebase pass, Codex adversarial (1 blocker → fixed, races assessed same-exposure-as-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)