### PR TITLE
fix(drift): treat live rc-missing as real drift signal (BRO-8)

### DIFF
--- a/.github/workflows/check-opening-night-drift.yml
+++ b/.github/workflows/check-opening-night-drift.yml
@@ -135,7 +135,7 @@ jobs:
               const r = JSON.parse(require('fs').readFileSync('/tmp/drift-results.json','utf8'));
               const alerts = r.filter(x => x.alert);
               console.log(alerts.map(x =>
-                \`**\${x.title}** (\${x.showId}): local=\${x.local}, agg=\${x.aggregate}, live=\${x.live ?? 'n/a'}, drift=\${x.drift}\`
+                \`**\${x.title}** (\${x.showId}): local=\${x.local}, agg=\${x.aggregate}, live=\${x.liveRcMissing ? 'RC-MISSING (live page lost its review count)' : x.live ?? 'n/a'}, drift=\${x.effectiveDrift ?? x.drift}\`
               ).join('\n'));
             " 2>/dev/null || echo "(parse error)")
             echo "alert_shows<<EOF" >> "$GITHUB_OUTPUT"

--- a/scripts/check-opening-night-drift.js
+++ b/scripts/check-opening-night-drift.js
@@ -26,7 +26,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { countLocalIncluded, countAggregate, fetchLiveRc, countLocalPerShowJson, computeDrift } = require('./lib/review-count-probe');
+const { countLocalIncluded, countAggregate, fetchLiveRc, countLocalPerShowJson, computeDrift, isLiveRcMissingField } = require('./lib/review-count-probe');
 
 // ── Args ─────────────────────────────────────────────────────────────────────
 
@@ -226,11 +226,23 @@ async function main() {
       live: live.rc,
     });
 
-    const fingerprint = makeFingerprint(local.included, agg, localJsonCount, live.rc);
+    // task #242: a 200 with no rc field is a real drift signal ONLY when the
+    // locally-generated artifact carries rc — then the live page is stale or
+    // malformed. Shows whose generator legitimately omits rc (pre-score shows:
+    // verified 2026-08-11, e.g. as-you-like-it-globe has rv:[] and no rc both
+    // locally and live) must not flag. Transport failures (http/timeout/
+    // network) keep the old skip behavior.
+    const liveRcMissing = isLiveRcMissingField(live) && localJson != null && localJson.rc != null;
+    const effectiveDrift = liveRcMissing ? Math.max(drift.drift, THRESHOLD + 1) : drift.drift;
+
+    const fingerprint = makeFingerprint(local.included, agg, localJsonCount, liveRcMissing ? 'rc-missing' : live.rc);
 
     // Check allowlist before shouldAlert so suppressed shows don't consume grace slots
     const allowEntry = allowlist[showId];
-    const suppressed  = allowEntry && drift.drift <= allowEntry.maxDrift;
+    // Suppress on effectiveDrift, not raw drift: an allowlist entry excusing an
+    // unrelated count mismatch must not swallow the rc-missing escalation
+    // (raw drift is 0 in exactly that case — second-opinion blocker, task #242).
+    const suppressed  = allowEntry && effectiveDrift <= allowEntry.maxDrift;
 
     // Grace: if the ONLY drift is between stage 3 (local per-show JSON) and stage 4 (live),
     // and the per-show JSON was written in the last GRACE_MINUTES, it's deploy lag — suppress.
@@ -239,7 +251,7 @@ async function main() {
     const ageMin = perShowJsonAgeMinutes(showId);
     const inGrace = only34Drift && ageMin != null && ageMin < GRACE_MINUTES;
 
-    const alert = (suppressed || inGrace) ? false : shouldAlert(showId, fingerprint, drift.drift, state);
+    const alert = (suppressed || inGrace) ? false : shouldAlert(showId, fingerprint, effectiveDrift, state);
     updateState(state, showId, fingerprint, alert);
 
     if (alert) anyAlert = true;
@@ -256,7 +268,9 @@ async function main() {
       localJsonRc: localJson ? localJson.rc : null,
       live: live.rc,
       liveErr: live.err,
+      liveRcMissing,
       drift: drift.drift,
+      effectiveDrift,
       threshold: THRESHOLD,
       graceMinutes: GRACE_MINUTES,
       inGrace,
@@ -275,8 +289,8 @@ async function main() {
     const header = ['Show', 'Opening', 'Local', 'Agg', 'LocalJSON', 'Live', 'Drift', 'Status'].join('\t');
     console.log(header);
     for (const r of results) {
-      const status = r.alert ? 'ALERT' : r.suppressed ? 'suppressed' : r.inGrace ? 'grace' : r.drift > THRESHOLD ? 'watch' : 'ok';
-      const liveFmt = r.live != null ? String(r.live) : `err(${r.liveErr})`;
+      const status = r.alert ? 'ALERT' : r.suppressed ? 'suppressed' : r.inGrace ? 'grace' : r.effectiveDrift > THRESHOLD ? 'watch' : 'ok';
+      const liveFmt = r.live != null ? String(r.live) : r.liveRcMissing ? 'RC-MISSING' : `err(${r.liveErr})`;
       const localJsonFmt = r.localJson != null ? String(r.localJson) : 'n/a';
       console.log([r.showId, r.openingDate || '?', r.local, r.aggregate, localJsonFmt, liveFmt, r.drift, status].join('\t'));
     }
@@ -286,21 +300,21 @@ async function main() {
     console.log('\n' + header);
     console.log('─'.repeat(90));
     for (const r of results) {
-      const alertMark = r.alert ? '🔴 YES' : r.suppressed ? '⏭  suppressed' : r.inGrace ? '⏳ grace-34' : r.drift > THRESHOLD ? '⏳ grace' : '✅ ok';
-      const liveFmt = r.live != null ? String(r.live) : `err(${r.liveErr})`;
+      const alertMark = r.alert ? '🔴 YES' : r.suppressed ? '⏭  suppressed' : r.inGrace ? '⏳ grace-34' : r.effectiveDrift > THRESHOLD ? '⏳ grace' : '✅ ok';
+      const liveFmt = r.live != null ? String(r.live) : r.liveRcMissing ? 'RC-MISSING' : `err(${r.liveErr})`;
       const localJsonFmt = r.localJson != null ? String(r.localJson) : 'n/a';
       console.log([r.showId, r.openingDate || '?', r.local, r.aggregate, localJsonFmt, liveFmt, r.drift, alertMark].join('\t'));
     }
     console.log();
 
-    const driftShows = results.filter(r => r.drift > THRESHOLD);
+    const driftShows = results.filter(r => r.effectiveDrift > THRESHOLD);
     if (driftShows.length === 0) {
       console.log(`✅ All ${results.length} show(s) within threshold (≤${THRESHOLD}).`);
     } else {
       console.log(`⚠️  ${driftShows.length}/${results.length} show(s) above drift threshold (>${THRESHOLD}):`);
       for (const r of driftShows) {
-        const stages = `local=${r.local}, agg=${r.aggregate}, localJson=${r.localJson ?? 'n/a'}, live=${r.live ?? 'n/a'}`;
-        console.log(`   ${r.showId}: ${stages}, drift=${r.drift}${r.inGrace ? ' (in 3↔4 grace)' : ''}`);
+        const stages = `local=${r.local}, agg=${r.aggregate}, localJson=${r.localJson ?? 'n/a'}, live=${r.liveRcMissing ? 'RC-MISSING (page served without rc)' : r.live ?? 'n/a'}`;
+        console.log(`   ${r.showId}: ${stages}, drift=${r.drift}${r.liveRcMissing ? ` (escalated to ${r.effectiveDrift}: live page lost its review count)` : ''}${r.inGrace ? ' (in 3↔4 grace)' : ''}`);
         console.log(`   Fix: node scripts/verify-review-recovery.js --show=${r.showId} --production`);
       }
     }

--- a/scripts/lib/review-count-probe.js
+++ b/scripts/lib/review-count-probe.js
@@ -61,7 +61,7 @@ function countAggregate(showId, reviewsDoc) {
  * The per-show JSON uses the `rc` field (verified 2026-04-16).
  *
  * @param {string} showId
- * @returns {Promise<{ rc: number|null, err: string|null }>}
+ * @returns {Promise<{ rc: number|null, err: string|null, errKind: 'http'|'timeout'|'network'|'missing-field'|null }>}
  */
 async function fetchLiveRc(showId) {
   const url = `https://broadwayscorecard.com/data/shows/${showId}.json`;
@@ -74,15 +74,35 @@ async function fetchLiveRc(showId) {
     });
     clearTimeout(timer);
     if (!res.ok) {
-      return { rc: null, err: `HTTP ${res.status}` };
+      return { rc: null, err: `HTTP ${res.status}`, errKind: 'http' };
     }
     const json = await res.json();
-    const rc = typeof json.rc === 'number' ? json.rc : null;
-    return { rc, err: rc == null ? 'field rc not found in response' : null };
+    return classifyLiveRcPayload(json);
   } catch (err) {
     clearTimeout(timer);
-    return { rc: null, err: err.name === 'AbortError' ? 'timeout (8s)' : String(err) };
+    return err.name === 'AbortError'
+      ? { rc: null, err: 'timeout (8s)', errKind: 'timeout' }
+      : { rc: null, err: String(err), errKind: 'network' };
   }
