### PR TITLE
fix: distinguish no-access from no-data newsletter section skips (#1158)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -19,6 +19,9 @@ paths = [
   '''(^|/)tests/unit/.*\.m?(j|t)s$''',
   # Colocated scripts/lib tests reference the same slug-string fixtures (e.g. idKey: 'becky-shaw-2026')
   '''(^|/)scripts/lib/.*\.test\.mjs$''',
+  # Colocated scripts/newsletter tests reference env VAR NAMES (e.g. 'no-access: GA4_PROPERTY_ID
+  # missing') that trip generic-api-key on entropy alone — no actual key values, just identifiers
+  '''(^|/)scripts/newsletter/.*\.test\.mjs$''',
   # Aggregated reviews.json contains the same third-party URL fragments as the per-show JSONs
   '''(^|/)data/reviews\.json$''',
   '''(^|/)public/data/reviews\.json$''',

--- a/scripts/lib/newsletter-sections.js
+++ b/scripts/lib/newsletter-sections.js
@@ -68,7 +68,20 @@ function createSectionRunner() {
 
   function entriesSnapshot() { return entries.slice(); }
 
-  return { run, printSummary, writeMeta, entries: entriesSnapshot };
+  // Rewrites each entry's skipReason in place via `classifierFn(entry)` — the
+  // no-data-vs-no-access reclassification (scripts/newsletter/
+  // section-credential-guard.mjs's classifyEntry) runs through here so
+  // printSummary/writeMeta below always see the corrected reason, not the
+  // generic 'no-data' the runner recorded at call time. classifierFn may
+  // return the same entry unchanged for cases it doesn't apply to.
+  function reclassify(classifierFn) {
+    for (let i = 0; i < entries.length; i++) {
+      const next = classifierFn(entries[i]);
+      if (next) entries[i] = next;
+    }
+  }
+
+  return { run, printSummary, writeMeta, entries: entriesSnapshot, reclassify };
 }
 
 module.exports = { createSectionRunner };

--- a/scripts/newsletter/generate.mjs
+++ b/scripts/newsletter/generate.mjs
@@ -27,6 +27,7 @@ const cjsRequire = createRequire(import.meta.url);
 const { showFormatTitle, showFormatLabel, resolveShowFormat } = cjsRequire('../lib/show-format.js');
 const { buildUnsubscribeUrl, resolveNewsletterEdition } = cjsRequire(path.join(repo, 'scripts/lib/email-templates'));
 const { reconcileClosure, reconcileClosureDateWithClosingDate } = cjsRequire(path.join(repo, 'scripts/lib/cast-changes-filters'));
+const { classifyEntry } = await import('./section-credential-guard.mjs');
 const { pluralize, pluralNoun } = cjsRequire(path.join(repo, 'scripts/lib/pluralize'));
 const { isFreshRecoupmentNews } = cjsRequire(path.join(repo, 'scripts/lib/recoupment-news'));
 const { reviews } = JSON.parse(fs.readFileSync(path.join(repo, 'data/reviews.json'), 'utf8'));
@@ -2653,6 +2654,11 @@ const slug = `A-${argDate}`;
 // click-tracking preserves the query string, so these survive the redirect.
 const { applyUtm } = cjsRequire('../lib/email-utm.js');
 fs.writeFileSync(`${outDir}/${slug}.html`, applyUtm(html, { source: 'newsletter', campaign: `${BRAND.utm}-${weekEndStr}` }));
+// Reclassify credential-backed skips (e.g. most-read-pages when GA4 creds
+// are absent) from 'no-data' to 'no-access: <var> missing' BEFORE the report
+// is printed/written — see scripts/newsletter/section-credential-guard.mjs.
+sections.reclassify(classifyEntry);
+
 // Sidecar JSON with subject + section-by-section run report so the send
 // script can pick up the subject without parsing HTML, and so we can detect
 // silently-skipped sections in regression tests / CI.

--- a/scripts/newsletter/pre-send-check.mjs
+++ b/scripts/newsletter/pre-send-check.mjs
@@ -49,6 +49,7 @@ const {
 } = require_('../lib/newsletter-preflight.js');
 const { loadAcks, isAcked, addAck, saveAcks, cellKey } = require_('../lib/t1-scoreboard.js');
 const { resolveNewsletterEdition } = require_('../lib/email-templates.js');
+const { hasNoAccessSection, noAccessSections } = await import('./section-credential-guard.mjs');
 
 const NEWSLETTER_GAP_NS = 'newsletter-gap'; // namespaced "outletId" in the shared ack store — see t1-scoreboard.js
 
@@ -250,6 +251,20 @@ if (hardFailuresEarly.length === 0 && Array.isArray(meta.openingShows)) {
 
 const hardFailures = [...hardFailuresEarly];  // stop the workflow entirely
 const softIssues = [...appliedSwapNotes, ...unswappableNotes];    // inject into draft banner so owner sees them
+
+// ── HARD: no-access sections (card #1158) ─────────────────────────────────────
+// generate.mjs reclassifies a credential-backed section's skip from 'no-data'
+// to 'no-access: <var> missing' when its required env var is absent (see
+// section-credential-guard.mjs). That is a fetch that never ran, not an empty
+// week — a dev machine missing GA4_PROPERTY_ID silently deleted "Trending
+// This Week" from a subscriber-facing draft on 2026-08-09 and nothing caught
+// it. Refuse to PATCH the Resend draft in that state; NEWSLETTER_ALLOW_NO_ACCESS=1
+// is the explicit, opt-in override (mirrors NEWSLETTER_ALLOW_GAPS).
+if (Array.isArray(meta.sections) && hasNoAccessSection(meta.sections)) {
+  for (const s of noAccessSections(meta.sections)) {
+    hardFailures.push(`Section "${s.name}" skipped for ${s.skipReason} — the draft is missing real data, not just an empty week. Run from an environment with the credential (see refresh-drafts.sh usage comment), or set NEWSLETTER_ALLOW_NO_ACCESS=1 to send without it.`);
+  }
+}
 
 // ── HARD: unsubscribe placeholder ────────────────────────────────────────────
 if (!html.includes('{{{RESEND_UNSUBSCRIBE_URL}}}')) {

--- a/scripts/newsletter/refresh-drafts.sh
+++ b/scripts/newsletter/refresh-drafts.sh
@@ -25,8 +25,13 @@
 # Usage:
 #   bash scripts/newsletter/refresh-drafts.sh [weekStart YYYY-MM-DD]
 #     weekStart defaults to the most recent Monday in America/New_York.
-#   Requires .env with RESEND_API_KEY (+ GA4_PROPERTY_ID/GA_KEY_FILE for the
-#   Trending section — without them that section silently no-ops).
+#   Requires .env with RESEND_API_KEY (+ GA4_PROPERTY_ID and either
+#   GA_KEY_FILE or GA_SERVICE_ACCOUNT_KEY for the Trending section). Those
+#   GA4 vars are GitHub secrets, not in local .env — without them pre-send-
+#   check.mjs's HARD no-access gate (card #1158) REFUSES to PATCH the Resend
+#   draft rather than silently shipping it with Trending deleted. Run
+#   newsletter-draft-refresh.yml (which holds the secrets) instead, or set
+#   NEWSLETTER_ALLOW_NO_ACCESS=1 to send without Trending on purpose.
 
 set -euo pipefail
 cd "$(dirname "$0")/../.."

--- a/scripts/newsletter/section-credential-guard.mjs
+++ b/scripts/newsletter/section-credential-guard.mjs
@@ -1,0 +1,82 @@
+// Distinguishes "this section has no data this week" from "this section
+// couldn't reach its data source because a credential is missing" for the
+// weekly newsletter's section runner (scripts/lib/newsletter-sections.js).
+//
+// Card #1158: every section that returns null/empty from `sections.run()`
+// was recorded as skipReason 'no-data', whether the cause was a genuinely
+// quiet week OR a section whose fetch never ran because GA4_PROPERTY_ID /
+// GA_SERVICE_ACCOUNT_KEY are absent (true on any dev machine — those are
+// GitHub secrets, never in local .env). A 2026-08-09 local regen silently
+// shipped a Broadway draft with "Trending This Week" deleted and nothing
+// flagged it; the owner caught it by eye.
+//
+// SECTION_CREDENTIALS is the enumerated table of every generate.mjs section
+// that reads from a live external API rather than local repo JSON (see
+// generate.mjs's section-runner block for the full section list — everything
+// NOT in this table reads shows.json/reviews.json/cast-changes.json/
+// grosses.json/commercial.json/.social.json, all committed to the repo, so
+// "no data" there really does mean "no data").
+//
+//   most-read-pages  — popular-pages.mjs's fetchPopularShowPages() queries
+//                       GA4 directly; needs GA4_PROPERTY_ID plus either a
+//                       key file or an inline service-account key.
+//
+// Each entry is a list of "require groups": every group must have at least
+// one set env var (AND across groups, OR within a group) for the section to
+// be considered credential-OK.
+export const SECTION_CREDENTIALS = {
+  'most-read-pages': [
+    ['GA4_PROPERTY_ID'],
+    ['GA_KEY_FILE', 'GA_SERVICE_ACCOUNT_KEY'],
+  ],
+};
+
+export function isCredentialBacked(name) {
+  return Object.prototype.hasOwnProperty.call(SECTION_CREDENTIALS, name);
+}
+
+// Returns a human-readable description of the first unmet requirement group
+// for `name`, or null when every group is satisfied (including sections with
+// no entry in SECTION_CREDENTIALS at all — those never need credentials).
+export function missingCredential(name, env = process.env) {
+  const groups = SECTION_CREDENTIALS[name];
+  if (!groups) return null;
+  for (const group of groups) {
+    if (!group.some((v) => !!env[v])) {
+      return group.length === 1 ? group[0] : group.join(' or ');
+    }
+  }
+  return null;
+}
+
+// Reclassifies one section-runner entry ({name, fired, skipReason, ...}):
+// a skipped, credential-backed section whose creds are absent is relabeled
+// 'no-access: <vars> missing' regardless of what the runner recorded — this
+// is the override that keeps a credential gap from ever reading as 'no-data'.
+// Fired sections and non-credential sections pass through unchanged.
+//
+// `noAccess: true` is the discrete field the PATCH-refusal gate below reads —
+// deliberately NOT a skipReason string-prefix check, so a future rewording of
+// the human-readable reason can't silently stop the gate from firing.
+export function classifyEntry(entry, env = process.env) {
+  if (!entry || entry.fired) return entry;
+  const missing = missingCredential(entry.name, env);
+  if (!missing) return entry;
+  return { ...entry, skipReason: `no-access: ${missing} missing`, noAccess: true };
+}
+
+export function classifyEntries(entries, env = process.env) {
+  return entries.map((e) => classifyEntry(e, env));
+}
+
+export function noAccessSections(entries) {
+  return entries.filter((e) => e && e.noAccess === true);
+}
+
+// The PATCH-refusal gate: true when any section in `entries` was skipped for
+// a missing credential. NEWSLETTER_ALLOW_NO_ACCESS=1 is the explicit,
+// opt-in override (mirrors NEWSLETTER_ALLOW_GAPS) — the default is refuse.
+export function hasNoAccessSection(entries, env = process.env) {
+  if (env.NEWSLETTER_ALLOW_NO_ACCESS === '1') return false;
+  return noAccessSections(entries).length > 0;
+}

--- a/scripts/newsletter/section-credential-guard.test.mjs
+++ b/scripts/newsletter/section-credential-guard.test.mjs
@@ -1,0 +1,215 @@
+// Card #1158: a section whose data source needs a credential (most-read-pages'
+// GA4 fetch) must never be reported as 'no-data' when the real cause is a
+// missing env var, and the PATCH-to-Resend path must refuse to ship a draft
+// that has one. Per CLAUDE.md §15 these exercise the real functions —
+// pre-send-check.mjs's HARD gate calls hasNoAccessSection/noAccessSections
+// straight from section-credential-guard.mjs, no reimplementation here.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import {
+  SECTION_CREDENTIALS,
+  isCredentialBacked,
+  missingCredential,
+  classifyEntry,
+  classifyEntries,
+  noAccessSections,
+  hasNoAccessSection,
+} from './section-credential-guard.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(__dirname, '..', '..');
+
+// ── (a) classification: missing credential → 'no-access', never 'no-data' ────
+
+test('missingCredential reports the unmet var for a credential-backed section', () => {
+  assert.equal(missingCredential('most-read-pages', {}), 'GA4_PROPERTY_ID');
+  assert.equal(
+    missingCredential('most-read-pages', { GA4_PROPERTY_ID: '123' }),
+    'GA_KEY_FILE or GA_SERVICE_ACCOUNT_KEY',
+  );
+  assert.equal(
+    missingCredential('most-read-pages', { GA4_PROPERTY_ID: '123', GA_SERVICE_ACCOUNT_KEY: 'xyz' }),
+    null,
+  );
+  assert.equal(
+    missingCredential('most-read-pages', { GA4_PROPERTY_ID: '123', GA_KEY_FILE: '/path' }),
+    null,
+  );
+});
+
+test('missingCredential is null for a section with no entry in the table', () => {
+  assert.equal(missingCredential('casting-updates', {}), null);
+  assert.equal(isCredentialBacked('casting-updates'), false);
+  assert.equal(isCredentialBacked('most-read-pages'), true);
+});
+
+test('classifyEntry relabels a credential-backed skip as no-access, not no-data', () => {
+  const raw = { name: 'most-read-pages', fired: false, skipReason: 'no-data', htmlLength: 0 };
+  const classified = classifyEntry(raw, {});
+  assert.equal(classified.skipReason, 'no-access: GA4_PROPERTY_ID missing');
+  assert.notEqual(classified.skipReason, 'no-data');
+});
+
+test('classifyEntry leaves a genuinely-empty non-credential section as no-data', () => {
+  const raw = { name: 'casting-updates', fired: false, skipReason: 'no-data', htmlLength: 0 };
+  const classified = classifyEntry(raw, {});
+  assert.equal(classified.skipReason, 'no-data');
+});
+
+test('classifyEntry leaves a fired section untouched even if credential-backed', () => {
+  const raw = { name: 'most-read-pages', fired: true, skipReason: null, htmlLength: 800 };
+  const classified = classifyEntry(raw, {});
+  assert.deepEqual(classified, raw);
+});
+
+test('classifyEntry does not misfire when the credential IS present', () => {
+  const raw = { name: 'most-read-pages', fired: false, skipReason: 'no-data', htmlLength: 0 };
+  const env = { GA4_PROPERTY_ID: '123', GA_SERVICE_ACCOUNT_KEY: 'xyz' };
+  const classified = classifyEntry(raw, env);
+  assert.equal(classified.skipReason, 'no-data'); // genuinely empty this week, creds were fine
+});
+
+test('classifyEntries reclassifies only the credential-backed entries in a full section report', () => {
+  const entries = [
+    { name: 'broadway-openings', fired: true, skipReason: null, htmlLength: 500 },
+    { name: 'casting-updates', fired: false, skipReason: 'no-data', htmlLength: 0 },
+    { name: 'most-read-pages', fired: false, skipReason: 'no-data', htmlLength: 0 },
+  ];
+  const out = classifyEntries(entries, {});
+  assert.equal(out[0].skipReason, null);
+  assert.equal(out[1].skipReason, 'no-data');
+  assert.equal(out[2].skipReason, 'no-access: GA4_PROPERTY_ID missing');
+});
+
+// ── (b) PATCH-refusal decision: hasNoAccessSection is the exact function
+// pre-send-check.mjs's HARD gate calls before allowing create-broadcast-
+// draft.mjs to PATCH the Resend draft ────────────────────────────────────────
+
+test('hasNoAccessSection is true when a no-access section survives classification', () => {
+  const entries = classifyEntries([
+    { name: 'most-read-pages', fired: false, skipReason: 'no-data', htmlLength: 0 },
+  ], {});
+  assert.equal(hasNoAccessSection(entries, {}), true);
+  assert.equal(noAccessSections(entries).length, 1);
+});
+
+test('noAccessSections keys off the noAccess boolean, not a skipReason string prefix', () => {
+  // Guards against the class of bug where a future skipReason rewording
+  // silently stops the gate from firing — the decision must not depend on
+  // string-matching human-readable text.
+  const lookalike = { name: 'some-other-section', fired: false, skipReason: 'no-access to the venue this week', htmlLength: 0 };
+  assert.equal(noAccessSections([lookalike]).length, 0);
+  const real = classifyEntry({ name: 'most-read-pages', fired: false, skipReason: 'no-data', htmlLength: 0 }, {});
+  assert.equal(noAccessSections([real]).length, 1);
+});
+
+test('hasNoAccessSection is false for an all-local-data draft with real empty sections', () => {
+  const entries = classifyEntries([
+    { name: 'broadway-openings', fired: true, skipReason: null, htmlLength: 500 },
+    { name: 'casting-updates', fired: false, skipReason: 'no-data', htmlLength: 0 },
+  ], {});
+  assert.equal(hasNoAccessSection(entries, {}), false);
+});
+
+test('hasNoAccessSection is false once the missing credential is supplied', () => {
+  const env = { GA4_PROPERTY_ID: '123', GA_SERVICE_ACCOUNT_KEY: 'xyz' };
+  const entries = classifyEntries([
+    { name: 'most-read-pages', fired: false, skipReason: 'no-data', htmlLength: 0 },
+  ], env);
+  assert.equal(hasNoAccessSection(entries, env), false);
+});
+
+test('NEWSLETTER_ALLOW_NO_ACCESS=1 is the explicit override — default stays refuse', () => {
+  const entries = classifyEntries([
+    { name: 'most-read-pages', fired: false, skipReason: 'no-data', htmlLength: 0 },
+  ], {});
+  assert.equal(hasNoAccessSection(entries, {}), true);
+  assert.equal(hasNoAccessSection(entries, { NEWSLETTER_ALLOW_NO_ACCESS: '1' }), false);
+});
+
+test('SECTION_CREDENTIALS only lists sections that actually fetch a live external API', () => {
+  // Guard against silent scope creep: this table exists specifically for
+  // generate.mjs sections backed by a network fetch, not local repo JSON.
+  assert.deepEqual(Object.keys(SECTION_CREDENTIALS), ['most-read-pages']);
+});
+
+// ── End-to-end: pre-send-check.mjs actually refuses to clear a draft with a
+// no-access section, and clears one without it. Spawns the real script
+// against synthetic fixtures — proves the gate is wired, not just the pure
+// decision function in isolation.
+
+function writeFixture(outDir, weekStart, { sections, htmlExtra = '' }) {
+  fs.mkdirSync(outDir, { recursive: true });
+  const html = `<!DOCTYPE html><html><body>${htmlExtra}{{{RESEND_UNSUBSCRIBE_URL}}}<!-- BODY_SECTIONS_START --></body></html>`;
+  fs.writeFileSync(path.join(outDir, `A-${weekStart}.html`), html);
+  fs.writeFileSync(path.join(outDir, `A-${weekStart}.meta.json`), JSON.stringify({
+    subject: 'Test Weekly Round-up',
+    edition: 'broadway',
+    weekStart,
+    weekEnd: weekStart,
+    sections,
+  }, null, 2));
+}
+
+test('pre-send-check.mjs exits non-zero and names the no-access section when one is present', () => {
+  const weekStart = '2026-08-03';
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'newsletter-no-access-'));
+  writeFixture(outDir, weekStart, {
+    sections: [
+      { name: 'broadway-openings', fired: true, skipReason: null, htmlLength: 500 },
+      { name: 'most-read-pages', fired: false, skipReason: 'no-access: GA4_PROPERTY_ID missing', htmlLength: 0, noAccess: true },
+    ],
+  });
+  assert.throws(() => {
+    execFileSync('node', [path.join(repoRoot, 'scripts/newsletter/pre-send-check.mjs'), weekStart], {
+      cwd: repoRoot,
+      env: { ...process.env, NEWSLETTER_OUT_DIR: outDir, NEWSLETTER_EDITION: undefined },
+      stdio: 'pipe',
+    });
+  }, (err) => {
+    assert.equal(err.status, 1);
+    const out = `${err.stdout || ''}${err.stderr || ''}`;
+    assert.match(out, /no-access: GA4_PROPERTY_ID missing/);
+    assert.match(out, /HARD FAILURE/);
+    return true;
+  });
+});
+
+test('pre-send-check.mjs clears a draft whose skips are all genuine no-data', () => {
+  const weekStart = '2026-08-03';
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'newsletter-no-access-'));
+  writeFixture(outDir, weekStart, {
+    sections: [
+      { name: 'broadway-openings', fired: true, skipReason: null, htmlLength: 500 },
+      { name: 'casting-updates', fired: false, skipReason: 'no-data', htmlLength: 0 },
+    ],
+  });
+  const out = execFileSync('node', [path.join(repoRoot, 'scripts/newsletter/pre-send-check.mjs'), weekStart], {
+    cwd: repoRoot,
+    env: { ...process.env, NEWSLETTER_OUT_DIR: outDir, NEWSLETTER_EDITION: undefined },
+    stdio: 'pipe',
+  }).toString();
+  assert.match(out, /Pre-send check OK/);
+});
+
+test('pre-send-check.mjs clears a no-access section when NEWSLETTER_ALLOW_NO_ACCESS=1 overrides it', () => {
+  const weekStart = '2026-08-03';
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'newsletter-no-access-'));
+  writeFixture(outDir, weekStart, {
+    sections: [
+      { name: 'broadway-openings', fired: true, skipReason: null, htmlLength: 500 },
+      { name: 'most-read-pages', fired: false, skipReason: 'no-access: GA4_PROPERTY_ID missing', htmlLength: 0, noAccess: true },
+    ],
+  });
+  const out = execFileSync('node', [path.join(repoRoot, 'scripts/newsletter/pre-send-check.mjs'), weekStart], {
+    cwd: repoRoot,
+    env: { ...process.env, NEWSLETTER_OUT_DIR: outDir, NEWSLETTER_EDITION: undefined, NEWSLETTER_ALLOW_NO_ACCESS: '1' },
+    stdio: 'pipe',
+  }).toString();
+  assert.match(out, /Pre-send check OK/);
+});

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -42,6 +42,7 @@ scripts/lib/zombie-tab-sweep.test.mjs
 scripts/llm-scoring/batch-mode.test.mjs
 scripts/llm-scoring/openai-leg-model.test.mjs
 scripts/newsletter/newsworthiness.test.mjs
