### PR TITLE
data: auto-register 9 new regional outlets

### DIFF
--- a/data/outlet-registry.json
+++ b/data/outlet-registry.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "description": "Canonical outlet registry - ALL scripts must use this for outlet normalization",
-    "lastUpdated": "2026-08-07T10:16:13.371Z",
+    "lastUpdated": "2026-08-10T13:26:05.052Z",
     "version": "2.1.0",
     "lastChange": "merge auto-registered ayoungishperspective into a-youngish-perspective (alias already present)"
   },
@@ -10638,6 +10638,85 @@
         "makaylahoppe"
       ],
       "domain": "makaylahoppe.com"
+    },
+    "londonlivinglarge": {
+      "displayName": "Londonlivinglarge",
+      "tier": 3,
+      "aliases": [
+        "londonlivinglarge"
+      ],
+      "domain": "londonlivinglarge.com",
+      "region": "london"
+    },
+    "thecomicscomic": {
+      "displayName": "Thecomicscomic",
+      "tier": 3,
+      "aliases": [
+        "thecomicscomic"
+      ],
+      "domain": "thecomicscomic.com"
+    },
+    "westminsterextra": {
+      "displayName": "Westminsterextra",
+      "tier": 3,
+      "aliases": [
+        "westminsterextra"
+      ],
+      "domain": "westminsterextra.co.uk",
+      "region": "london"
+    },
+    "elementaltheatre": {
+      "displayName": "Elementaltheatre",
+      "tier": 3,
+      "aliases": [
+        "elementaltheatre"
+      ],
+      "domain": "elementaltheatre.com",
+      "region": "london"
+    },
+    "thelivereview": {
+      "displayName": "Thelivereview",
+      "tier": 3,
+      "aliases": [
+        "thelivereview"
+      ],
+      "domain": "thelivereview.co.uk",
+      "region": "london"
+    },
+    "behindtheencore": {
+      "displayName": "Behindtheencore",
+      "tier": 3,
+      "aliases": [
+        "behindtheencore"
+      ],
+      "domain": "behindtheencore.substack.com"
+    },
+    "aviewfromthebox": {
+      "displayName": "Aviewfromthebox",
+      "tier": 3,
+      "aliases": [
+        "aviewfromthebox"
+      ],
+      "domain": "aviewfromthebox.net",
+      "region": "london"
+    },
+    "theartsdispatch": {
+      "displayName": "Theartsdispatch",
+      "tier": 3,
+      "aliases": [
+        "theartsdispatch"
+      ],
+      "domain": "theartsdispatch.substack.com",
+      "region": "london"
+    },
+    "lsbo": {
+      "displayName": "Lsbo",
+      "tier": 3,
+      "aliases": [
+        "lsbo"
+      ],
+      "domain": "lsbo.co.uk",
+      "region": "london"
     }
   },
   "_aliasIndex": {


### PR DESCRIPTION
Auto-registers 9 new UK regional theater outlets to the registry.

**Outlets added:**
- londonlivinglarge
- thecomicscomic  
- westminsterextra
- elementaltheatre
- thelivereview
- behindtheencore
- aviewfromthebox
- theartsdispatch
- lsbo (London Box Office)

**Verification:**
- `npm run data:check` passed (2886 shows, 19670 reviews)
- All outlets properly configured with tier 3 and regional markers where applicable