+}
+
+/**
+ * Classify a successfully-fetched live show JSON. A 200 response whose body
+ * lacks a numeric `rc` is NOT "can't compare" — the deployed artifact itself
+ * is malformed/stale (the site is serving a show without its review count),
+ * which is precisely the drift symptom the detector exists to catch. Callers
+ * distinguish it from transport errors via errKind === 'missing-field'.
+ */
+function classifyLiveRcPayload(json) {
+  const rc = json && typeof json.rc === 'number' ? json.rc : null;
+  return rc == null
+    ? { rc: null, err: 'field rc not found in response', errKind: 'missing-field' }
+    : { rc, err: null, errKind: null };
+}
+
+/** True when the live page was served (HTTP 200) but carries no review count. */
+function isLiveRcMissingField(live) {
+  return !!live && live.errKind === 'missing-field';
 }
 
 /**
@@ -134,4 +154,6 @@ module.exports = {
   fetchLiveRc,
   countLocalPerShowJson,
   computeDrift,
+  classifyLiveRcPayload,
+  isLiveRcMissingField,
 };

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -240,6 +240,7 @@ tests/unit/late-star-anchor.test.mjs
 tests/unit/lbo-first-party-downgrade.test.mjs
 tests/unit/lbo-individual-star-extraction.test.mjs
 tests/unit/lbo-roundup-page-validation.test.mjs
+tests/unit/live-rc-missing-drift.test.mjs
 tests/unit/lint-committed-pii.test.mjs
 tests/unit/llm-confidence-cap.test.mjs
 tests/unit/llm-fallback-partial.test.mjs

--- a/tests/unit/live-rc-missing-drift.test.mjs
+++ b/tests/unit/live-rc-missing-drift.test.mjs
@@ -1,0 +1,43 @@
+// Task #242 / Linear BRO-8: a live show JSON served with HTTP 200 but no
+// numeric `rc` field is a REAL drift signal (the deployed artifact is
+// malformed/stale), not a "can't compare" skip. These tests require() the
+// real classifier — never a copy (CLAUDE.md rule 15).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { classifyLiveRcPayload, isLiveRcMissingField } = require('../../scripts/lib/review-count-probe.js');
+
+test('numeric rc classifies as clean', () => {
+  const r = classifyLiveRcPayload({ rc: 7, rv: [] });
+  assert.equal(r.rc, 7);
+  assert.equal(r.err, null);
+  assert.equal(r.errKind, null);
+  assert.equal(isLiveRcMissingField(r), false);
+});
+
+test('rc absent classifies as missing-field drift signal', () => {
+  const r = classifyLiveRcPayload({ title: 'Some Show', rv: [] });
+  assert.equal(r.rc, null);
+  assert.equal(r.errKind, 'missing-field');
+  assert.equal(isLiveRcMissingField(r), true);
+});
+
+test('rc of wrong type (string) classifies as missing-field', () => {
+  const r = classifyLiveRcPayload({ rc: '7' });
+  assert.equal(r.rc, null);
+  assert.equal(r.errKind, 'missing-field');
+  assert.equal(isLiveRcMissingField(r), true);
+});
+
+test('null/empty payload classifies as missing-field, not a crash', () => {
+  assert.equal(classifyLiveRcPayload(null).errKind, 'missing-field');
+  assert.equal(classifyLiveRcPayload({}).errKind, 'missing-field');
+});
+
+test('transport-style errors are NOT missing-field', () => {
+  assert.equal(isLiveRcMissingField({ rc: null, err: 'HTTP 404', errKind: 'http' }), false);
+  assert.equal(isLiveRcMissingField({ rc: null, err: 'timeout (8s)', errKind: 'timeout' }), false);
+  assert.equal(isLiveRcMissingField(null), false);
+});


### PR DESCRIPTION
Fixes Linear BRO-8 (task #242): the opening-night drift detector silently dropped a live show JSON that was served with HTTP 200 but no numeric `rc` — a stale/malformed deployed page read as no-drift.

**Change:** `fetchLiveRc` now classifies error kinds (http/timeout/network/missing-field via new pure `classifyLiveRcPayload`); the detector escalates rc-missing to alert-eligible drift **only when the locally-generated per-show JSON carries rc** (pre-score shows legitimately omit rc both locally and live — verified on the real corpus, e.g. as-you-like-it-globe-west-end-2026). Fingerprint carries an rc-missing marker so consecutive-run dedup still applies; allowlist suppression compares effectiveDrift (review blocker); all outputs (table, human, Discord alert) surface RC-MISSING so an alert never prints as "drift=0".

**Verified:** 5/5 new unit tests (registered in tests/unit-test-manifest.txt); real-data sweep — pre-score shows quiet, scored shows unchanged, synthetic true-drift case escalates; second-opinion review pass recorded (1 blocker found and fixed).

Pilot note: first PR produced through the Linear-pilot workflow (issue → branch → PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)