### PR TITLE
Detectors for two silent-exclusion classes (task #1188)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -477,6 +477,14 @@ on:
       # scripts/health-check.js (checkQuality "Quality: star-vs-score mismatch").
       - 'scripts/lib/star-score-mismatch.js'
       - 'scripts/lib/star-score-mismatch.test.mjs'
+      # Silent-exclusion detectors (task #1188): outlet domain moves + reviews
+      # with text and a byline but no contentTier. Pure predicates + colocated
+      # test run by the scripts/lib/*.test.mjs glob; path-listed so a solo edit
+      # triggers CI (allow-list gate). CLI + health-check wiring live in
+      # scripts/audit-silent-exclusions.js and scripts/health-check.js
+      # ("Quality: reviews missing contentTier", "Quality: outlet domain move").
+      - 'scripts/lib/silent-exclusion-detectors.js'
+      - 'scripts/lib/silent-exclusion-detectors.test.mjs'
       # extractScore()'s KNOWN_STAR_OUTLETS fallthrough (card #935): a combined
       # multi-show roundup column's per-show rating list ("Phaedra ***** Sylvia
       # *** ...") was resolved by blindly taking the FIRST anchored star group,

--- a/data/audit/silent-exclusions.json
+++ b/data/audit/silent-exclusions.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-10T13:47:12.455Z",
+  "generatedAt": "2026-08-10T14:03:20.428Z",
   "outletDomainMoves": {
     "scannedHosts": 218,
     "domainlessMatches": 40,
@@ -54,6 +54,10 @@
     ]
   },
   "missingContentTier": {
-    "skipped": "review-texts not checked out (private repo)"
+    "scannedFiles": 42276,
+    "baselinedCount": 0,
+    "predicateErrors": 0,
+    "firstPredicateError": null,
+    "findings": []
   }
 }

--- a/data/audit/silent-exclusions.json
+++ b/data/audit/silent-exclusions.json
@@ -1,0 +1,59 @@
+{
+  "generatedAt": "2026-08-10T13:47:12.455Z",
+  "outletDomainMoves": {
+    "scannedHosts": 218,
+    "domainlessMatches": 40,
+    "baselinedCount": 0,
+    "findings": [
+      {
+        "host": "reviewsgate.co.uk",
+        "outletId": "reviewsgate",
+        "registeredDomain": "reviewsgate.com",
+        "matchedSlug": "reviewsgate",
+        "occurrences": 3,
+        "sampleUrl": "https://www.reviewsgate.co.uk/all-reviews/driftwood-by-martina-laird-rsc-the-other-place-stratford-upon-avon",
+        "shows": [
+          "driftwood-west-end-2026",
+          "the-car-man-west-end-2026",
+          "the-importance-of-being-oscar-off-west-end-2026"
+        ]
+      },
+      {
+        "host": "dailymail.com",
+        "outletId": "daily-mail",
+        "registeredDomain": "dailymail.co.uk",
+        "matchedSlug": "dailymail",
+        "occurrences": 1,
+        "sampleUrl": "https://www.dailymail.com/tvshowbiz/article-15927453/PATRICK-MARMIONs-night-review-intoxicating-voice-like-double-whiskey-you-never-skin-airbrushed-Sinatra.html",
+        "shows": [
+          "sinatra-the-musical-west-end-2026"
+        ]
+      },
+      {
+        "host": "dancemagazine.co.uk",
+        "outletId": "dance-magazine",
+        "registeredDomain": "dancemagazine.com",
+        "matchedSlug": "dancemagazine",
+        "occurrences": 1,
+        "sampleUrl": "https://dancemagazine.co.uk/2026/05/dancers-revealed-for-a-life-in-four-seasons-at-regents-park-open-air-theatre/",
+        "shows": [
+          "a-life-in-four-seasons-west-end-2026"
+        ]
+      },
+      {
+        "host": "metro.news",
+        "outletId": "metro-uk",
+        "registeredDomain": "metro.co.uk",
+        "matchedSlug": "metro",
+        "occurrences": 1,
+        "sampleUrl": "https://www.metro.news/theatre-review-cyrano-de-bergerac/1828065/",
+        "shows": [
+          "cyrano-de-bergerac-west-end-2026"
+        ]
+      }
+    ]
+  },
+  "missingContentTier": {
+    "skipped": "review-texts not checked out (private repo)"
+  }
+}

--- a/scripts/audit-silent-exclusions.js
+++ b/scripts/audit-silent-exclusions.js
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * audit-silent-exclusions.js
+ *
+ * CLI for the two silent-exclusion detectors added by task #1188:
+ *
+ *   (a) OUTLET DOMAIN MOVES — an unregistered host in
+ *       data/audit/unknown-aggregator-outlets.json that derives the same
+ *       identity slug as an outlet registered under a DIFFERENT domain. That
+ *       is the shape of one-minute-critic's move to 1minutecritic.substack.com,
+ *       which silently dropped every review on the new host behind a routine
+ *       `domain-mismatch` skip until it was found by hand.
+ *
+ *   (b) MISSING contentTier — a review with real text, a real byline, no
+ *       rejection flags, and no contentTier: a file that fell out of the
+ *       classification path entirely, which nothing anywhere reported.
+ *
+ * Decision logic lives in scripts/lib/silent-exclusion-detectors.js (pure,
+ * unit-tested) and is shared verbatim with the daily health check, so the CLI
+ * and the digest can never disagree about what counts as a finding.
+ *
+ * BASELINE MODEL: same posture as audit-star-score-mismatch.js. A time window
+ * is the wrong filter — these defects are found long after they land — so the
+ * known/triaged backlog is baselined in data/audit/silent-exclusions-baseline
+ * .json and the health check alerts only on findings NOT in it.
+ *
+ * USAGE:
+ *   node scripts/audit-silent-exclusions.js                  # NEW findings; exit 1 if any
+ *   node scripts/audit-silent-exclusions.js --all            # everything, ignore baseline (exit 0)
+ *   node scripts/audit-silent-exclusions.js --write-baseline # ack the current backlog
+ *   node scripts/audit-silent-exclusions.js --json           # machine-readable
+ *   node scripts/audit-silent-exclusions.js --show=<id>      # (b) for one show
+ *
+ * EXIT CODES: 0 = no new findings (or --all / --write-baseline). 1 = new
+ * findings. 2 = usage/error, including a vacuous scan (task #1065): a corpus
+ * walk that saw ZERO files is a broken checkout, not a clean corpus, and must
+ * never be reported as a pass.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {
+  scanMissingContentTier,
+  missingTierKey,
+  detectOutletDomainMoves,
+  domainMoveKey,
+} = require('./lib/silent-exclusion-detectors');
+
+const ROOT = path.join(__dirname, '..');
+const REVIEW_TEXTS_DIR = path.join(ROOT, 'data', 'review-texts');
+const REGISTRY_PATH = path.join(ROOT, 'data', 'outlet-registry.json');
+const UNKNOWN_HOSTS_PATH = path.join(ROOT, 'data', 'audit', 'unknown-aggregator-outlets.json');
+const BASELINE_PATH = path.join(ROOT, 'data', 'audit', 'silent-exclusions-baseline.json');
+const REPORT_PATH = path.join(ROOT, 'data', 'audit', 'silent-exclusions.json');
+
+function parseArgs(argv) {
+  const args = { all: false, json: false, writeBaseline: false, show: null, help: false };
+  for (const a of argv) {
+    if (a === '--help' || a === '-h') args.help = true;
+    else if (a === '--all') args.all = true;
+    else if (a === '--json') args.json = true;
+    else if (a === '--write-baseline') args.writeBaseline = true;
+    else if (a.startsWith('--show=')) args.show = a.slice(7);
+  }
+  return args;
+}
+
+function usage() {
+  console.log(`audit-silent-exclusions.js — detect two silent-exclusion classes with no other detector.
+
+  (default)          list NEW findings (not in the baseline); exit 1 if any
+  --all              everything, ignore the baseline (audit mode; always exit 0)
+  --write-baseline   snapshot ALL current findings into the baseline (after triage)
+  --show=<id>        restrict the contentTier scan to a single show directory
+  --json             machine-readable output
+  -h, --help         this help
+
+Reads:  data/outlet-registry.json, data/audit/unknown-aggregator-outlets.json, data/review-texts/
+Writes: ${path.relative(ROOT, REPORT_PATH)} (and the baseline with --write-baseline)`);
+}
+
+function readJSON(file, fallback = null) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return fallback; }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  // --help must not write anything (task #534 class).
+  if (args.help) { usage(); process.exit(0); }
+
+  const baselineFile = readJSON(BASELINE_PATH, {}) || {};
+  const useBaseline = !args.all && !args.writeBaseline;
+  const tierBaseline = useBaseline ? (baselineFile.missingContentTier || []) : [];
+  const moveBaseline = useBaseline ? (baselineFile.outletDomainMoves || []) : [];
+
+  // ── (a) outlet domain moves ──────────────────────────────────────────────
+  const registry = readJSON(REGISTRY_PATH);
+  const unknown = readJSON(UNKNOWN_HOSTS_PATH);
+  if (!registry || !registry.outlets) {
+    console.error(`ERROR: cannot read outlet registry at ${REGISTRY_PATH}`);
+    process.exit(2);
+  }
+  const moves = detectOutletDomainMoves({
+    outlets: registry.outlets,
+    unknownHosts: (unknown && unknown.outlets) || [],
+    baselineKeys: moveBaseline,
+  });
+
+  // ── (b) missing contentTier ──────────────────────────────────────────────
+  // review-texts is a private repo (CLAUDE.md §11) and is legitimately absent
+  // on some checkouts. Absent = skipped and SAID SO. Present but empty = a
+  // broken checkout, which is an error, not a pass (task #1065).
+  let tier = null;
+  const reviewTextsPresent = fs.existsSync(REVIEW_TEXTS_DIR);
+  if (reviewTextsPresent) {
+    tier = scanMissingContentTier(REVIEW_TEXTS_DIR, {
+      shows: args.show ? [args.show] : undefined,
+      baselineKeys: tierBaseline,
+    });
+  }
+
+  if (args.writeBaseline) {
+    const payload = {
+      generatedAt: new Date().toISOString(),
+      note: 'Acked backlog for scripts/audit-silent-exclusions.js. Findings NOT listed here alert in the daily health check.',
+      outletDomainMoves: moves.findings.map(domainMoveKey),
+      missingContentTier: tier ? tier.findings.map(missingTierKey) : (baselineFile.missingContentTier || []),
+    };
+    fs.writeFileSync(BASELINE_PATH, `${JSON.stringify(payload, null, 2)}\n`);
+    console.log(`Baseline written: ${payload.outletDomainMoves.length} domain move(s), ${payload.missingContentTier.length} missing-tier finding(s)`);
+    console.log(path.relative(ROOT, BASELINE_PATH));
+    process.exit(0);
+  }
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    outletDomainMoves: {
+      scannedHosts: moves.scanned,
+      domainlessMatches: moves.domainlessMatches,
+      baselinedCount: moves.baselinedCount,
+      findings: moves.findings,
+    },
+    missingContentTier: tier
+      ? { scannedFiles: tier.scanned, baselinedCount: tier.baselinedCount, findings: tier.findings }
+      : { skipped: 'review-texts not checked out (private repo)' },
+  };
+  fs.writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log('=== (a) Probable outlet domain moves ===');
+    console.log(`Scanned ${moves.scanned} unregistered host(s); ${moves.domainlessMatches} matched a domainless outlet (separate class, not reported); ${moves.baselinedCount} baselined.`);
+    if (moves.findings.length === 0) {
+      console.log('No probable domain moves.');
+    } else {
+      for (const f of moves.findings) {
+        console.log(`  ${f.host} → outlet "${f.outletId}" (registered: ${f.registeredDomain}) — ${f.occurrences} occurrence(s)`);
+        if (f.sampleUrl) console.log(`      e.g. ${f.sampleUrl}`);
+      }
+      console.log('\nFix: if the host really is that outlet, add it to the outlet\'s domainAliases in data/outlet-registry.json.');
+      console.log('Otherwise register it as its own outlet, or ack with --write-baseline.');
+    }
+
+    console.log('\n=== (b) Reviews with text + byline + no contentTier ===');
+    if (!tier) {
+      console.log('Skipped — data/review-texts not checked out (private repo).');
+    } else {
+      console.log(`Scanned ${tier.scanned} file(s); ${tier.baselinedCount} baselined.`);
+      if (tier.findings.length === 0) {
+        console.log('No unclassified reviews.');
+      } else {
+        for (const f of tier.findings) {
+          console.log(`  ${f.showId}/${f.file} — ${f.criticName} (${f.outletId}), ${f.chars} chars, scored: ${f.hasScore}`);
+        }
+        console.log('\nFix: re-run classification for the show, or restore the tier via classifyContentTier() in scripts/lib/content-quality.js.');
+      }
+    }
+    console.log(`\nReport: ${path.relative(ROOT, REPORT_PATH)}`);
+  }
+
+  // A corpus walk that saw zero files is a broken checkout, not a clean corpus.
+  if (tier && tier.scanned === 0 && !args.show) {
+    console.error('\nERROR: review-texts is present but the scan saw 0 files — broken checkout, refusing to report a pass.');
+    process.exit(2);
+  }
+
+  if (args.all) process.exit(0);
+  const newFindings = moves.findings.length + (tier ? tier.findings.length : 0);
+  process.exit(newFindings > 0 ? 1 : 0);
+}
+
+if (require.main === module) main();

