### PR TITLE
fix: filter page-asset/ticketing chaff from review-gap audit (task #71)

### DIFF
--- a/scripts/lib/non-review-url-patterns.js
+++ b/scripts/lib/non-review-url-patterns.js
@@ -74,21 +74,31 @@ const NON_REVIEW_HOST_PATTERNS = [
   /^threads\.com$/, /(^|\.)atgtickets\.com$/, /(^|\.)getyourguide\./,
   /(^|\.)klook\.com$/, /(^|\.)headout\.com$/, /(^|\.)yelp\./,
   /(^|\.)justluxe\.com$/, /(^|\.)whichmuseum\./, /(^|\.)theotherpalace\.co\.uk$/,
-  // Fourth wave (task #71 residual-gap triage, 2026-08-05): page-asset and
-  // aggregator-own-domain chaff measured in data/audit/show-review-gap.json's
-  // "missing" lists across ~150 audited shows — fonts/CDN/maps/forms embedded
-  // in an aggregator article's HTML, and Show Score's OWN show pages (never an
-  // outlet, only ever a discovery source — see show-score-discover.js) leaking
-  // through as "missing" gaps because they carry no distinguishing path.
+  // Fourth wave (task #71 residual-gap triage, 2026-08-05): page-asset
+  // chaff measured in data/audit/show-review-gap.json's "missing" lists
+  // across ~150 audited shows — fonts/CDN/maps/forms embedded in an
+  // aggregator article's HTML. show-score.com is DELIBERATELY NOT added
+  // here despite its own catalog/nav links leaking through the same way —
+  // ship-check adversarial review caught that coverage-adversarial-probe.js's
+  // onDiskByUrlFor() relies on isReviewUrl() to index legitimately-captured
+  // Show Score star-stub review files by URL (aggregator-domains.js's
+  // AGGREGATOR_DOMAINS carries show-score.com as a valid outlet-URL pair);
+  // blocking the whole host here would make the S5 probe stop recognizing
+  // those on-disk records and misreport them as gaps. See the header comment
+  // on classifyNonReviewUrl() in coverage-adversarial-probe.js.
   /(^|\.)cloudfront\.net$/, /(^|\.)gstatic\.com$/, /(^|\.)googleapis\.com$/,
-  /(^|\.)google\.com$/, /(^|\.)show-score\.com$/, /(^|\.)todaytixgroup\.com$/,
+  /(^|\.)google\.com$/, /(^|\.)todaytixgroup\.com$/,
   // Fifth wave (task #71): UK ticketing/tourism-listing platforms and ad-tech,
   // measured on WE family/kids shows (Dog Man - The Musical, A Midsummer
   // Night's Dream) — never review outlets, unlike londontheatredirect.com
   // (deliberately NOT added here — it also publishes /news/*-review posts).
+  // southlondon.co.uk is ALSO deliberately excluded from this wave — ship-check
+  // adversarial review caught that it's a registered Tier 4 outlet
+  // ("south-london" in outlet-registry.json) with 7 real scored reviews under
+  // /lifestyle/review-*; the sampled dog-man URL was its unrelated /area/
+  // listing section, not evidence the whole host is non-review.
   /^doubleclick\.net$/, /^showify\.uk$/, /^showpass\.com$/,
   /^showtours\.co\.uk$/, /^bookitplease\.com$/, /^visitlondon\.com$/,
-  /^southlondon\.co\.uk$/,
 ];
 
 const ALLOWED_ORG_HOSTS = new Set([

--- a/scripts/lib/non-review-url-patterns.js
+++ b/scripts/lib/non-review-url-patterns.js
@@ -74,6 +74,21 @@ const NON_REVIEW_HOST_PATTERNS = [
   /^threads\.com$/, /(^|\.)atgtickets\.com$/, /(^|\.)getyourguide\./,
   /(^|\.)klook\.com$/, /(^|\.)headout\.com$/, /(^|\.)yelp\./,
   /(^|\.)justluxe\.com$/, /(^|\.)whichmuseum\./, /(^|\.)theotherpalace\.co\.uk$/,
+  // Fourth wave (task #71 residual-gap triage, 2026-08-05): page-asset and
+  // aggregator-own-domain chaff measured in data/audit/show-review-gap.json's
+  // "missing" lists across ~150 audited shows — fonts/CDN/maps/forms embedded
+  // in an aggregator article's HTML, and Show Score's OWN show pages (never an
+  // outlet, only ever a discovery source — see show-score-discover.js) leaking
+  // through as "missing" gaps because they carry no distinguishing path.
+  /(^|\.)cloudfront\.net$/, /(^|\.)gstatic\.com$/, /(^|\.)googleapis\.com$/,
+  /(^|\.)google\.com$/, /(^|\.)show-score\.com$/, /(^|\.)todaytixgroup\.com$/,
+  // Fifth wave (task #71): UK ticketing/tourism-listing platforms and ad-tech,
+  // measured on WE family/kids shows (Dog Man - The Musical, A Midsummer
+  // Night's Dream) — never review outlets, unlike londontheatredirect.com
+  // (deliberately NOT added here — it also publishes /news/*-review posts).
+  /^doubleclick\.net$/, /^showify\.uk$/, /^showpass\.com$/,
+  /^showtours\.co\.uk$/, /^bookitplease\.com$/, /^visitlondon\.com$/,
+  /^southlondon\.co\.uk$/,
 ];
 
 const ALLOWED_ORG_HOSTS = new Set([

--- a/scripts/lib/non-review-url-patterns.test.mjs
+++ b/scripts/lib/non-review-url-patterns.test.mjs
@@ -55,19 +55,23 @@ test('namedNonReviewReason: an unparseable URL returns null, never throws', () =
   assert.equal(namedNonReviewReason(null), null);
 });
 
-test('NON_REVIEW_HOST_PATTERNS: page-asset and aggregator-own-domain chaff is blocked (task #71)', () => {
+test('NON_REVIEW_HOST_PATTERNS: page-asset chaff is blocked (task #71)', () => {
   // Measured in data/audit/show-review-gap.json's "missing" lists across
   // ~150 audited shows: fonts/CDN/maps/forms embedded in an aggregator
-  // article's HTML, and Show Score's own catalogue pages (never an outlet).
+  // article's HTML.
   assert.equal(isHostBlocked('https://dalyklerwhmui.cloudfront.net'), true);
   assert.equal(isHostBlocked('https://fonts.gstatic.com'), true);
   assert.equal(isHostBlocked('https://fonts.googleapis.com/css2'), true);
   assert.equal(isHostBlocked('https://maps.google.com/'), true);
   assert.equal(isHostBlocked('https://docs.google.com/forms/d/e/abc/viewform'), true);
   assert.equal(isHostBlocked('https://www.todaytixgroup.com/careers'), true);
-  assert.equal(isHostBlocked('https://www.show-score.com/off-broadway-shows/bone-wars'), true);
   // A real outlet is never blocked by this wave.
   assert.equal(isHostBlocked('https://www.nytimes.com/2026/01/01/theater/some-review.html'), false);
+  // show-score.com is deliberately NOT blocked despite its own catalog links
+  // leaking through the same way — coverage-adversarial-probe.js's
+  // onDiskByUrlFor() depends on isReviewUrl() to index legitimately-captured
+  // Show Score star-stub files by URL (see aggregator-domains.js).
+  assert.equal(isHostBlocked('https://www.show-score.com/off-broadway-shows/bone-wars'), false);
 });
 
 test('NON_REVIEW_HOST_PATTERNS: UK ticketing/tourism-listing chaff is blocked (task #71 fifth wave)', () => {
@@ -77,10 +81,14 @@ test('NON_REVIEW_HOST_PATTERNS: UK ticketing/tourism-listing chaff is blocked (t
   assert.equal(isHostBlocked('https://showtours.co.uk/book/dog-man-the-musical-london/'), true);
   assert.equal(isHostBlocked('https://www.bookitplease.com/shows/united-kingdom/dog-man-6046'), true);
   assert.equal(isHostBlocked('https://www.visitlondon.com/things-to-do/event/51157787-dog-man'), true);
-  assert.equal(isHostBlocked('https://southlondon.co.uk/area/southwark/dog-man-the-musical/'), true);
   // londontheatredirect.com is deliberately NOT blocked — it also publishes
   // /news/*-review posts alongside its ticketing pages.
   assert.equal(isHostBlocked('https://www.londontheatredirect.com/news/oh-mary-review'), false);
+  // southlondon.co.uk is ALSO deliberately NOT blocked — it's a registered
+  // Tier 4 outlet ("south-london") with real reviews under /lifestyle/review-*;
+  // its /area/ listing pages are a different section of the same site.
+  assert.equal(isHostBlocked('https://southlondon.co.uk/area/southwark/dog-man-the-musical/'), false);
+  assert.equal(isHostBlocked('https://southlondon.co.uk/lifestyle/review-cyrano-de-bergerac-at-noel-coward-theatre/'), false);
 });
 
 test('NAMED_NON_REVIEW_URL_PATTERNS: every entry has a host regex and a reason string', () => {

--- a/scripts/lib/non-review-url-patterns.test.mjs
+++ b/scripts/lib/non-review-url-patterns.test.mjs
@@ -7,7 +7,20 @@ import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { namedNonReviewReason, NAMED_NON_REVIEW_URL_PATTERNS } = require('./non-review-url-patterns.js');
+const { namedNonReviewReason, NAMED_NON_REVIEW_URL_PATTERNS, NON_REVIEW_HOST_PATTERNS, ALLOWED_ORG_HOSTS } = require('./non-review-url-patterns.js');
+
+// Mirrors audit-show-review-gap.js's registrableHost() collapse for a plain
+// host-pattern check (task #71 residual-gap triage additions) — including its
+// multi-part public-suffix list, so a .co.uk host collapses to 3 labels, not 2.
+const MULTIPART_SUFFIXES = ['co.uk', 'org.uk', 'me.uk', 'ac.uk', 'gov.uk', 'com.au', 'net.au', 'org.au', 'co.nz', 'co.za', 'com.br'];
+function isHostBlocked(url) {
+  let host;
+  try { host = new URL(url).hostname.replace(/^www\./, '').toLowerCase(); } catch { return false; }
+  const parts = host.split('.').filter(Boolean);
+  const keep = MULTIPART_SUFFIXES.some(s => host.endsWith('.' + s)) ? 3 : 2;
+  const registrable = parts.length > keep ? parts.slice(-keep).join('.') : host;
+  return NON_REVIEW_HOST_PATTERNS.some(rx => rx.test(registrable)) && !ALLOWED_ORG_HOSTS.has(registrable);
+}
 
 test('namedNonReviewReason: ticketing reseller hosts are named', () => {
   assert.equal(namedNonReviewReason('https://www.newyorkcitytheatre.com/some-show'), 'ticketing-reseller');
@@ -40,6 +53,34 @@ test('namedNonReviewReason: an unparseable URL returns null, never throws', () =
   assert.equal(namedNonReviewReason('not-a-url'), null);
   assert.equal(namedNonReviewReason(''), null);
   assert.equal(namedNonReviewReason(null), null);
+});
+
+test('NON_REVIEW_HOST_PATTERNS: page-asset and aggregator-own-domain chaff is blocked (task #71)', () => {
+  // Measured in data/audit/show-review-gap.json's "missing" lists across
+  // ~150 audited shows: fonts/CDN/maps/forms embedded in an aggregator
+  // article's HTML, and Show Score's own catalogue pages (never an outlet).
+  assert.equal(isHostBlocked('https://dalyklerwhmui.cloudfront.net'), true);
+  assert.equal(isHostBlocked('https://fonts.gstatic.com'), true);
+  assert.equal(isHostBlocked('https://fonts.googleapis.com/css2'), true);
+  assert.equal(isHostBlocked('https://maps.google.com/'), true);
+  assert.equal(isHostBlocked('https://docs.google.com/forms/d/e/abc/viewform'), true);
+  assert.equal(isHostBlocked('https://www.todaytixgroup.com/careers'), true);
+  assert.equal(isHostBlocked('https://www.show-score.com/off-broadway-shows/bone-wars'), true);
+  // A real outlet is never blocked by this wave.
+  assert.equal(isHostBlocked('https://www.nytimes.com/2026/01/01/theater/some-review.html'), false);
+});
+
+test('NON_REVIEW_HOST_PATTERNS: UK ticketing/tourism-listing chaff is blocked (task #71 fifth wave)', () => {
+  assert.equal(isHostBlocked('https://securepubads.g.doubleclick.net/pagead/managed/dict/m1/gpt'), true);
+  assert.equal(isHostBlocked('https://www.showify.uk/shows/dog-man-the-musical'), true);
+  assert.equal(isHostBlocked('https://www.showpass.com/dog-man-the-musical-affp3/'), true);
+  assert.equal(isHostBlocked('https://showtours.co.uk/book/dog-man-the-musical-london/'), true);
+  assert.equal(isHostBlocked('https://www.bookitplease.com/shows/united-kingdom/dog-man-6046'), true);
+  assert.equal(isHostBlocked('https://www.visitlondon.com/things-to-do/event/51157787-dog-man'), true);
+  assert.equal(isHostBlocked('https://southlondon.co.uk/area/southwark/dog-man-the-musical/'), true);
+  // londontheatredirect.com is deliberately NOT blocked — it also publishes
+  // /news/*-review posts alongside its ticketing pages.
+  assert.equal(isHostBlocked('https://www.londontheatredirect.com/news/oh-mary-review'), false);
 });
 
 test('NAMED_NON_REVIEW_URL_PATTERNS: every entry has a host regex and a reason string', () => {


### PR DESCRIPTION
## Summary
- Triaged the 306 residual-gap shows from the catalogue backfill: sampled ~150 recently-audited shows in `data/audit/show-review-gap.json` and found ~20% of non-prior-run "missing" candidates were never reviews (page-asset/CDN/ticketing chaff leaking through `isReviewUrl()`).
- Added the missing host patterns to `scripts/lib/non-review-url-patterns.js` (shared by `audit-show-review-gap.js` and the S5 adversarial probe).
- Top 3 shows (schmigadoon-2026, the-lost-boys-2026, the-rocky-horror-show-2026) confirmed complete — every current "gap" is a correctly-excluded prior-production/wrongShow/duplicate/syndication entry, not a real miss.
- ship-check (Codex adversarial review) caught 2 false positives in the first pass — `southlondon.co.uk` is a real registered outlet, and blocking `show-score.com` would break `coverage-adversarial-probe.js`'s on-disk URL index — both reverted in a follow-up commit.

## Test plan
- [x] `node --test scripts/lib/non-review-url-patterns.test.mjs` (9/9 pass)
- [x] `node --test scripts/audit-show-review-gap.test.mjs` (13/13 pass, required by card acceptance criteria)
- [x] `npx tsc --noEmit` clean
- [x] ship-check adversarial review run + findings fixed
- [x] review-gate verdict recorded (pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)