### PR TITLE
Linear issue-cap monitor + Done auto-archive (BRO-285)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2331,6 +2331,17 @@ on:
       - 'scripts/linear-next.js'
       - 'scripts/lib/linear-dispatch.js'
       - 'scripts/lib/dispatch-guards.js'
+      # Linear issue-cap monitor + Done auto-archive (BRO-285): free-tier hard-
+      # caps a workspace at 250 unarchived issues, hit once already 2026-08-12.
+      # linear-cap-policy.js's pure isOverCapThreshold/isArchivableIssue are
+      # colocated-tested (tests/unit/linear-cap.test.mjs, registered in
+      # tests/unit-test-manifest.txt — tests/** already globbed above); the two
+      # CLI scripts + the policy lib need explicit listing so a solo edit
+      # triggers CI (feedback_test_yml_push_path_allowlist). No schedule/cron
+      # wired yet — a follow-up session wires it after this lands.
+      - 'scripts/lib/linear-cap-policy.js'
+      - 'scripts/check-linear-cap.js'
+      - 'scripts/linear-archive-done.js'
   pull_request:
     branches: [main]
   schedule:

--- a/scripts/check-linear-cap.js
+++ b/scripts/check-linear-cap.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * check-linear-cap.js — warns before the workspace hits Linear's free-tier
+ * 250-unarchived-issue hard cap (BRO-285). Exits 1 (with the count) once
+ * unarchived issues reach WARN_THRESHOLD, so an alert/cron can fire
+ * scripts/linear-archive-done.js before new-issue creation starts throwing
+ * USAGE_LIMIT_EXCEEDED (scripts/lib/linear-issue-create.js).
+ *
+ * All Linear API access goes through scripts/lib/linear-client.js — a raw
+ * GraphQL mutation call or a direct reference to Linear's API host anywhere
+ * outside that file's small allowlist fails the CI gate at
+ * scripts/audit-linear-issuecreate-chokepoint.js.
+ *
+ * Usage: node scripts/check-linear-cap.js
+ */
+
+'use strict';
+
+const linear = require('./lib/linear-client');
+const { WARN_THRESHOLD, isOverCapThreshold } = require('./lib/linear-cap-policy');
+
+async function main() {
+  const team = await linear.getTeam();
+  const issues = await linear.listIssues(team.id);
+  const count = issues.length;
+
+  if (isOverCapThreshold(count, WARN_THRESHOLD)) {
+    console.error(
+      `check-linear-cap: ${count} unarchived issues >= ${WARN_THRESHOLD} warn threshold ` +
+      `(Linear's free-tier hard cap is 250). Run scripts/linear-archive-done.js to archive ` +
+      `stale Done/Canceled issues.`
+    );
+    process.exit(1);
+  }
+
+  console.log(`check-linear-cap: OK — ${count} unarchived issues (< ${WARN_THRESHOLD} threshold).`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(`check-linear-cap: ${err.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/scripts/lib/linear-cap-policy.js
+++ b/scripts/lib/linear-cap-policy.js
@@ -7,6 +7,13 @@
  *
  * No fetch, no fs, no Date.now() — callers pass `now` in so this stays a pure
  * function CLAUDE.md rule 15 requires tests to require() directly.
+ *
+ * Scope note: the 250-issue cap is workspace-wide, but every caller counts
+ * only team BRO's issues (scripts/lib/linear-client.js's TEAM_KEY) — the same
+ * team-scoped assumption every other Linear script in this repo already
+ * makes. Correct today because BRO is the only team in the workspace; if a
+ * second team is ever added, this stops being an accurate proxy for the real
+ * cap and needs a workspace-wide count instead.
  */
 
 'use strict';
@@ -24,12 +31,14 @@ function isOverCapThreshold(count, threshold = WARN_THRESHOLD) {
 }
 
 // issue: { stateType, completedAt, canceledAt } (the shape linear-client.js's
-// listIssues() returns). Prefers completedAt when an issue somehow carries
-// both timestamps — intentional, not a bug to "fix": completedAt is the more
-// recent/authoritative close event on a Done issue.
+// listIssues() returns). closedAt is picked by CURRENT stateType, not by an
+// completedAt-wins fallback — an issue moved Done -> Canceled can carry a
+// stale completedAt from its earlier Done pass, and blindly preferring it
+// would archive on the wrong (older) timestamp, undercutting the 48h reopen
+// buffer for the transition that actually made it terminal.
 function isArchivableIssue(issue, now, ageHours = ARCHIVE_AGE_HOURS) {
   if (!issue || (issue.stateType !== 'completed' && issue.stateType !== 'canceled')) return false;
-  const closedAt = issue.completedAt || issue.canceledAt;
+  const closedAt = issue.stateType === 'completed' ? issue.completedAt : issue.canceledAt;
   if (!closedAt) return false;
   const ageMs = now - new Date(closedAt).getTime();
   return ageMs >= ageHours * 60 * 60 * 1000;

--- a/scripts/lib/linear-cap-policy.js
+++ b/scripts/lib/linear-cap-policy.js
@@ -1,0 +1,38 @@
+/**
+ * linear-cap-policy.js — pure decision logic for the Linear issue-cap monitor
+ * (BRO-285). Linear's free tier hard-caps a workspace at 250 unarchived
+ * issues; scripts/lib/linear-issue-create.js's USAGE_LIMIT_MESSAGE documents
+ * the hard cap itself, this file's WARN_THRESHOLD is the earlier trip wire
+ * scripts/check-linear-cap.js and scripts/linear-archive-done.js act on.
+ *
+ * No fetch, no fs, no Date.now() — callers pass `now` in so this stays a pure
+ * function CLAUDE.md rule 15 requires tests to require() directly.
+ */
+
+'use strict';
+
+// Warn well under the 250 hard cap so there's runway to archive before a
+// createIssue() call fails with USAGE_LIMIT_EXCEEDED.
+const WARN_THRESHOLD = 200;
+
+// Don't archive an issue the moment it closes — a quick reopen shouldn't
+// require an unarchive round-trip.
+const ARCHIVE_AGE_HOURS = 48;
+
+function isOverCapThreshold(count, threshold = WARN_THRESHOLD) {
+  return count >= threshold;
+}
+
+// issue: { stateType, completedAt, canceledAt } (the shape linear-client.js's
+// listIssues() returns). Prefers completedAt when an issue somehow carries
+// both timestamps — intentional, not a bug to "fix": completedAt is the more
+// recent/authoritative close event on a Done issue.
+function isArchivableIssue(issue, now, ageHours = ARCHIVE_AGE_HOURS) {
+  if (!issue || (issue.stateType !== 'completed' && issue.stateType !== 'canceled')) return false;
+  const closedAt = issue.completedAt || issue.canceledAt;
+  if (!closedAt) return false;
+  const ageMs = now - new Date(closedAt).getTime();
+  return ageMs >= ageHours * 60 * 60 * 1000;
+}
+
+module.exports = { WARN_THRESHOLD, ARCHIVE_AGE_HOURS, isOverCapThreshold, isArchivableIssue };

--- a/scripts/lib/linear-client.js
+++ b/scripts/lib/linear-client.js
@@ -94,7 +94,10 @@ async function listIssues(teamId) {
       `query($teamId: String!, $after: String) {
         team(id: $teamId) {
           issues(first: 100, after: $after) {
-            nodes { id identifier title url project { name } state { name } }
+            nodes {
+              id identifier title url project { name } state { name type }
+              completedAt canceledAt
+            }
             pageInfo { hasNextPage endCursor }
           }
         }
@@ -110,6 +113,13 @@ async function listIssues(teamId) {
         url: n.url,
         project: n.project ? n.project.name : null,
         state: n.state ? n.state.name : null,
+        // stateType/completedAt/canceledAt: added for the issue-cap monitor
+        // (BRO-285) to classify archive candidates without a second query —
+        // additive fields, existing callers (scripts/linear-import.js) only
+        // read id/identifier/title/url/project/state and are unaffected.
+        stateType: n.state ? n.state.type : null,
+        completedAt: n.completedAt || null,
+        canceledAt: n.canceledAt || null,
       });
     }
     if (!pageInfo.hasNextPage) break;
@@ -143,6 +153,22 @@ async function createComment(issueId, body) {
   const data = await graphql(linearDispatch.buildCommentMutation(), { issueId, body });
   if (!data.commentCreate.success) throw new Error(`commentCreate failed for issue ${issueId}`);
   return data.commentCreate;
+}
+
+// Archive a Done/Canceled issue so it stops counting against the free-tier
+// 250-unarchived-issue cap (BRO-285). Archiving is reversible in Linear's UI
+// (unarchive), unlike delete, so this carries a lower bar than updateIssue's
+// board-reprojection mutations — callers still keep their own audit trail
+// (see scripts/linear-archive-done.js) before calling this.
+async function archiveIssue(id) {
+  const data = await graphql(
+    `mutation($id: String!) {
+      issueArchive(id: $id) { success }
+    }`,
+    { id }
+  );
+  if (!data.issueArchive.success) throw new Error(`issueArchive failed for ${id}`);
+  return data.issueArchive;
 }
 
 async function updateIssue(id, input) {
@@ -192,6 +218,7 @@ module.exports = {
   listOpenIssues,
   createComment,
   updateIssue,
+  archiveIssue,
   listProjects,
   createProject,
   createIssue,

--- a/scripts/linear-archive-done.js
+++ b/scripts/linear-archive-done.js
@@ -14,6 +14,12 @@
  * outside that file's small allowlist fails the CI gate at
  * scripts/audit-linear-issuecreate-chokepoint.js.
  *
+ * Note: Linear's issues() connection excludes archived issues by default, so
+ * an issue archived here drops out of scripts/linear-import.js --reconcile's
+ * view too. That's fine — --reconcile only ever reports a vanished issue as
+ * "missing" (console.error, not a re-create) — but don't be surprised if a
+ * reconcile run's missing-count ticks up right after an archive run.
+ *
  * Usage:
  *   node scripts/linear-archive-done.js             # archives eligible issues
  *   node scripts/linear-archive-done.js --dry-run    # lists eligible issues only
@@ -59,20 +65,33 @@ async function main() {
     return;
   }
 
+  // Per-issue try/catch: one failing archiveIssue() call (network blip, an
+  // issue already archived by a concurrent run) must not abort the rest of
+  // the batch — and the log entry is written AFTER the mutation attempt,
+  // recording what actually happened, not what was about to be attempted.
   let archived = 0;
+  let failed = 0;
   for (const issue of candidates) {
-    logArchive({
-      identifier: issue.identifier,
-      id: issue.id,
-      title: issue.title,
-      stateType: issue.stateType,
-      closedAt: issue.completedAt || issue.canceledAt,
-      archivedAt: new Date(now).toISOString(),
-    });
-    await linear.archiveIssue(issue.id);
-    archived += 1;
+    const closedAt = issue.stateType === 'completed' ? issue.completedAt : issue.canceledAt;
+    try {
+      await linear.archiveIssue(issue.id);
+      logArchive({
+        identifier: issue.identifier, id: issue.id, title: issue.title,
+        stateType: issue.stateType, closedAt, archivedAt: new Date(now).toISOString(), outcome: 'archived',
+      });
+      archived += 1;
+    } catch (err) {
+      logArchive({
+        identifier: issue.identifier, id: issue.id, title: issue.title,
+        stateType: issue.stateType, closedAt, archivedAt: new Date(now).toISOString(),
+        outcome: 'failed', error: err.message,
+      });
+      console.error(`linear-archive-done: failed to archive ${issue.identifier}: ${err.message}`);
+      failed += 1;
+    }
   }
-  console.log(`linear-archive-done: archived ${archived} issue(s). Log: ${ARCHIVE_LOG_PATH}`);
+  console.log(`linear-archive-done: archived ${archived} issue(s), ${failed} failed. Log: ${ARCHIVE_LOG_PATH}`);
+  if (failed > 0) process.exitCode = 1;
 }
 
 if (require.main === module) {

--- a/scripts/linear-archive-done.js
+++ b/scripts/linear-archive-done.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * linear-archive-done.js — archives Done/Canceled Linear issues older than
+ * ARCHIVE_AGE_HOURS, to keep the workspace under the free-tier 250-unarchived
+ * -issue cap (BRO-285, scripts/check-linear-cap.js is the companion monitor).
+ *
+ * Every archive is logged to data/audit/linear-archive-done.jsonl BEFORE the
+ * mutation is applied, mirroring scripts/linear-import.js's logMutation()
+ * convention — archiving is reversible in Linear's UI, but there's otherwise
+ * no local record of what was archived or when.
+ *
+ * All Linear API access goes through scripts/lib/linear-client.js — a raw
+ * GraphQL mutation call or a direct reference to Linear's API host anywhere
+ * outside that file's small allowlist fails the CI gate at
+ * scripts/audit-linear-issuecreate-chokepoint.js.
+ *
+ * Usage:
+ *   node scripts/linear-archive-done.js             # archives eligible issues
+ *   node scripts/linear-archive-done.js --dry-run    # lists eligible issues only
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const linear = require('./lib/linear-client');
+const { ARCHIVE_AGE_HOURS, isArchivableIssue } = require('./lib/linear-cap-policy');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const ARCHIVE_LOG_PATH = path.join(REPO_ROOT, 'data/audit/linear-archive-done.jsonl');
+
+function logArchive(entry) {
+  fs.mkdirSync(path.dirname(ARCHIVE_LOG_PATH), { recursive: true });
+  fs.appendFileSync(ARCHIVE_LOG_PATH, JSON.stringify(entry) + '\n');
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const team = await linear.getTeam();
+  const issues = await linear.listIssues(team.id);
+  const now = Date.now();
+  const candidates = issues.filter((issue) => isArchivableIssue(issue, now, ARCHIVE_AGE_HOURS));
+
+  if (candidates.length === 0) {
+    console.log(`linear-archive-done: no issues completed/canceled >= ${ARCHIVE_AGE_HOURS}h ago.`);
+    return;
+  }
+
+  console.log(
+    `linear-archive-done: ${candidates.length} issue(s) eligible for archive ` +
+    `(completed/canceled >= ${ARCHIVE_AGE_HOURS}h ago):`
+  );
+  for (const issue of candidates) {
+    console.log(`  ${issue.identifier} — ${issue.title}`);
+  }
+
+  if (dryRun) {
+    console.log('linear-archive-done: --dry-run, not archiving.');
+    return;
+  }
+
+  let archived = 0;
+  for (const issue of candidates) {
+    logArchive({
+      identifier: issue.identifier,
+      id: issue.id,
+      title: issue.title,
+      stateType: issue.stateType,
+      closedAt: issue.completedAt || issue.canceledAt,
+      archivedAt: new Date(now).toISOString(),
+    });
+    await linear.archiveIssue(issue.id);
+    archived += 1;
+  }
+  console.log(`linear-archive-done: archived ${archived} issue(s). Log: ${ARCHIVE_LOG_PATH}`);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(`linear-archive-done: ${err.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -246,6 +246,7 @@ tests/unit/late-star-anchor.test.mjs
 tests/unit/lbo-first-party-downgrade.test.mjs
 tests/unit/lbo-individual-star-extraction.test.mjs
 tests/unit/lbo-roundup-page-validation.test.mjs
+tests/unit/linear-cap.test.mjs
 tests/unit/linear-next.test.mjs
 tests/unit/lint-committed-pii.test.mjs
 tests/unit/live-rc-missing-drift.test.mjs

--- a/tests/unit/linear-cap.test.mjs
+++ b/tests/unit/linear-cap.test.mjs
@@ -1,0 +1,73 @@
+// Tests scripts/lib/linear-cap-policy.js's pure decision logic — no live
+// Linear API calls (CLAUDE.md rule 15: require() the real function).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { WARN_THRESHOLD, ARCHIVE_AGE_HOURS, isOverCapThreshold, isArchivableIssue } =
+  require('../../scripts/lib/linear-cap-policy.js');
+
+const HOUR_MS = 60 * 60 * 1000;
+const NOW = Date.parse('2026-08-12T12:00:00.000Z');
+
+test('isOverCapThreshold: false below the threshold', () => {
+  assert.equal(isOverCapThreshold(199, WARN_THRESHOLD), false);
+});
+
+test('isOverCapThreshold: true at the threshold', () => {
+  assert.equal(isOverCapThreshold(200, WARN_THRESHOLD), true);
+});
+
+test('isOverCapThreshold: true above the threshold', () => {
+  assert.equal(isOverCapThreshold(230, WARN_THRESHOLD), true);
+});
+
+test('isOverCapThreshold: respects a custom threshold', () => {
+  assert.equal(isOverCapThreshold(50, 40), true);
+  assert.equal(isOverCapThreshold(30, 40), false);
+});
+
+test('isArchivableIssue: false for a non-terminal state (started)', () => {
+  const issue = { stateType: 'started', completedAt: new Date(NOW - 100 * HOUR_MS).toISOString() };
+  assert.equal(isArchivableIssue(issue, NOW), false);
+});
+
+test('isArchivableIssue: false when completed less than the age threshold ago', () => {
+  const issue = { stateType: 'completed', completedAt: new Date(NOW - 1 * HOUR_MS).toISOString() };
+  assert.equal(isArchivableIssue(issue, NOW), false);
+});
+
+test('isArchivableIssue: true when completed at least the age threshold ago', () => {
+  const issue = { stateType: 'completed', completedAt: new Date(NOW - 49 * HOUR_MS).toISOString() };
+  assert.equal(isArchivableIssue(issue, NOW), true);
+});
+
+test('isArchivableIssue: true for a canceled issue past the age threshold', () => {
+  const issue = { stateType: 'canceled', canceledAt: new Date(NOW - 49 * HOUR_MS).toISOString() };
+  assert.equal(isArchivableIssue(issue, NOW), true);
+});
+
+test('isArchivableIssue: false when completed/canceled but no timestamp present', () => {
+  const issue = { stateType: 'completed', completedAt: null, canceledAt: null };
+  assert.equal(isArchivableIssue(issue, NOW), false);
+});
+
+test('isArchivableIssue: prefers completedAt when both timestamps are present', () => {
+  const issue = {
+    stateType: 'completed',
+    completedAt: new Date(NOW - 49 * HOUR_MS).toISOString(),
+    canceledAt: new Date(NOW - 1 * HOUR_MS).toISOString(),
+  };
+  assert.equal(isArchivableIssue(issue, NOW), true);
+});
+
+test('isArchivableIssue: respects a custom ageHours override', () => {
+  const issue = { stateType: 'completed', completedAt: new Date(NOW - 5 * HOUR_MS).toISOString() };
+  assert.equal(isArchivableIssue(issue, NOW, 4), true);
+  assert.equal(isArchivableIssue(issue, NOW, ARCHIVE_AGE_HOURS), false);
+});
+
+test('isArchivableIssue: false for a null issue', () => {
+  assert.equal(isArchivableIssue(null, NOW), false);
+});

--- a/tests/unit/linear-cap.test.mjs
+++ b/tests/unit/linear-cap.test.mjs
@@ -53,13 +53,42 @@ test('isArchivableIssue: false when completed/canceled but no timestamp present'
   assert.equal(isArchivableIssue(issue, NOW), false);
 });
 
-test('isArchivableIssue: prefers completedAt when both timestamps are present', () => {
+test('isArchivableIssue: uses completedAt (not canceledAt) when stateType is completed, even if canceledAt is also set', () => {
+  // A recent canceledAt from an earlier pass through Canceled shouldn't matter
+  // once the issue is back at Done — old canceledAt would wrongly make this
+  // look archivable-since-the-stale-cancellation instead of the real close.
   const issue = {
     stateType: 'completed',
+    completedAt: new Date(NOW - 1 * HOUR_MS).toISOString(),
+    canceledAt: new Date(NOW - 49 * HOUR_MS).toISOString(),
+  };
+  assert.equal(isArchivableIssue(issue, NOW), false);
+});
+
+test('isArchivableIssue: uses canceledAt (not a stale completedAt) when stateType is canceled', () => {
+  // Issue went Done -> Canceled: completedAt is stale from the earlier Done
+  // pass. Must not archive on that old timestamp — only the actual
+  // cancellation, which happened recently, governs the 48h buffer.
+  const issue = {
+    stateType: 'canceled',
     completedAt: new Date(NOW - 49 * HOUR_MS).toISOString(),
     canceledAt: new Date(NOW - 1 * HOUR_MS).toISOString(),
   };
+  assert.equal(isArchivableIssue(issue, NOW), false);
+});
+
+test('isArchivableIssue: exact age boundary is inclusive (>=)', () => {
+  const issue = { stateType: 'completed', completedAt: new Date(NOW - ARCHIVE_AGE_HOURS * HOUR_MS).toISOString() };
   assert.equal(isArchivableIssue(issue, NOW), true);
+});
+
+test('isArchivableIssue: false for a bare object with no stateType at all', () => {
+  assert.equal(isArchivableIssue({}, NOW), false);
+});
+
+test('isOverCapThreshold: uses WARN_THRESHOLD when no threshold argument is passed', () => {
+  assert.equal(isOverCapThreshold(WARN_THRESHOLD - 1), false);
+  assert.equal(isOverCapThreshold(WARN_THRESHOLD), true);
 });
 
 test('isArchivableIssue: respects a custom ageHours override', () => {


### PR DESCRIPTION
## Summary
- `scripts/lib/linear-cap-policy.js`: pure decision logic — `isOverCapThreshold` (warn at 200, well under the 250 free-tier hard cap) and `isArchivableIssue` (Done/Canceled issues closed 48h+ ago, closedAt picked by the issue's *current* stateType, not a completedAt-wins fallback)
- `scripts/check-linear-cap.js`: exits 1 with the count once unarchived issues hit the warn threshold
- `scripts/linear-archive-done.js`: archives eligible issues via `linear.archiveIssue()`, `--dry-run` supported, per-issue try/catch so one failure doesn't abort the batch, each attempt logged to `data/audit/linear-archive-done.jsonl` with its real outcome
- `scripts/lib/linear-client.js`: extended `listIssues()` to also return `stateType`/`completedAt`/`canceledAt` (additive — existing caller `linear-import.js` only reads the pre-existing fields), added `archiveIssue(id)`
- `tests/unit/linear-cap.test.mjs`: 16 unit tests against the pure policy logic
- No cron/schedule wired — deliberately deferred per the issue's own instructions to a follow-up session

## Verification
- `node --test tests/unit/linear-cap.test.mjs` — 16/16 pass
- `node scripts/audit-orphan-tests.js` / `node scripts/audit-linear-issuecreate-chokepoint.js` — both exit 0
- `npx tsc --noEmit` clean
- Live smoke test against the real workspace: `check-linear-cap.js` correctly reports 223/200 unarchived issues (already over the warn threshold — a real, useful signal); `linear-archive-done.js --dry-run` correctly finds 0 candidates (verified via raw field dump that this is because only 1 completed issue exists workspace-wide, closed <48h ago — not a parsing bug)
- `/second-opinion` (plan) + `/ship-check` (implementation, Claude codebase review + Codex adversarial review) both ran; Codex caught two real bugs (closedAt selection, archive-loop failure handling) which are fixed in the second commit

## Test plan
- [ ] CI green on this branch
- [ ] Build owner reviews before merge (this touches `.github/workflows/test.yml`, a critical-tier CI gate file)
- [ ] Follow-up session wires the actual cron schedule for these two scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)