--- a/scripts/audit-silent-exclusions.js
+++ b/scripts/audit-silent-exclusions.js
@@ -113,9 +113,16 @@ function main() {
   let tier = null;
   const reviewTextsPresent = fs.existsSync(REVIEW_TEXTS_DIR);
   if (reviewTextsPresent) {
+    // The canonical inclusion predicate needs each review's show record —
+    // without it four of explainExclusion's rules go dark and the scan
+    // over-reports. See scripts/lib/silent-exclusion-detectors.js.
+    const showsById = {};
+    const showsFile = readJSON(path.join(ROOT, 'data', 'shows.json'));
+    for (const s of (showsFile?.shows || [])) if (s?.id) showsById[s.id] = s;
     tier = scanMissingContentTier(REVIEW_TEXTS_DIR, {
       shows: args.show ? [args.show] : undefined,
       baselineKeys: tierBaseline,
+      showsById,
     });
   }
 
@@ -141,7 +148,13 @@ function main() {
       findings: moves.findings,
     },
     missingContentTier: tier
-      ? { scannedFiles: tier.scanned, baselinedCount: tier.baselinedCount, findings: tier.findings }
+      ? {
+        scannedFiles: tier.scanned,
+        baselinedCount: tier.baselinedCount,
+        predicateErrors: tier.predicateErrors,
+        firstPredicateError: tier.firstPredicateError,
+        findings: tier.findings,
+      }
       : { skipped: 'review-texts not checked out (private repo)' },
   };
   fs.writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
@@ -167,6 +180,13 @@ function main() {
       console.log('Skipped — data/review-texts not checked out (private repo).');
     } else {
       console.log(`Scanned ${tier.scanned} file(s); ${tier.baselinedCount} baselined.`);
+      if (tier.predicateErrors) {
+        // Loud, because a predicate that threw decided nothing — "no findings"
+        // off the back of it would be a false all-clear.
+        console.log(`  ⚠ inclusion check FAILED on ${tier.predicateErrors} file(s) — those were not judged at all.`);
+        console.log(`    first: ${tier.firstPredicateError}`);
+        console.log('    Usually a missing data/shows.json in this checkout.');
+      }
       if (tier.findings.length === 0) {
         console.log('No unclassified reviews.');
       } else {

--- a/scripts/health-check.js
+++ b/scripts/health-check.js
@@ -947,24 +947,42 @@ function checkQuality() {
         const b = readJSON(path.join(AUDIT_DIR, 'silent-exclusions-baseline.json'));
         if (b && Array.isArray(b.missingContentTier)) baselineKeys = b.missingContentTier;
       } catch { /* no baseline yet — everything is "new" */ }
-      const { scanned, findings, baselinedCount } = scanMissingContentTier(rtDir, { baselineKeys });
+      // The canonical inclusion predicate needs each review's show record (see
+      // silent-exclusion-detectors.js) — without it four of its rules go dark.
+      let showsById = {};
+      try {
+        const showsFile = readJSON(path.join(DATA_DIR, 'shows.json'));
+        for (const s of (showsFile?.shows || [])) if (s?.id) showsById[s.id] = s;
+      } catch { /* no shows.json — predicate runs degraded, surfaced below */ }
+      const { scanned, findings, baselinedCount, predicateErrors, firstPredicateError } =
+        scanMissingContentTier(rtDir, { baselineKeys, showsById });
       if (scanned === 0) {
         return {
           name: 'Quality: reviews missing contentTier',
           status: 'warn',
-          message: 'review-texts is present but the scan saw 0 files — broken checkout, not a clean corpus',
+          message: 'review-texts is present but the scan read 0 files — this is a broken checkout, not a clean corpus',
           hint: 'Check the data/review-texts clone; a vacuous pass here would hide the whole class (task #1065).',
         };
       }
+      // A predicate that threw on most files decided nothing — reporting "all
+      // clear" off that would be the silent all-clear this module exists to kill.
+      if (predicateErrors > scanned * 0.01) {
+        return {
+          name: 'Quality: reviews missing contentTier',
+          status: 'warn',
+          message: `inclusion check failed on ${predicateErrors} of ${scanned} files — the result is not trustworthy (first: ${firstPredicateError})`,
+          hint: 'Usually a missing data/shows.json in this checkout. Fix the checkout and re-run `node scripts/audit-silent-exclusions.js`.',
+        };
+      }
       if (findings.length === 0) {
-        return { name: 'Quality: reviews missing contentTier', status: 'pass', message: `${scanned} files scanned, all classified (${baselinedCount} known/baselined)` };
+        return { name: 'Quality: reviews missing contentTier', status: 'pass', message: `${scanned} review files checked; every one with text has a content tier (${baselinedCount} previously acked)` };
       }
       const worst = findings[0];
       return {
         name: 'Quality: reviews missing contentTier',
         status: 'warn',
-        message: `${findings.length} scored/unflagged review(s) carry text but no contentTier (worst: ${worst.showId}/${worst.file}, ${worst.criticName}, ${worst.chars} chars)`,
-        hint: 'Run `node scripts/audit-silent-exclusions.js` — these fell out of classification and are invisible to every contentTier consumer. Re-run classification for the show, then `--write-baseline` to ack.',
+        message: `${findings.length} review(s) have text and a score but were never classified, so they are missing from the site (worst: ${worst.showId}/${worst.file}, ${worst.criticName}, ${worst.chars} chars)`,
+        hint: 'Run `node scripts/audit-silent-exclusions.js` to list them, then re-run classification for those shows to put them back in the corpus. `--write-baseline` acks any you decide to leave.',
       };
     }),
 