+scripts/newsletter/section-credential-guard.test.mjs
 scripts/newsletter/we-openings-section.test.mjs
 scripts/notion-tasks-sync.test.mjs
 scripts/opening-night-checklist.test.mjs


### PR DESCRIPTION
## Summary
- A credential-backed newsletter section (most-read-pages, needs GA4_PROPERTY_ID + GA_SERVICE_ACCOUNT_KEY/GA_KEY_FILE) was reported as 'no-data' identically to a genuinely empty section, whenever its fetch never ran due to missing env vars — indistinguishable in logs and in the rendered draft. A 2026-08-09 local regen (no GA4 creds in local .env) silently shipped a Broadway draft with "Trending This Week" deleted.
- `scripts/newsletter/section-credential-guard.mjs` declares which sections require which env vars and reclassifies a credential-backed skip to `'no-access: <var> missing'` (never `'no-data'`).
- `scripts/newsletter/pre-send-check.mjs` now HARD-refuses to PATCH the Resend draft when any no-access section is present. `NEWSLETTER_ALLOW_NO_ACCESS=1` is the explicit override.
- Every other newsletter section reads committed repo JSON (shows.json, reviews.json, cast-changes.json, grosses.json, commercial.json, .social.json) — `most-read-pages` is the only one that hits a live external API.

## Test plan
- [x] `node --test scripts/newsletter/section-credential-guard.test.mjs` — 16/16 passing, proves both (a) missing-credential classification and (b) PATCH-refusal gate
- [x] `npx tsc --noEmit` clean
- [x] Reproduced the real incident locally (no GA4 creds): `generate.mjs` now reports `no-access: GA4_PROPERTY_ID missing` instead of `no-data`, and `pre-send-check.mjs` exits 1 and refuses the draft
- [x] Ship-check: independent Claude review (no bugs found) + adversarial GPT-5.4-mini review (one finding applied — switched the PATCH-refusal gate from a skipReason string-prefix match to an explicit `noAccess` boolean field for robustness)
- [x] Full `scripts/newsletter/*.test.mjs` suite green (29/29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)