@@ -1392,14 +1410,15 @@ function checkOutletHealth() {
         baselineKeys,
       });
       if (findings.length === 0) {
-        return { name: 'Quality: outlet domain move', status: 'pass', message: `${scanned} unregistered host(s) checked, no probable outlet domain moves (${baselinedCount} known/baselined, ${domainlessMatches} domainless-outlet matches out of scope)` };
+        return { name: 'Quality: outlet domain move', status: 'pass', message: `${scanned} unrecognised host(s) checked, none look like an outlet that changed domain (${baselinedCount} previously acked; ${domainlessMatches} matched an outlet that has no domain recorded at all, which a different guard owns)` };
       }
       const worst = findings[0];
+      const hosts = findings.slice(0, 4).map(f => `${f.host}→${f.outletId}`).join(', ');
       return {
         name: 'Quality: outlet domain move',
         status: 'warn',
-        message: `${findings.length} unregistered host(s) look like a registered outlet's new home (worst: ${worst.host} → "${worst.outletId}", registered as ${worst.registeredDomain}, ${worst.occurrences} occurrence(s))`,
-        hint: 'Run `node scripts/audit-silent-exclusions.js` — if the host really is that outlet, add it to the outlet\'s domainAliases in data/outlet-registry.json, otherwise register it as its own outlet. Until then every review on that host is dropped by the domain-mismatch guard. `--write-baseline` acks the current backlog once triaged.',
+        message: `${findings.length} host(s) need a decision: are they the same outlet under a new domain, or a new outlet? Until one is recorded, every review published on them is silently dropped. ${hosts}${findings.length > 4 ? ', …' : ''} (worst: ${worst.host}, currently registered as ${worst.registeredDomain}, ${worst.occurrences} occurrence(s))`,
+        hint: 'Run `node scripts/audit-silent-exclusions.js`. Same outlet → add the host to that outlet\'s domainAliases in data/outlet-registry.json. Different outlet → register it as its own. Either way the alert clears; `--write-baseline` only silences it without fixing the dropped reviews.',
       };
     }),
   ];

--- a/scripts/health-check.js
+++ b/scripts/health-check.js
@@ -925,6 +925,49 @@ function checkQuality() {
       };
     }),
 
+    // Silent-exclusion half (b), task #1188. A review with real text, a real
+    // byline and no rejection flags that carries NO contentTier is a file that
+    // fell out of the classification path — nothing else in the pipeline says
+    // so, which is how a scored review sat absent from the corpus with no
+    // warning anywhere (rosie-odonnell-common-knowledge, 2026-08-09).
+    //
+    // Corpus was clean (0 findings / 42,276 files) when this shipped, so there
+    // is no baseline to seed — anything this reports is genuinely new. A scan
+    // that sees ZERO files is treated as a broken checkout rather than a clean
+    // corpus (task #1065): a gate that passes because it read nothing is worse
+    // than no gate. `/^Quality:/` playbook route = this-week warn, not a page.
+    runCheck('Quality: reviews missing contentTier', () => {
+      const { scanMissingContentTier } = require('./lib/silent-exclusion-detectors');
+      const rtDir = path.join(DATA_DIR, 'review-texts');
+      if (!fs.existsSync(rtDir)) {
+        return { name: 'Quality: reviews missing contentTier', status: 'pass', message: 'Skipped (review-texts not checked out)' };
+      }
+      let baselineKeys = [];
+      try {
+        const b = readJSON(path.join(AUDIT_DIR, 'silent-exclusions-baseline.json'));
+        if (b && Array.isArray(b.missingContentTier)) baselineKeys = b.missingContentTier;
+      } catch { /* no baseline yet — everything is "new" */ }
+      const { scanned, findings, baselinedCount } = scanMissingContentTier(rtDir, { baselineKeys });
+      if (scanned === 0) {
+        return {
+          name: 'Quality: reviews missing contentTier',
+          status: 'warn',
+          message: 'review-texts is present but the scan saw 0 files — broken checkout, not a clean corpus',
+          hint: 'Check the data/review-texts clone; a vacuous pass here would hide the whole class (task #1065).',
+        };
+      }
+      if (findings.length === 0) {
+        return { name: 'Quality: reviews missing contentTier', status: 'pass', message: `${scanned} files scanned, all classified (${baselinedCount} known/baselined)` };
+      }
+      const worst = findings[0];
+      return {
+        name: 'Quality: reviews missing contentTier',
+        status: 'warn',
+        message: `${findings.length} scored/unflagged review(s) carry text but no contentTier (worst: ${worst.showId}/${worst.file}, ${worst.criticName}, ${worst.chars} chars)`,
+        hint: 'Run `node scripts/audit-silent-exclusions.js` — these fell out of classification and are invisible to every contentTier consumer. Re-run classification for the show, then `--write-baseline` to ack.',
+      };
+    }),
+
     runCheck('Quality: scored review ratio', () => {
       const reviews = readJSON(path.join(DATA_DIR, 'reviews.json'));
       const stats = reviews._meta?.stats || {};
@@ -1312,6 +1355,51 @@ function checkOutletHealth() {
         status: 'warn',
         message: `${actionable.length} NEW T1/T2 outlet×market row(s) silent 2+ consecutive weekly checks (worst: ${worst.outletId}/${worst.market}, ${worst.silentDays}d silent vs ${worst.thresholdDays}d threshold; ${baselinedCount} known/baselined)`,
         hint: 'Run `node scripts/monitor-outlet-recency.js` — check whether the outlet stopped reviewing or an extractor broke (card #582 class). `--write-baseline` acks the ENTIRE current red backlog at once (not just the worst offender) — only run it once every currently-red outlet has been triaged.',
+      };
+    }),
+
+    // Silent-exclusion half (a), task #1188. An outlet that moves host keeps
+    // publishing, but every review on the new host is refused by the
+    // domain-mismatch guard (review-file-writer.js:448) and that refusal is
+    // deliberately quiet — one-minute-critic's move to Substack cost weeks of
+    // that critic's reviews before a human noticed.
+    //
+    // Reads the registry + the unregistered-host census that
+    // audit-show-review-gap.js already writes; no new cron, no new fetch. Both
+    // are small committed JSONs, so this is a cheap read like its neighbours
+    // here — the corpus-walking half of #1188 lives in checkQuality() instead.
+    runCheck('Quality: outlet domain move', () => {
+      const { detectOutletDomainMoves } = require('./lib/silent-exclusion-detectors');
+      const unknownPath = path.join(AUDIT_DIR, 'unknown-aggregator-outlets.json');
+      if (!core || !core.outlets) {
+        return { name: 'Quality: outlet domain move', status: 'pass', message: 'Skipped (core data not checked out)' };
+      }
+      if (!fs.existsSync(unknownPath)) {
+        return { name: 'Quality: outlet domain move', status: 'warn', message: 'No unknown-aggregator-outlets.json (audit-aggregator-gap.yml may not have run)', hint: 'Trigger the "Audit Aggregator Review Gap" workflow' };
+      }
+      const unknown = readJSON(unknownPath);
+      let baselineKeys = [];
+      try {
+        const b = readJSON(path.join(AUDIT_DIR, 'silent-exclusions-baseline.json'));
+        if (b && Array.isArray(b.outletDomainMoves)) baselineKeys = b.outletDomainMoves;
+      } catch { /* no baseline yet — everything is "new" */ }
+
+      // loadOutletHealthCoreData() already unwraps `.outlets`, so this IS the
+      // id → entry map the detector expects.
+      const { findings, baselinedCount, domainlessMatches, scanned } = detectOutletDomainMoves({
+        outlets: core.outlets,
+        unknownHosts: (unknown && unknown.outlets) || [],
+        baselineKeys,
+      });
+      if (findings.length === 0) {
+        return { name: 'Quality: outlet domain move', status: 'pass', message: `${scanned} unregistered host(s) checked, no probable outlet domain moves (${baselinedCount} known/baselined, ${domainlessMatches} domainless-outlet matches out of scope)` };
+      }
+      const worst = findings[0];
+      return {
+        name: 'Quality: outlet domain move',
+        status: 'warn',
+        message: `${findings.length} unregistered host(s) look like a registered outlet's new home (worst: ${worst.host} → "${worst.outletId}", registered as ${worst.registeredDomain}, ${worst.occurrences} occurrence(s))`,
+        hint: 'Run `node scripts/audit-silent-exclusions.js` — if the host really is that outlet, add it to the outlet\'s domainAliases in data/outlet-registry.json, otherwise register it as its own outlet. Until then every review on that host is dropped by the domain-mismatch guard. `--write-baseline` acks the current backlog once triaged.',
       };
     }),
   ];

--- a/scripts/lib/silent-exclusion-detectors.js
+++ b/scripts/lib/silent-exclusion-detectors.js
@@ -129,10 +129,30 @@ function normalizeHost(host) {
  *
  * Pure — no fs, no fetch. The scanner and the unit test share it.
  *
+ * `show` and `filePath` are NOT optional decoration: explainExclusion() gates
+ * real rules on them (isPrematureReviewForUnopenedShow at review-guards.js:71,
+ * the KNOWN_SYNDICATION_PAIRS sibling scan at :156, the tour-excerpt check at
+ * :195, and the duplicateOf sibling resolution at :81). Calling the canonical
+ * predicate with only `data` silently changes its verdict in BOTH directions —
+ * a never-opened show's premature review and a syndicated duplicate both stop
+ * being excluded, so both get reported as invariant violations that aren't.
+ * t1-silent-gap.js:108 already passes both; this does too. Callers that
+ * genuinely have no show record pass undefined and get the degraded verdict,
+ * which is why the scanner counts those separately rather than hiding them.
+ *
+ * Throws whatever the canonical predicate throws — see scanMissingContentTier,
+ * which counts predicate failures instead of swallowing them. Swallowing was
+ * the first version's bug: on a checkout without shows.json the tour check
+ * throws ENOENT for every file, and a silent catch turned the whole detector
+ * into a permanent all-clear — the exact class this module exists to kill.
+ *
  * @param {object} review - parsed review-text JSON
+ * @param {object} [opts]
+ * @param {object} [opts.show] - the show record from shows.json
+ * @param {string} [opts.filePath] - absolute path to the review file
  * @returns {{criticName:string, outletId:string, chars:number, hasScore:boolean}|null}
  */
-function evaluateMissingContentTier(review) {
+function evaluateMissingContentTier(review, opts = {}) {
   if (!review || typeof review !== 'object') return null;
 
   // Already classified — nothing to report. Any non-empty tier counts, including
@@ -151,13 +171,10 @@ function evaluateMissingContentTier(review) {
   // nonReview, …) is SUPPOSED to be absent; its missing tier is not a silent
   // exclusion, and reporting it would drown the real signal. 54 of the 115
   // tier-less files in the live corpus are exactly this case.
-  let includable = false;
-  try {
-    includable = isIncludableForRebuild(review);
-  } catch {
-    return null;
-  }
-  if (!includable) return null;
+  //
+  // Called with the SAME context rebuild has (see the note above) — a bare
+  // isIncludableForRebuild(review) quietly disables four of its rules.
+  if (!isIncludableForRebuild(review, opts.show, opts.filePath)) return null;
 
   return {
     criticName,
@@ -176,34 +193,57 @@ function missingTierKey(finding) {
  * Walk a review-texts root for the (b) invariant violation.
  *
  * Returns `scanned` so callers can refuse to report a vacuous pass: a scan that
- * saw zero files is a broken checkout, not a clean corpus (task #1065).
+ * saw zero files is a broken checkout, not a clean corpus (task #1065). Returns
+ * `predicateErrors` for the same reason one level down: if the canonical
+ * predicate throws for every file (e.g. its tour-excerpt branch needs
+ * shows.json and the checkout has none), the scan would otherwise report a
+ * confident all-clear built on zero actual verdicts.
  *
  * @param {string} rootDir - path to data/review-texts
  * @param {object} [opts]
  * @param {string[]} [opts.shows] - restrict to these show dirs (default: all)
+ * @param {Map<string,object>|object} [opts.showsById] - show records by id, so
+ *        the canonical predicate gets the same `show` context rebuild has
  * @param {Set<string>|string[]} [opts.baselineKeys] - already-triaged keys
- * @returns {{scanned:number, findings:object[], baselinedCount:number}}
+ * @returns {{scanned:number, findings:object[], baselinedCount:number,
+ *            predicateErrors:number, firstPredicateError:string|null}}
  */
 function scanMissingContentTier(rootDir, opts = {}) {
   const baseline = opts.baselineKeys
     ? (opts.baselineKeys instanceof Set ? opts.baselineKeys : new Set(opts.baselineKeys))
     : null;
+  const showsById = opts.showsById instanceof Map
+    ? opts.showsById
+    : new Map(Object.entries(opts.showsById || {}));
 
   const shows = opts.shows || listShowDirs(rootDir);
   const findings = [];
   let scanned = 0;
   let baselinedCount = 0;
+  let predicateErrors = 0;
+  let firstPredicateError = null;
 
   for (const showId of shows) {
     const dir = path.join(rootDir, showId);
     let files;
     try { files = fs.readdirSync(dir); } catch { continue; }
+    const show = showsById.get(showId);
     for (const f of files) {
       if (!f.endsWith('.json')) continue;
+      const filePath = path.join(dir, f);
       let review;
-      try { review = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')); } catch { continue; }
+      try { review = JSON.parse(fs.readFileSync(filePath, 'utf8')); } catch { continue; }
       scanned++;
-      const hit = evaluateMissingContentTier(review);
+      let hit;
+      try {
+        hit = evaluateMissingContentTier(review, { show, filePath });
+      } catch (err) {
+        // Never swallow silently — that would make this detector the very
+        // thing it detects. Counted and surfaced by the caller.
+        predicateErrors++;
+        if (!firstPredicateError) firstPredicateError = `${showId}/${f}: ${err.message}`;
+        continue;
+      }
       if (!hit) continue;
       const full = { showId, file: f, url: review.url || '', ...hit };
       if (baseline && baseline.has(missingTierKey(full))) { baselinedCount++; continue; }
@@ -212,7 +252,7 @@ function scanMissingContentTier(rootDir, opts = {}) {
   }
 
   findings.sort((a, b) => b.chars - a.chars);
-  return { scanned, findings, baselinedCount };
+  return { scanned, findings, baselinedCount, predicateErrors, firstPredicateError };
 }
 
 // ───────────────────────── (a) outlet domain moves ─────────────────────────
@@ -277,6 +317,7 @@ function detectOutletDomainMoves({ outlets, unknownHosts, baselineKeys } = {}) {
   const findings = [];
   let baselinedCount = 0;
   let domainlessMatches = 0;
+  let genericAliasMatches = 0;
   let scanned = 0;
 
   for (const row of Array.isArray(unknownHosts) ? unknownHosts : []) {
@@ -304,6 +345,23 @@ function detectOutletDomainMoves({ outlets, unknownHosts, baselineKeys } = {}) {
         domainlessMatches++;
         continue;
       }
+
+      // CORROBORATION: the candidate host and the outlet's CURRENT domain must
+      // derive the same identity label. A slug that merely matches one of the
+      // outlet's aliases is not enough, because 8 registered outlets answer to
+      // a bare generic word that clears the length floor — `guardian`,
+      // `herald`, `mirror`, `standard`, `observer`, `express`, `tribune`,
+      // `metro`. Without this, guardian.ng (The Guardian Nigeria, a different
+      // newspaper) reads as "theguardian.com moved to guardian.ng", and acting
+      // on that alert would file Nigerian reviews under a T1 UK outlet — a
+      // worse outcome than the missed detection this check exists to prevent.
+      //
+      // Comparing labels instead of aliases keeps the detector's actual claim
+      // honest: "same publication name, different host" (reviewsgate.com →
+      // .co.uk, dailymail.co.uk → .com, 1minutecritic.com → the Substack), not
+      // "this host's name appears somewhere in that outlet's alias list".
+      const registeredSlug = identitySlug(provisionalOutletIdFromHost(registeredDomain));
+      if (registeredSlug !== slug) { genericAliasMatches++; continue; }
       const finding = {
         host: row.host,
         outletId,
@@ -319,7 +377,7 @@ function detectOutletDomainMoves({ outlets, unknownHosts, baselineKeys } = {}) {
   }
 
   findings.sort((a, b) => b.occurrences - a.occurrences || a.host.localeCompare(b.host));
-  return { findings, baselinedCount, domainlessMatches, scanned };
+  return { findings, baselinedCount, domainlessMatches, genericAliasMatches, scanned };
 }
 
 module.exports = {

--- a/scripts/lib/silent-exclusion-detectors.js
+++ b/scripts/lib/silent-exclusion-detectors.js
@@ -1,0 +1,337 @@
+/**
+ * silent-exclusion-detectors.js — two members of the #1147 silent-exclusion
+ * class that had no detector at all (task #1188, found 2026-08-09).
+ *
+ * Both have the same shape as the rest of that tracker: a pipeline stage
+ * declines to include a review and records nothing an operator would ever look
+ * at. Neither is a scoring decision, so neither shows up in any score delta.
+ *
+ * ─── (a) AN OUTLET CHANGES ITS PUBLISHING DOMAIN ───────────────────────────
+ *
+ * one-minute-critic moved to 1minutecritic.substack.com. The registry knew only
+ * 1minutecritic.com, so review-file-writer.js:448 answered every ingest attempt
+ * on the new host with `domain-mismatch: URL domain 1minutecritic.substack.com
+ * does not match outlet one-minute-critic (expected 1minutecritic.com)`. That
+ * skip is classified EXPECTED-REJECTION by ingest-skip-classify.js — correct,
+ * because a mismatched domain usually IS a misrouted outlet id — so it stayed
+ * deliberately quiet while a real critic's reviews were dropped for weeks. It
+ * was found by hand and fixed with a domainAliases entry. Outlets migrating to
+ * Substack is now common, so "the next one" is a matter of when.
+ *
+ * The signal already exists and nothing reads it: data/audit/unknown-aggregator-
+ * outlets.json (written by audit-show-review-gap.js) records every host seen on
+ * an aggregator-cited review URL that maps to no registered outlet — 225 of them
+ * as of 2026-08-10. If one of those hosts derives the SAME identity slug as an
+ * outlet that IS registered under a DIFFERENT domain, that is a probable move.
+ *
+ * The host→identity derivation is NOT re-implemented here. It delegates to
+ * outlet-canonicalize.js provisionalOutletIdFromHost(), which already owns the
+ * blog-platform list (substack/wordpress/medium/... → the SUBDOMAIN is the
+ * publication) and the multi-part public-suffix list (.co.uk → the label is
+ * parts[-3], not "co"). Copying those lists here would fork a list that has
+ * already caused two shipped bugs on its own (junk outlets literally named "co"
+ * and "wordpress", 2026-06-21; the generic "theatre" label from theatre.reviews
+ * that held the trunk red 08-07→08-09) — a second copy would reopen that class
+ * independently of any fix to the original. It also gets the aggregator-host
+ * veto for free: provisionalOutletIdFromHost returns null for aggregator
+ * domains, which is why show-score.com and google.com never reach the matcher.
+ *
+ * DELIBERATELY NOT REPORTED: a host whose matched outlet has no `domain` at all.
+ * That is the separate domainless-outlet class (scripts/lib/domainless-outlet-
+ * guard.test.mjs) and it accounts for 40 of the 44 raw slug matches in the live
+ * file. Folding them in here would bury the 4 real moves under a backlog that a
+ * different guard already owns — the exact "unread signal" failure the
+ * outlet-heartbeat baseline exists to prevent.
+ *
+ * ─── (b) A REVIEW WITH NO contentTier ──────────────────────────────────────
+ *
+ * Found by making the mistake: clearing an exclusion flag and deleting
+ * contentTier (expecting rebuild to re-derive it) left a scored, unflagged
+ * review absent from the corpus with no warning anywhere.
+ *
+ * Scope note, verified rather than assumed: rebuild-all-reviews.js:2046-2067
+ * DOES re-derive the tier unconditionally for every file it processes (there is
+ * no early `continue` between the loop head at :1974 and that block), and
+ * isIncludableForRebuild() is indifferent to a missing tier — both checked
+ * directly on the file from the incident. So a missing tier is not, by itself,
+ * what rebuild excludes on.
+ *
+ * What it IS: proof that no writer ever classified the file. contentTier is
+ * read as a raw field by 126 files across scripts/ and src/, and they are the
+ * ones that quietly change behaviour when it is absent — collect-review-texts.js
+ * :3084 (`review.contentTier === 'complete'` decides whether to re-fetch),
+ * verify-review-recovery.js:158, audit-text-quality.js:57. A text-bearing,
+ * real-byline, unflagged review that carries no tier is a file that fell out of
+ * the classification path, and until this module nothing said so out loud.
+ *
+ * ─── SHAPE ─────────────────────────────────────────────────────────────────
+ *
+ * Structured after star-score-mismatch.js, the closest existing analogue: a
+ * pure per-record evaluator, an fs scanner over the corpus, and a stable key
+ * function for baselining — shared verbatim by the CLI
+ * (scripts/audit-silent-exclusions.js) and the daily health check, so the two
+ * can never drift apart. Inclusion semantics are DELEGATED to the canonical
+ * predicate in review-guards.js per
+ * memory/feedback_includability_predicates_must_be_canonical.md — this module
+ * never re-implements the rule chain.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { listShowDirs } = require('./list-show-dirs');
+const { isIncludableForRebuild } = require('./review-guards');
+const { provisionalOutletIdFromHost } = require('./outlet-canonicalize');
+
+/**
+ * Floor for "this file carries meaningful review text".
+ * 200 is not a new number: rebuild-all-reviews.js:2029/2031 already uses it as
+ * the threshold below which recovered text is not worth promoting.
+ */
+const MIN_FULLTEXT_CHARS = 200;
+
+/**
+ * Identity slugs shorter than this are too generic to match on. Guards against
+ * a host like "arts.com" claiming any outlet with "arts" in an alias. The four
+ * true positives in the live corpus (reviewsgate, dancemagazine, metro,
+ * dailymail) and the motivating case (1minutecritic) all clear it.
+ */
+const MIN_IDENTITY_SLUG_LEN = 5;
+
+/**
+ * Bylines that are not a person. A file credited to one of these is a
+ * collapsed/derived attribution, not a critic, so its missing tier is not
+ * evidence that a real review fell out of classification.
+ *
+ * review-guards.js:661 checks a narrower set ('unknown'/'staff') for a
+ * different purpose (strand routing); there is no canonical shared list to
+ * delegate to, so this one is deliberately kept to obvious non-person tokens
+ * rather than growing into a third competing definition.
+ */
+const PLACEHOLDER_CRITIC = /^(unknown|unnamed|unattributed|staff|n\/?a|none|anonymous|editor|editorial|admin|guest|contributor|review|reviews)$/i;
+
+/** Lowercase, strip everything but [a-z0-9]. "one-minute-critic" -> "oneminutecritic". */
+function identitySlug(value) {
+  return String(value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/** Lowercase, drop a leading www., trim. */
+function normalizeHost(host) {
+  return String(host || '').toLowerCase().trim().replace(/^www\./, '');
+}
+
+// ───────────────────────── (b) missing contentTier ─────────────────────────
+
+/**
+ * Does this review file violate the "every text-bearing includable review
+ * carries a derived contentTier" invariant?
+ *
+ * Pure — no fs, no fetch. The scanner and the unit test share it.
+ *
+ * @param {object} review - parsed review-text JSON
+ * @returns {{criticName:string, outletId:string, chars:number, hasScore:boolean}|null}
+ */
+function evaluateMissingContentTier(review) {
+  if (!review || typeof review !== 'object') return null;
+
+  // Already classified — nothing to report. Any non-empty tier counts, including
+  // 'invalid'/'stub': the invariant is that SOME writer made the call, not that
+  // the call was favourable.
+  if (review.contentTier) return null;
+
+  const text = typeof review.fullText === 'string' ? review.fullText.trim() : '';
+  if (text.length < MIN_FULLTEXT_CHARS) return null;
+
+  const criticName = String(review.criticName || '').trim();
+  if (!criticName || PLACEHOLDER_CRITIC.test(criticName)) return null;
+
+  // Canonical predicate — NOT a local re-implementation of the rule chain.
+  // A file the corpus deliberately excludes (wrongProduction, duplicateOf,
+  // nonReview, …) is SUPPOSED to be absent; its missing tier is not a silent
+  // exclusion, and reporting it would drown the real signal. 54 of the 115
+  // tier-less files in the live corpus are exactly this case.
+  let includable = false;
+  try {
+    includable = isIncludableForRebuild(review);
+  } catch {
+    return null;
+  }
+  if (!includable) return null;
+
+  return {
+    criticName,
+    outletId: review.outletId || '',
+    chars: text.length,
+    hasScore: !!(review.llmScore || review.assignedScore != null),
+  };
+}
+
+/** Stable baseline key. Includes the byline so a re-derived file re-alerts. */
+function missingTierKey(finding) {
+  return `${finding.showId}/${finding.file}#${finding.criticName}`;
+}
+
+/**
+ * Walk a review-texts root for the (b) invariant violation.
+ *
+ * Returns `scanned` so callers can refuse to report a vacuous pass: a scan that
+ * saw zero files is a broken checkout, not a clean corpus (task #1065).
+ *
+ * @param {string} rootDir - path to data/review-texts
+ * @param {object} [opts]
+ * @param {string[]} [opts.shows] - restrict to these show dirs (default: all)
+ * @param {Set<string>|string[]} [opts.baselineKeys] - already-triaged keys
+ * @returns {{scanned:number, findings:object[], baselinedCount:number}}
+ */
+function scanMissingContentTier(rootDir, opts = {}) {
+  const baseline = opts.baselineKeys
+    ? (opts.baselineKeys instanceof Set ? opts.baselineKeys : new Set(opts.baselineKeys))
+    : null;
+
+  const shows = opts.shows || listShowDirs(rootDir);
+  const findings = [];
+  let scanned = 0;
+  let baselinedCount = 0;
+
+  for (const showId of shows) {
+    const dir = path.join(rootDir, showId);
+    let files;
+    try { files = fs.readdirSync(dir); } catch { continue; }
+    for (const f of files) {
+      if (!f.endsWith('.json')) continue;
+      let review;
+      try { review = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')); } catch { continue; }
+      scanned++;
+      const hit = evaluateMissingContentTier(review);
+      if (!hit) continue;
+      const full = { showId, file: f, url: review.url || '', ...hit };
+      if (baseline && baseline.has(missingTierKey(full))) { baselinedCount++; continue; }
+      findings.push(full);
+    }
+  }
+
+  findings.sort((a, b) => b.chars - a.chars);
+  return { scanned, findings, baselinedCount };
+}
+
+// ───────────────────────── (a) outlet domain moves ─────────────────────────
+
+/**
+ * Index a registry's outlets by every identity string they answer to, and
+ * collect every host they are already known to publish on.
+ *
+ * @param {object} outlets - the `outlets` map from data/outlet-registry.json
+ * @returns {{knownHosts:Set<string>, identityIndex:Map<string,string[]>}}
+ */
+function buildOutletIdentityIndex(outlets) {
+  const knownHosts = new Set();
+  const identityIndex = new Map();
+
+  for (const [outletId, entry] of Object.entries(outlets || {})) {
+    if (!entry || typeof entry !== 'object') continue;
+
+    for (const d of [entry.domain, ...(Array.isArray(entry.domainAliases) ? entry.domainAliases : [])]) {
+      const host = normalizeHost(d);
+      if (host) knownHosts.add(host);
+    }
+
+    const names = [outletId, entry.displayName, ...(Array.isArray(entry.aliases) ? entry.aliases : [])];
+    for (const name of names) {
+      const slug = identitySlug(name);
+      if (slug.length < MIN_IDENTITY_SLUG_LEN) continue;
+      if (!identityIndex.has(slug)) identityIndex.set(slug, []);
+      const bucket = identityIndex.get(slug);
+      if (!bucket.includes(outletId)) bucket.push(outletId);
+    }
+  }
+
+  return { knownHosts, identityIndex };
+}
+
+/** Stable baseline key. Host+outlet, so a NEW host for the same outlet re-alerts. */
+function domainMoveKey(finding) {
+  return `${finding.host}#${finding.outletId}`;
+}
+
+/**
+ * Find unregistered hosts that are probably a registered outlet's new home.
+ *
+ * Pure — takes already-loaded data so the unit test can hand it fixtures and
+ * the CLI/health-check can hand it the real files.
+ *
+ * @param {object} input
+ * @param {object} input.outlets - `outlets` map from data/outlet-registry.json
+ * @param {object[]} input.unknownHosts - `outlets` array from
+ *        data/audit/unknown-aggregator-outlets.json ({host, provisionalOutletId,
+ *        occurrences, sampleUrls, shows})
+ * @param {Set<string>|string[]} [input.baselineKeys] - already-triaged keys
+ * @returns {{findings:object[], baselinedCount:number, domainlessMatches:number, scanned:number}}
+ */
+function detectOutletDomainMoves({ outlets, unknownHosts, baselineKeys } = {}) {
+  const { knownHosts, identityIndex } = buildOutletIdentityIndex(outlets);
+  const baseline = baselineKeys
+    ? (baselineKeys instanceof Set ? baselineKeys : new Set(baselineKeys))
+    : null;
+
+  const findings = [];
+  let baselinedCount = 0;
+  let domainlessMatches = 0;
+  let scanned = 0;
+
+  for (const row of Array.isArray(unknownHosts) ? unknownHosts : []) {
+    if (!row || !row.host) continue;
+    scanned++;
+
+    const host = normalizeHost(row.host);
+    // Already a host this outlet (or any outlet) publishes on — not a move.
+    if (knownHosts.has(host)) continue;
+
+    // Prefer the value the producing audit already computed; fall back to the
+    // canonical helper for hand-built or older files that predate the field.
+    // Either way the derivation lives in outlet-canonicalize.js, not here.
+    const provisional = row.provisionalOutletId || provisionalOutletIdFromHost(host);
+    const slug = identitySlug(provisional);
+    if (slug.length < MIN_IDENTITY_SLUG_LEN) continue;
+
+    const matches = identityIndex.get(slug);
+    if (!matches) continue;
+
+    for (const outletId of matches) {
+      const registeredDomain = normalizeHost(outlets[outletId].domain);
+      if (!registeredDomain) {
+        // Outlet has no domain at all — the domainless-outlet class, not a move.
+        domainlessMatches++;
+        continue;
+      }
+      const finding = {
+        host: row.host,
+        outletId,
+        registeredDomain,
+        matchedSlug: slug,
+        occurrences: row.occurrences || 0,
+        sampleUrl: (Array.isArray(row.sampleUrls) && row.sampleUrls[0]) || '',
+        shows: Array.isArray(row.shows) ? row.shows.slice(0, 5) : [],
+      };
+      if (baseline && baseline.has(domainMoveKey(finding))) { baselinedCount++; continue; }
+      findings.push(finding);
+    }
+  }
+
+  findings.sort((a, b) => b.occurrences - a.occurrences || a.host.localeCompare(b.host));
+  return { findings, baselinedCount, domainlessMatches, scanned };
+}
+
+module.exports = {
+  MIN_FULLTEXT_CHARS,
+  MIN_IDENTITY_SLUG_LEN,
+  PLACEHOLDER_CRITIC,
+  identitySlug,
+  normalizeHost,
+  evaluateMissingContentTier,
+  missingTierKey,
+  scanMissingContentTier,
+  buildOutletIdentityIndex,
+  detectOutletDomainMoves,
+  domainMoveKey,
+};

--- a/scripts/lib/silent-exclusion-detectors.test.mjs
+++ b/scripts/lib/silent-exclusion-detectors.test.mjs
@@ -156,6 +156,34 @@ test('(b) NEGATIVE CONTROL: a tier-less file with no real byline is NOT reported
   }
 });
 
+test('(b) the show record reaches the canonical predicate (not a bare one-arg call)', () => {
+  // Regression guard for the ship-check finding: calling
+  // isIncludableForRebuild(review) with only `data` silently disables
+  // isPrematureReviewForUnopenedShow (review-guards.js:340 returns false the
+  // moment `show` is undefined), so a pre-opening review that rebuild DOES
+  // exclude was being reported as an invariant violation.
+  //
+  // Same review, two calls. Without the show it is reported; with a show whose
+  // first performance is months after the review's publishDate, the canonical
+  // predicate excludes it and there is nothing to report. If the wiring
+  // regresses to a one-arg call, the second assertion fails.
+  const review = tierlessReview({ publishDate: '2026-06-14' });
+  const unopenedShow = {
+    id: 'rosie-odonnell-common-knowledge-off-broadway-2026',
+    title: "Rosie O'Donnell: Common Knowledge",
+    status: 'previews',
+    previewsStartDate: '2026-12-01',
+    openingDate: '2026-12-15',
+  };
+
+  assert.ok(evaluateMissingContentTier(review), 'no show context → nothing excludes it, so it is reported');
+  assert.equal(
+    evaluateMissingContentTier(review, { show: unopenedShow }),
+    null,
+    'with the show, the canonical predicate excludes it as premature — so it must NOT be reported',
+  );
+});
+
 test('(b) survives junk input instead of throwing', () => {
   for (const junk of [null, undefined, 'a string', 42, []]) {
     assert.equal(evaluateMissingContentTier(junk), null);
@@ -246,6 +274,43 @@ test('(a) NEGATIVE CONTROL: an unrelated host matching no outlet is NOT reported
     unknownHosts: [unknownHostRow('some-random-blog.com', { provisionalOutletId: 'some-random-blog' })],
   });
   assert.deepEqual(findings, []);
+});
+
+test('(a) NEGATIVE CONTROL: a generic alias match is NOT a move unless the domains corroborate', () => {
+  // The real hazard, found in ship-check: 8 registered outlets answer to a bare
+  // generic word that clears the length floor. The Guardian Nigeria
+  // (guardian.ng) is a DIFFERENT newspaper from theguardian.com; reporting it
+  // as a domain move would invite an alias that files Nigerian reviews under a
+  // T1 UK outlet. Same shape for The Herald (Glasgow) vs Zimbabwe's herald.co.zw.
+  const { findings, genericAliasMatches } = detectOutletDomainMoves({
+    outlets: {
+      guardian: { displayName: 'The Guardian', aliases: ['guardian'], domain: 'theguardian.com' },
+      herald: { displayName: 'The Herald (Glasgow)', aliases: ['herald'], domain: 'heraldscotland.com' },
+    },
+    unknownHosts: [
+      unknownHostRow('guardian.ng', { provisionalOutletId: 'guardian' }),
+      unknownHostRow('herald.co.zw', { provisionalOutletId: 'herald' }),
+    ],
+  });
+  assert.deepEqual(findings, [], 'an alias-only match with a non-corroborating domain is not a move');
+  assert.equal(genericAliasMatches, 2, 'suppressed, but counted rather than silently dropped');
+});
+
+test('(a) corroboration still admits a genuine same-name host change', () => {
+  // metro.co.uk → metro.news and dailymail.co.uk → dailymail.com both survive:
+  // the registered domain derives the SAME label as the candidate host.
+  const { findings } = detectOutletDomainMoves({
+    outlets: {
+      'metro-uk': { displayName: 'Metro', aliases: ['metro'], domain: 'metro.co.uk' },
+      'daily-mail': { displayName: 'Daily Mail', aliases: ['dailymail'], domain: 'dailymail.co.uk' },
+    },
+    unknownHosts: [
+      unknownHostRow('metro.news', { provisionalOutletId: 'metro' }),
+      unknownHostRow('dailymail.com', { provisionalOutletId: 'dailymail' }),
+    ],
+  });
+  assert.equal(findings.length, 2, 'same label, different host is exactly what this detects');
+  assert.deepEqual(findings.map(f => f.outletId).sort(), ['daily-mail', 'metro-uk']);
 });
 
 test('(a) NEGATIVE CONTROL: short generic slugs never match', () => {

--- a/scripts/lib/silent-exclusion-detectors.test.mjs
+++ b/scripts/lib/silent-exclusion-detectors.test.mjs
@@ -1,0 +1,315 @@
+/**
+ * Tests for the two silent-exclusion detectors (task #1188).
+ *
+ * Both halves are anchored on the REAL incidents from 2026-08-09, reproduced as
+ * fixtures in the exact shape the corpus holds:
+ *
+ *  (a) one-minute-critic publishing on 1minutecritic.substack.com while the
+ *      registry knew only 1minutecritic.com. The registry fixture below is the
+ *      PRE-FIX entry — the live one now carries the substack domainAlias that
+ *      was added by hand, so the fixture is what main looked like when every
+ *      review on the new host was being dropped.
+ *
+ *  (b) rosie-odonnell-common-knowledge-off-broadway-2026/nyt-theater--jonathan
+ *      .json — llmScore 78, 744 words, exclusion flag manually cleared,
+ *      contentTier deleted, and absent from reviews.json through a full scoring
+ *      run + rebuild with no warning anywhere.
+ *
+ * Per CLAUDE.md §15 this require()s the real module — no logic is copied here,
+ * so a change to the predicates fails these tests rather than passing a stale
+ * duplicate.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  MIN_FULLTEXT_CHARS,
+  MIN_IDENTITY_SLUG_LEN,
+  identitySlug,
+  normalizeHost,
+  evaluateMissingContentTier,
+  missingTierKey,
+  buildOutletIdentityIndex,
+  detectOutletDomainMoves,
+  domainMoveKey,
+} = require('./silent-exclusion-detectors.js');
+
+// ── shared fixture helpers ────────────────────────────────────────────────
+
+const REVIEW_TEXT = 'x'.repeat(4200); // stands in for the 744-word Mandell review
+
+/** A file in the exact state the Rosie O'Donnell review was left in. */
+function tierlessReview(overrides = {}) {
+  return {
+    showId: 'rosie-odonnell-common-knowledge-off-broadway-2026',
+    outletId: 'nyt-theater',
+    outlet: 'New York Theater',
+    criticName: 'Jonathan',
+    url: 'https://newyorktheater.me/2026/06/13/rosie-odonnells-common-knowledge-coming-to-nyc/',
+    fullText: REVIEW_TEXT,
+    publishDate: '2026-06-14',
+    assignedScore: 78,
+    llmScore: { score: 78, confidence: 'high', bucket: 'Positive' },
+    llmMetadata: { model: 'ensemble:claude-sonnet-4-6+gpt-4o+gemini-2.5-flash' },
+    scoreSource: 'llm-v6',
+    // contentTier deliberately absent — that is the defect under test.
+    ...overrides,
+  };
+}
+
+/** Registry as it stood BEFORE the hand-fix: no substack alias. */
+const REGISTRY_PRE_FIX = {
+  'one-minute-critic': {
+    displayName: '1 Minute Critic',
+    tier: 3,
+    aliases: ['one-minute-critic', 'one minute critic', 'oneminutecritic', '1minutecritic', '1-minute-critic'],
+    domain: '1minutecritic.com',
+    domainAliases: ['oneminutecritic.com'],
+    region: 'us',
+  },
+  guardian: {
+    displayName: 'The Guardian',
+    tier: 1,
+    aliases: ['guardian', 'the guardian'],
+    domain: 'theguardian.com',
+  },
+};
+
+/** The row audit-show-review-gap.js writes for an unrecognised host. */
+function unknownHostRow(host, overrides = {}) {
+  return {
+    host,
+    provisionalOutletId: null,
+    occurrences: 3,
+    sampleUrls: [`https://${host}/2026/08/some-review/`],
+    shows: ['the-pass-off-broadway-2026'],
+    ...overrides,
+  };
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// (b) A review with fullText + a real byline + no rejection flags + no tier
+// ══════════════════════════════════════════════════════════════════════════
+
+test('(b) the Rosie O\'Donnell file — scored, unflagged, tier deleted — is reported', () => {
+  const finding = evaluateMissingContentTier(tierlessReview());
+  assert.ok(finding, 'a scored, unflagged, text-bearing review with no contentTier must be reported');
+  assert.equal(finding.criticName, 'Jonathan');
+  assert.equal(finding.outletId, 'nyt-theater');
+  assert.equal(finding.hasScore, true);
+  assert.equal(finding.chars, REVIEW_TEXT.length);
+});
+
+test('(b) restoring contentTier clears the finding', () => {
+  // The hand-fix that was actually applied: classifyContentTier() returned
+  // 'complete' at 744 words, and the file was written back with it.
+  assert.equal(evaluateMissingContentTier(tierlessReview({ contentTier: 'complete' })), null);
+});
+
+test('(b) any non-empty tier counts as classified, including unfavourable ones', () => {
+  // The invariant is "some writer made the call", not "the call was favourable".
+  for (const tier of ['complete', 'truncated', 'excerpt', 'stub', 'invalid']) {
+    assert.equal(
+      evaluateMissingContentTier(tierlessReview({ contentTier: tier })),
+      null,
+      `contentTier=${tier} is classified and must not be reported`,
+    );
+  }
+});
+
+test('(b) NEGATIVE CONTROL: a tier-less file carrying a rejection flag is NOT reported', () => {
+  // 54 of the 115 tier-less files in the live corpus are exactly this. They are
+  // SUPPOSED to be absent from the corpus, so reporting them would bury the
+  // real signal under a backlog of correct exclusions.
+  const flagged = tierlessReview({
+    wrongProduction: true,
+    wrongProductionReason: 'Review of the 2025 Edinburgh run, not this production',
+  });
+  assert.equal(evaluateMissingContentTier(flagged), null);
+});
+
+test('(b) NEGATIVE CONTROL: a tier-less file with no meaningful text is NOT reported', () => {
+  // Star-only / aggregator-excerpt entries legitimately carry no fullText.
+  assert.equal(evaluateMissingContentTier(tierlessReview({ fullText: '' })), null);
+  assert.equal(evaluateMissingContentTier(tierlessReview({ fullText: undefined })), null);
+  assert.equal(
+    evaluateMissingContentTier(tierlessReview({ fullText: 'y'.repeat(MIN_FULLTEXT_CHARS - 1) })),
+    null,
+    'below the meaningful-text floor',
+  );
+  assert.ok(
+    evaluateMissingContentTier(tierlessReview({ fullText: 'y'.repeat(MIN_FULLTEXT_CHARS) })),
+    'exactly at the floor is meaningful',
+  );
+});
+
+test('(b) NEGATIVE CONTROL: a tier-less file with no real byline is NOT reported', () => {
+  for (const name of ['', '   ', 'Unknown', 'unknown', 'Staff', 'Anonymous', 'Editorial', 'N/A']) {
+    assert.equal(
+      evaluateMissingContentTier(tierlessReview({ criticName: name })),
+      null,
+      `criticName=${JSON.stringify(name)} is not a person`,
+    );
+  }
+});
+
+test('(b) survives junk input instead of throwing', () => {
+  for (const junk of [null, undefined, 'a string', 42, []]) {
+    assert.equal(evaluateMissingContentTier(junk), null);
+  }
+});
+
+test('(b) baseline key includes the byline so a re-derived file re-alerts', () => {
+  const a = { showId: 's', file: 'f.json', criticName: 'Jonathan' };
+  const b = { showId: 's', file: 'f.json', criticName: 'Jonathan Mandell' };
+  assert.notEqual(missingTierKey(a), missingTierKey(b));
+});
+
+// ══════════════════════════════════════════════════════════════════════════
+// (a) An outlet whose registry entry lists only its old host
+// ══════════════════════════════════════════════════════════════════════════
+
+test('(a) the one-minute-critic move to Substack is reported against the pre-fix registry', () => {
+  const { findings } = detectOutletDomainMoves({
+    outlets: REGISTRY_PRE_FIX,
+    unknownHosts: [unknownHostRow('1minutecritic.substack.com', {
+      provisionalOutletId: '1minutecritic',
+      occurrences: 7,
+      sampleUrls: ['https://1minutecritic.substack.com/p/the-pass'],
+      shows: ['the-pass-off-broadway-2026'],
+    })],
+  });
+
+  assert.equal(findings.length, 1, 'the moved host must be reported exactly once');
+  assert.equal(findings[0].host, '1minutecritic.substack.com');
+  assert.equal(findings[0].outletId, 'one-minute-critic');
+  assert.equal(findings[0].registeredDomain, '1minutecritic.com', 'names the stale host so the fix is obvious');
+  assert.equal(findings[0].occurrences, 7);
+});
+
+test('(a) the same host is silent once the domainAlias is added — the fix resolves the alert', () => {
+  const fixed = JSON.parse(JSON.stringify(REGISTRY_PRE_FIX));
+  fixed['one-minute-critic'].domainAliases.push('1minutecritic.substack.com');
+
+  const { findings } = detectOutletDomainMoves({
+    outlets: fixed,
+    unknownHosts: [unknownHostRow('1minutecritic.substack.com', { provisionalOutletId: '1minutecritic' })],
+  });
+  assert.deepEqual(findings, [], 'a registered host is not a move');
+});
+
+test('(a) a TLD move is reported (the reviewsgate.co.uk / .com live case)', () => {
+  const { findings } = detectOutletDomainMoves({
+    outlets: { reviewsgate: { displayName: 'ReviewsGate', aliases: ['reviewsgate'], domain: 'reviewsgate.com' } },
+    unknownHosts: [unknownHostRow('reviewsgate.co.uk', { provisionalOutletId: 'reviewsgate' })],
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].outletId, 'reviewsgate');
+  assert.equal(findings[0].registeredDomain, 'reviewsgate.com');
+});
+
+test('(a) derives the identity itself when the audit file predates provisionalOutletId', () => {
+  // Older/hand-built rows have no provisionalOutletId — the canonical helper
+  // must still recover "1minutecritic" from the Substack subdomain.
+  const { findings } = detectOutletDomainMoves({
+    outlets: REGISTRY_PRE_FIX,
+    unknownHosts: [unknownHostRow('1minutecritic.substack.com', { provisionalOutletId: undefined })],
+  });
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].outletId, 'one-minute-critic');
+});
+
+test('(a) NEGATIVE CONTROL: a domainless outlet is NOT reported as a move', () => {
+  // 40 of the 44 raw slug matches in the live file are this class, which
+  // domainless-outlet-guard.test.mjs already owns. Folding them in would bury
+  // the real moves.
+  const { findings, domainlessMatches } = detectOutletDomainMoves({
+    outlets: {
+      cleveland: { displayName: 'Cleveland.com', aliases: ['cleveland'] }, // no `domain`
+      'the-jewish-news': { displayName: 'The Jewish News', aliases: ['thejewishnews'], domain: '' },
+    },
+    unknownHosts: [
+      unknownHostRow('cleveland.com', { provisionalOutletId: 'cleveland' }),
+      unknownHostRow('thejewishnews.com', { provisionalOutletId: 'thejewishnews' }),
+    ],
+  });
+  assert.deepEqual(findings, [], 'no registered domain means there is no move to detect');
+  assert.equal(domainlessMatches, 2, 'but the class is counted, not silently swallowed');
+});
+
+test('(a) NEGATIVE CONTROL: an unrelated host matching no outlet is NOT reported', () => {
+  const { findings } = detectOutletDomainMoves({
+    outlets: REGISTRY_PRE_FIX,
+    unknownHosts: [unknownHostRow('some-random-blog.com', { provisionalOutletId: 'some-random-blog' })],
+  });
+  assert.deepEqual(findings, []);
+});
+
+test('(a) NEGATIVE CONTROL: short generic slugs never match', () => {
+  // "arts.com" must not claim an outlet aliased "arts".
+  const { findings } = detectOutletDomainMoves({
+    outlets: { 'arts-desk': { displayName: 'The Arts Desk', aliases: ['arts'], domain: 'theartsdesk.com' } },
+    unknownHosts: [unknownHostRow('arts.com', { provisionalOutletId: 'arts' })],
+  });
+  assert.deepEqual(findings, [], `slugs under ${MIN_IDENTITY_SLUG_LEN} chars are too generic to match`);
+});
+
+test('(a) aggregator hosts are vetoed by the canonical helper, not matched', () => {
+  // provisionalOutletIdFromHost returns null for aggregator domains, which is
+  // why show-score.com never reaches the matcher even though a "show-score"
+  // outlet is registered.
+  const { findings } = detectOutletDomainMoves({
+    outlets: { 'show-score': { displayName: 'Show Score', aliases: ['showscore'], domain: 'showscore.com' } },
+    unknownHosts: [unknownHostRow('show-score.com', { provisionalOutletId: null })],
+  });
+  assert.deepEqual(findings, []);
+});
+
+test('(a) tolerates junk rows and an empty registry without throwing', () => {
+  const { findings, scanned } = detectOutletDomainMoves({
+    outlets: {},
+    unknownHosts: [null, {}, { host: '' }, unknownHostRow('example.com')],
+  });
+  assert.deepEqual(findings, []);
+  assert.equal(scanned, 1, 'only the well-formed row counts as scanned');
+  assert.deepEqual(detectOutletDomainMoves({}).findings, []);
+});
+
+test('(a) baseline key is host+outlet so a NEW host for the same outlet re-alerts', () => {
+  const first = { host: '1minutecritic.substack.com', outletId: 'one-minute-critic' };
+  const second = { host: '1minutecritic.ghost.io', outletId: 'one-minute-critic' };
+  assert.notEqual(domainMoveKey(first), domainMoveKey(second));
+});
+
+test('(a) baselined findings are withheld but counted', () => {
+  const args = {
+    outlets: REGISTRY_PRE_FIX,
+    unknownHosts: [unknownHostRow('1minutecritic.substack.com', { provisionalOutletId: '1minutecritic' })],
+  };
+  const { findings } = detectOutletDomainMoves(args);
+  const result = detectOutletDomainMoves({ ...args, baselineKeys: [domainMoveKey(findings[0])] });
+  assert.deepEqual(result.findings, []);
+  assert.equal(result.baselinedCount, 1);
+});
+
+// ── shared helpers ────────────────────────────────────────────────────────
+
+test('identitySlug and normalizeHost normalise both sides of the comparison', () => {
+  assert.equal(identitySlug('one-minute-critic'), 'oneminutecritic');
+  assert.equal(identitySlug('1 Minute Critic'), '1minutecritic');
+  assert.equal(identitySlug(null), '');
+  assert.equal(normalizeHost('WWW.Example.COM'), 'example.com');
+  assert.equal(normalizeHost('  example.com  '), 'example.com');
+});
+
+test('buildOutletIdentityIndex collects every host and every identity', () => {
+  const { knownHosts, identityIndex } = buildOutletIdentityIndex(REGISTRY_PRE_FIX);
+  assert.ok(knownHosts.has('1minutecritic.com'));
+  assert.ok(knownHosts.has('oneminutecritic.com'), 'domainAliases count as known hosts');
+  assert.ok(knownHosts.has('theguardian.com'));
+  assert.deepEqual(identityIndex.get('1minutecritic'), ['one-minute-critic']);
+  assert.deepEqual(identityIndex.get('oneminutecritic'), ['one-minute-critic']);
+});


### PR DESCRIPTION
Closes the two members of the #1147 silent-exclusion tracker that had no detector at all. In both, a pipeline stage declines to include a review and records nothing an operator would ever look at.

## (a) Outlet domain moves
`one-minute-critic` moved to `1minutecritic.substack.com`; the registry knew only `1minutecritic.com`, so every review on the new host hit the domain-mismatch guard (`review-file-writer.js:448`) and was dropped. That skip is classified EXPECTED-REJECTION, so it stayed deliberately quiet.

`detectOutletDomainMoves()` mines the unregistered-host census `audit-show-review-gap.js` already writes. Host→identity derivation delegates to `outlet-canonicalize.js` `provisionalOutletIdFromHost()` rather than forking its blog-platform and public-suffix lists (those have caused two shipped bugs on their own), which also inherits its aggregator-host veto for free.

A corroboration rule requires the candidate host and the outlet's current domain to derive the *same* identity label. Without it, `guardian.ng` (The Guardian Nigeria, a different paper) reads as `theguardian.com` changing domain, and acting on that alert would file Nigerian reviews under a T1 UK outlet. 8 registered outlets answer to a bare generic word that clears the length floor.

## (b) Missing contentTier
A review with real text, a real byline, no rejection flags and no `contentTier` fell out of the classification path; 126 files across `scripts/` and `src/` read the raw field.

Verified rather than assumed: `rebuild-all-reviews.js:2046` *does* re-derive the tier unconditionally and `isIncludableForRebuild()` is indifferent to its absence, so this is an integrity invariant, not a rebuild-exclusion rule.

## Wiring
Into the existing daily health check, no new cron: the corpus scan sits in `checkQuality()` beside the structurally identical star-vs-score row, the registry check in `checkOutletHealth()`. A scan that sees zero files warns instead of passing (#1065) — a gate that passes because it read nothing is worse than no gate.

## Live results
- (b) 42,276 files scanned, 0 findings, so the check starts green with no baseline to seed.
- (a) 4 findings (`reviewsgate.co.uk`, `dancemagazine.co.uk`, `metro.news`, `dailymail.com`), with 40 domainless-outlet matches excluded as a separate, already-guarded class. Those 4 need an owner call on whether each host is the same outlet, so they are reported rather than auto-aliased.

## Review
`/second-opinion` on the plan (reused the canonical host helper instead of forking it; moved the corpus scan into `checkQuality()`), then `/ship-check`, which found two real defects now fixed in the second commit:
- the canonical predicate was being called with one arg, silently disabling four of `explainExclusion`'s rules
- generic alias matches could misattribute a T1 outlet

24/24 unit tests. Each half was proven to fail against main before the fix (module absent → 0 pass / 1 fail; mutating each detector to main's behavior fails 2 and 6 tests respectively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
