### PR TITLE
fix: reject non-integer --max across all 7 audit gates

### DIFF
--- a/scripts/audit-cross-show-url.js
+++ b/scripts/audit-cross-show-url.js
@@ -38,6 +38,7 @@ const fs = require('fs');
 const path = require('path');
 const { detectCrossShowUrlMismatch } = require('./lib/cross-show-url');
 const { isRejectedNonReview } = require('./lib/review-guards');
+const { parseMaxArgOrExit } = require('./lib/parse-max-arg.js');
 
 const REVIEW_TEXTS_DIR = path.join(__dirname, '..', 'data', 'review-texts');
 const SHOWS_PATH = path.join(__dirname, '..', 'data', 'shows.json');
@@ -45,8 +46,8 @@ const SHOWS_PATH = path.join(__dirname, '..', 'data', 'shows.json');
 const FIX = process.argv.includes('--fix');
 const JSON_OUT = process.argv.includes('--json');
 const STRICT = process.argv.includes('--strict');
-const maxArg = process.argv.find(a => a.startsWith('--max='));
-const MAX = maxArg ? parseInt(maxArg.split('=')[1], 10) : 0; // strict fails when unhandled > MAX
+// strict fails when unhandled > MAX
+const MAX = parseMaxArgOrExit(process.argv.slice(2), { scriptName: 'audit-cross-show-url' });
 
 // A file is already handled if a guard/human has resolved its show membership.
 // Mirrors shouldSkipCrossShowUrlFlag (review-guards.js) plus the exclusion flags

--- a/scripts/audit-nonreview-cv-conflict.js
+++ b/scripts/audit-nonreview-cv-conflict.js
@@ -33,6 +33,7 @@ const path = require('path');
 const { hasHelpFlag } = require('./lib/cli-help.js');
 const { isNonReviewDemotedByFreshCV } = require('./lib/review-guards');
 const { assertCorpusScanned, CorpusNotScannedError } = require('./lib/corpus-scan-guard');
+const { parseMaxArgOrExit } = require('./lib/parse-max-arg.js');
 
 const USAGE = `audit-nonreview-cv-conflict.js — stale isNonReview outranked by a fresher high-confidence CV (#1255)
 
@@ -51,11 +52,15 @@ const REVIEW_TEXTS_DIR = path.join(ROOT, 'data', 'review-texts');
 const SKIP_DIRS = new Set(['_superseded-misattributed']);
 
 function parseArgs(argv) {
-  const args = { gate: false, max: 15, show: null, json: false };
+  const args = {
+    gate: false,
+    max: parseMaxArgOrExit(argv, { defaultMax: 15, scriptName: 'audit-nonreview-cv-conflict' }),
+    show: null,
+    json: false,
+  };
   for (const a of argv) {
     if (a === '--gate') args.gate = true;
     else if (a === '--json') args.json = true;
-    else if (a.startsWith('--max=')) args.max = parseInt(a.split('=')[1], 10);
     else if (a.startsWith('--show=')) args.show = a.split('=')[1];
   }
   return args;

--- a/scripts/audit-review-key-duplicates.js
+++ b/scripts/audit-review-key-duplicates.js
@@ -32,6 +32,7 @@ const fs = require('fs');
 const path = require('path');
 const { listShowDirs } = require('./lib/list-show-dirs');
 const { isRejectedNonReview } = require('./lib/review-guards');
+const { parseMaxArgOrExit } = require('./lib/parse-max-arg.js');
 
 const REVIEW_TEXTS_DIR = path.join(__dirname, '..', 'data', 'review-texts');
 
@@ -86,8 +87,7 @@ function countKeyDuplicates(reviewTextsDir) {
 
 function main() {
   const argv = process.argv.slice(2);
-  const maxArg = argv.find((a) => a.startsWith('--max='));
-  const max = maxArg ? parseInt(maxArg.split('=')[1], 10) : 5;
+  const max = parseMaxArgOrExit(argv, { defaultMax: 5, scriptName: 'audit-review-key-duplicates' });
   const asJson = argv.includes('--json');
 
   if (!fs.existsSync(REVIEW_TEXTS_DIR)) {

--- a/scripts/audit-self-contradictory-clears.js
+++ b/scripts/audit-self-contradictory-clears.js
@@ -35,6 +35,7 @@ const {
   retractStaleClearBreadcrumb,
 } = require('./lib/flag-contradiction');
 const { assertCorpusScanned, CorpusNotScannedError } = require('./lib/corpus-scan-guard');
+const { parseMaxArgOrExit } = require('./lib/parse-max-arg.js');
 
 const USAGE = `audit-self-contradictory-clears.js — exclusion flag + its own clear breadcrumb (#1020/#1022/#1023)
 
@@ -59,12 +60,20 @@ const REVIEW_TEXTS_DIR = path.join(ROOT, 'data', 'review-texts');
 const SKIP_DIRS = new Set(['_superseded-misattributed']);
 
 function parseArgs(argv) {
-  const args = { gate: false, max: 0, fix: false, show: null, json: false };
+  // --max via the shared parser: the old inline parseInt returned NaN for
+  // `--max=abc`/`--max=`, and `unhandled > NaN` is always false, which would
+  // have silently disabled this gate (test.yml runs it at --max=780).
+  const args = {
+    gate: false,
+    max: parseMaxArgOrExit(argv, { scriptName: 'audit-self-contradictory-clears' }),
+    fix: false,
+    show: null,
+    json: false,
+  };
   for (const a of argv) {
     if (a === '--gate') args.gate = true;
     else if (a === '--fix') args.fix = true;
     else if (a === '--json') args.json = true;
-    else if (a.startsWith('--max=')) args.max = parseInt(a.split('=')[1], 10);
     else if (a.startsWith('--show=')) args.show = a.split('=')[1];
   }
   return args;

--- a/scripts/audit-stale-flag-after-url-correction.js
+++ b/scripts/audit-stale-flag-after-url-correction.js
@@ -30,6 +30,7 @@ const { hasHelpFlag } = require('./lib/cli-help.js');
 const { listShowDirs } = require('./lib/list-show-dirs.js');
 const { detectStaleFlagAfterUrlCorrection, remediateStaleFlagAfterUrlCorrection } = require('./lib/stale-flag-after-url-correction.js');
 const { assertCorpusScanned, CorpusNotScannedError } = require('./lib/corpus-scan-guard.js');
+const { parseMaxArgOrExit } = require('./lib/parse-max-arg.js');
 
 const USAGE = `audit-stale-flag-after-url-correction.js — stale flag + URL-correction breadcrumb sweep (#483)
 
@@ -82,21 +83,7 @@ function main() {
   // does not mean "not scoreable". The real fix is to narrow the DETECTOR so it
   // stops matching records whose publishDate independently corroborates the
   // flag — not to weaken the date guard.
-  const maxArg = argv.find((a) => a.startsWith('--max='));
-  // Reject a non-integer instead of letting parseInt hand back NaN. `--max=abc`
-  // and `--max=` both yielded NaN, and `hits.length > NaN` is ALWAYS false — so
-  // a typo in the workflow silently disabled the gate entirely while still
-  // printing a pass. Fail loud (exit 2, distinct from the exit-1 gate failure)
-  // so a malformed ceiling can never be mistaken for a clean corpus.
-  let max = 0;
-  if (maxArg) {
-    const raw = maxArg.slice('--max='.length);
-    if (!/^\d+$/.test(raw)) {
-      console.error(`FAIL: --max must be a non-negative integer, got "${raw}".`);
-      process.exit(2);
-    }
-    max = Number(raw);
-  }
+  const max = parseMaxArgOrExit(argv, { scriptName: 'audit-stale-flag-after-url-correction' });
   const dirArg = argv.find((a) => a.startsWith('--review-texts-dir='));
   const REVIEW_TEXTS_DIR = dirArg ? dirArg.split('=')[1] : path.join(ROOT, 'data', 'review-texts');
 

--- a/scripts/audit-stale-flag-after-url-correction.js
+++ b/scripts/audit-stale-flag-after-url-correction.js
@@ -64,8 +64,39 @@ function main() {
   // session's merge — which is how one data record came to gate all code
   // delivery for two days. Default stays 0 so local `--gate` is unchanged;
   // CI passes a ceiling with headroom.
+  //
+  // DO NOT ratchet this to 0 by draining with --fix until the conflict below
+  // is resolved. As of 2026-08-14 this gate and validate-data.js CHECK 0
+  // [wrong-production-by-date] disagree about ~121 records, and the
+  // date guard is the one that is RIGHT: on every sampled record the
+  // `_urlChangedClear.to` equals the CURRENT url and `publishDate` was
+  // re-derived FOR that url (dateSource `manual-live-page-…`, `url-compact`
+  // parsed from the new slug), so the flag is a correct verdict about the
+  // corrected URL, not a leftover from the old one. `publishDate` appearing in
+  // `_urlChangedClear.cleared` only records that it was cleared at
+  // URL-change time; it was repopulated afterwards. Draining these therefore
+  // un-suppresses genuinely wrong-production reviews — measured: 8 entered
+  // reviews.json, including a 2019 Trafalgar Studios Equus review scoring 97
+  // on equus-west-end-2026 and a 2017 Playhouse Glengarry on the 2026 revival.
+  // These records have no fullText but DO carry aggregatorStars, so "no body"
+  // does not mean "not scoreable". The real fix is to narrow the DETECTOR so it
+  // stops matching records whose publishDate independently corroborates the
+  // flag — not to weaken the date guard.
   const maxArg = argv.find((a) => a.startsWith('--max='));
-  const max = maxArg ? parseInt(maxArg.split('=')[1], 10) : 0;
+  // Reject a non-integer instead of letting parseInt hand back NaN. `--max=abc`
+  // and `--max=` both yielded NaN, and `hits.length > NaN` is ALWAYS false — so
+  // a typo in the workflow silently disabled the gate entirely while still
+  // printing a pass. Fail loud (exit 2, distinct from the exit-1 gate failure)
+  // so a malformed ceiling can never be mistaken for a clean corpus.
+  let max = 0;
+  if (maxArg) {
+    const raw = maxArg.slice('--max='.length);
+    if (!/^\d+$/.test(raw)) {
+      console.error(`FAIL: --max must be a non-negative integer, got "${raw}".`);
+      process.exit(2);
+    }
+    max = Number(raw);
+  }
   const dirArg = argv.find((a) => a.startsWith('--review-texts-dir='));
   const REVIEW_TEXTS_DIR = dirArg ? dirArg.split('=')[1] : path.join(ROOT, 'data', 'review-texts');
 

--- a/scripts/audit-stuck-rescore-flags.js
+++ b/scripts/audit-stuck-rescore-flags.js
@@ -31,6 +31,7 @@ const { listShowDirs } = require('./lib/list-show-dirs');
 const { isStuckRescoreFlag, isScoredButStillQueued } = require('./lib/stuck-rescore-flag');
 
 const { hasHelpFlag } = require('./lib/cli-help.js');
+const { parseMaxArgOrExit } = require('./lib/parse-max-arg.js');
 
 const USAGE = `audit-stuck-rescore-flags.js — corpus invariant: no review may carry.
 
@@ -42,12 +43,11 @@ const ROOT = path.join(__dirname, '..');
 const REVIEW_TEXTS_DIR = path.join(ROOT, 'data', 'review-texts');
 
 function parseArgs(argv) {
-  const maxArg = argv.find((a) => a.startsWith('--max='));
   return {
     fix: argv.includes('--fix'),
     gate: argv.includes('--gate') || argv.includes('--strict'),
     json: argv.includes('--json'),
-    max: maxArg ? parseInt(maxArg.split('=')[1], 10) : 0,
+    max: parseMaxArgOrExit(argv, { scriptName: 'audit-stuck-rescore-flags' }),
   };
 }
 

--- a/scripts/audit-unknown-outlets.js
+++ b/scripts/audit-unknown-outlets.js
@@ -31,6 +31,7 @@
 const fs = require('fs');
 const path = require('path');
 const { isRejectedNonReview } = require('./lib/review-guards');
+const { parseMaxArgOrExit } = require('./lib/parse-max-arg.js');
 
 const DATA_DIR = path.join(__dirname, '..', 'data');
 
@@ -97,8 +98,7 @@ function countResolvableUnknowns(reviewTextsDir, validOutlets) {
 
 function main() {
   const argv = process.argv.slice(2);
-  const maxArg = argv.find((a) => a.startsWith('--max='));
-  const max = maxArg ? parseInt(maxArg.split('=')[1], 10) : 5;
+  const max = parseMaxArgOrExit(argv, { defaultMax: 5, scriptName: 'audit-unknown-outlets' });
   const asJson = argv.includes('--json');
 
   const reviewTextsDir = path.join(DATA_DIR, 'review-texts');

--- a/scripts/lib/parse-max-arg.js
+++ b/scripts/lib/parse-max-arg.js
@@ -1,0 +1,68 @@
+/**
+ * Shared `--max=N` ceiling parser for the audit/gate scripts.
+ *
+ * Every gate script had hand-rolled this as
+ *   `maxArg ? parseInt(maxArg.split('=')[1], 10) : DEFAULT`
+ * which hands back NaN for `--max=abc` and `--max=`. Every one of those gates
+ * then compares `hits.length > max`, and `anything > NaN` is ALWAYS false — so
+ * a single typo in a workflow silently converts a blocking gate into a no-op
+ * that still prints a passing summary. `audit-self-contradictory-clears.js`
+ * runs in test.yml at `--max=780`; a typo there would have disabled it with no
+ * signal whatsoever.
+ *
+ * Centralised so the next gate that needs a ceiling cannot reintroduce the
+ * hole by copying the old one-liner (the copy is exactly how this spread to
+ * six scripts).
+ *
+ * Rejects, rather than coercing:
+ *   --max=abc  --max=  --max=1.5  --max=-1  --max=15x  --max   (bare, no '=')
+ *
+ * @param {string[]} argv - argument list (without node/script)
+ * @param {object} [opts]
+ * @param {number} [opts.defaultMax=0] - value when no --max is supplied
+ * @param {string} [opts.scriptName] - name used in the error message
+ * @returns {number} the parsed non-negative integer ceiling
+ * @throws {MaxArgError} when a --max is present but not a non-negative integer
+ */
+class MaxArgError extends Error {}
+
+function parseMaxArg(argv, { defaultMax = 0, scriptName = '' } = {}) {
+  const list = Array.isArray(argv) ? argv : [];
+  // A bare `--max` (no '=') never matched the old startsWith('--max=') check,
+  // so it silently fell through to the default — a ceiling the operator
+  // believed they had set. Treat it as the error it is.
+  if (list.includes('--max')) {
+    throw new MaxArgError(
+      `${scriptName ? `${scriptName}: ` : ''}--max requires a value, e.g. --max=15`
+    );
+  }
+  const maxArg = list.find((a) => a.startsWith('--max='));
+  if (!maxArg) return defaultMax;
+
+  const raw = maxArg.slice('--max='.length);
+  if (!/^\d+$/.test(raw)) {
+    throw new MaxArgError(
+      `${scriptName ? `${scriptName}: ` : ''}--max must be a non-negative integer, got "${raw}". ` +
+      'A non-numeric ceiling silently disables the gate (hits > NaN is always false), so this is fatal.'
+    );
+  }
+  return Number(raw);
+}
+
+/**
+ * CLI wrapper: parse, or print the error and exit 2. Exit 2 is deliberately
+ * distinct from the exit 1 that gates use for "corpus failed the check", so a
+ * malformed invocation can never be mistaken for either a pass or a real
+ * finding.
+ */
+function parseMaxArgOrExit(argv, opts = {}) {
+  try {
+    return parseMaxArg(argv, opts);
+  } catch (e) {
+    if (!(e instanceof MaxArgError)) throw e;
+    console.error(`FAIL: ${e.message}`);
+    process.exit(2);
+  }
+}
+
+module.exports = { parseMaxArg, parseMaxArgOrExit, MaxArgError };

--- a/scripts/lib/parse-max-arg.test.mjs
+++ b/scripts/lib/parse-max-arg.test.mjs
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { parseMaxArg, MaxArgError } = require('./parse-max-arg.js');
+
+// The hole this replaces: `parseInt('abc', 10)` is NaN, and every gate script
+// compares `hits.length > max`, so `> NaN` is ALWAYS false — a typo'd ceiling
+// silently turned a blocking gate into a no-op that still printed a pass.
+// test.yml runs audit-self-contradictory-clears.js at --max=780.
+
+test('valid non-negative integers parse', () => {
+  assert.equal(parseMaxArg(['--max=0']), 0);
+  assert.equal(parseMaxArg(['--max=15']), 15);
+  assert.equal(parseMaxArg(['--max=780']), 780);
+  assert.equal(parseMaxArg(['--max=007']), 7);
+  assert.equal(parseMaxArg(['--gate', '--max=3', '--json']), 3);
+});
+
+test('absent --max yields the caller-supplied default', () => {
+  assert.equal(parseMaxArg(['--gate']), 0);
+  assert.equal(parseMaxArg(['--gate'], { defaultMax: 5 }), 5);
+  assert.equal(parseMaxArg([], { defaultMax: 15 }), 15);
+});
+
+test('every value that used to become NaN is now rejected', () => {
+  for (const bad of ['--max=abc', '--max=', '--max=1.5', '--max=-1', '--max=15x', '--max=NaN', '--max= 3']) {
+    assert.throws(() => parseMaxArg([bad]), MaxArgError, `${bad} must be rejected`);
+  }
+});
+
+test('the NaN comparison this prevents really is always false (regression rationale)', () => {
+  // Documents WHY rejection matters rather than defaulting: if we coerced to
+  // NaN, a gate with 121 hits would report a pass.
+  assert.equal(121 > Number.NaN, false);
+  assert.equal(0 > Number.NaN, false);
+});
+
+test('a bare --max (no "=") is rejected rather than silently using the default', () => {
+  // The old `startsWith('--max=')` check never matched a bare `--max`, so an
+  // operator who wrote `--max 15` got the default ceiling with no warning.
+  assert.throws(() => parseMaxArg(['--gate', '--max', '15']), MaxArgError);
+});
+
+test('the error message names the script so a CI log points at the right gate', () => {
+  try {
+    parseMaxArg(['--max=abc'], { scriptName: 'audit-self-contradictory-clears' });
+    assert.fail('should have thrown');
+  } catch (e) {
+    assert.match(e.message, /audit-self-contradictory-clears/);
+    assert.match(e.message, /non-negative integer/);
+  }
+});

--- a/scripts/lib/stale-flag-after-url-correction.test.mjs
+++ b/scripts/lib/stale-flag-after-url-correction.test.mjs
@@ -9,6 +9,38 @@ const {
   isAwaitingUrlCorrectionRefetch,
   shouldWithholdStaleExclusionFlag,
 } = require('./stale-flag-after-url-correction.js');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const { fileURLToPath } = require('node:url');
+
+// --- audit CLI: --max must never silently disable the gate ------------------
+// `parseInt('abc', 10)` is NaN, and `hits.length > NaN` is ALWAYS false, so a
+// typo'd ceiling in test.yml turned this blocking gate into a no-op that still
+// printed a pass. Reject non-integers loudly (exit 2, distinct from the exit-1
+// gate failure) so a malformed ceiling can't be mistaken for a clean corpus.
+// The --max parse runs before any corpus read, so a nonexistent dir is fine.
+const AUDIT_SCRIPT = path.join(
+  path.dirname(fileURLToPath(import.meta.url)), '..', 'audit-stale-flag-after-url-correction.js'
+);
+
+function runAudit(args) {
+  return spawnSync(process.execPath, [AUDIT_SCRIPT, ...args], { encoding: 'utf8' });
+}
+
+test('audit --max with a non-integer value exits 2 instead of silently disabling the gate', () => {
+  for (const bad of ['--max=abc', '--max=', '--max=1.5', '--max=-1', '--max=15x']) {
+    const r = runAudit(['--gate', bad, '--review-texts-dir=/nonexistent-corpus-path']);
+    assert.equal(r.status, 2, `${bad} should exit 2, got ${r.status}`);
+    assert.match(r.stderr, /--max must be a non-negative integer/);
+  }
+});
+
+test('audit --max with a valid integer is accepted (not rejected as malformed)', () => {
+  for (const good of ['--max=0', '--max=15', '--max=007']) {
+    const r = runAudit([good, '--review-texts-dir=/nonexistent-corpus-path']);
+    assert.notEqual(r.status, 2, `${good} should not be rejected as malformed`);
+  }
+});
 
 // --- producer/detector agreement (the drain→rebuild→re-flag loop) ---------
 // The #483 gate stayed red for a day because the DRAIN and the RE-FLAGGER were

--- a/scripts/lib/stale-flag-after-url-correction.test.mjs
+++ b/scripts/lib/stale-flag-after-url-correction.test.mjs
@@ -42,6 +42,31 @@ test('audit --max with a valid integer is accepted (not rejected as malformed)',
   }
 });
 
+// Proves --max is actually USED as a ceiling, not merely parsed. Without this,
+// the rejection tests above would still pass if --max were ignored entirely.
+test('audit --max is applied as a real ceiling against a corpus with a known hit count', () => {
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'stale-flag-ceiling-'));
+  const HITS = 3;
+  for (let i = 0; i < HITS; i++) {
+    const showDir = path.join(root, `show-${i}-2026`);
+    fs.mkdirSync(showDir, { recursive: true });
+    fs.writeFileSync(path.join(showDir, 'outlet--critic.json'), JSON.stringify({
+      criticName: 'Critic',
+      wrongProduction: true,
+      _urlChangedClear: { from: 'https://a.example/old', to: 'https://a.example/new', cleared: ['fullText'] },
+    }));
+  }
+
+  const atCeiling = runAudit(['--gate', `--max=${HITS}`, `--review-texts-dir=${root}`]);
+  assert.equal(atCeiling.status, 0, `${HITS} hits at --max=${HITS} should pass; stdout=${atCeiling.stdout}`);
+
+  const belowCeiling = runAudit(['--gate', `--max=${HITS - 1}`, `--review-texts-dir=${root}`]);
+  assert.equal(belowCeiling.status, 1, `${HITS} hits at --max=${HITS - 1} should fail`);
+  assert.match(belowCeiling.stderr, /match the #483 stale-flag-after-URL-correction signature/);
+});
+
 // --- producer/detector agreement (the drain→rebuild→re-flag loop) ---------
 // The #483 gate stayed red for a day because the DRAIN and the RE-FLAGGER were
 // different code: a human cleared 157 flags (review-texts 773ebb7189d) and the


### PR DESCRIPTION
## What

`parseInt('abc', 10)` is NaN, and every audit gate compares `count > max`. `anything > NaN` is **always false**, so a typo'd ceiling silently converted a blocking gate into a no-op that still printed a passing summary. `audit-self-contradictory-clears.js` runs in `test.yml` at `--max=780`; a typo there would have disabled it with no signal at all.

Extracted `scripts/lib/parse-max-arg.js` and routed all seven affected scripts through it, so the next gate can't reintroduce the hole by copying the old one-liner (copying is how it spread to seven).

Rejected now with **exit 2** (distinct from a gate's exit 1, so a malformed invocation is never mistaken for a pass *or* a real finding): `--max=abc`, `--max=`, `--max=1.5`, `--max=-1`, `--max=15x`, and a bare `--max` with no `=` (which never matched the old `startsWith('--max=')` test and silently fell back to the default).

Per-script defaults (0/5/15) preserved. No gate's ceiling behavior changes.

## Tests

- `scripts/lib/parse-max-arg.test.mjs` — parser unit tests
- stale-flag suite gains a **real ceiling test** (3 hits pass at `--max=3`, fail at `--max=2`), proving the gate USES the value rather than merely parsing it
- Sabotage-checked: neutering the validation makes the rejection test fail

## Not included, deliberately

This branch started as a fix for the `test.yml` deadlock between `audit-stale-flag-after-url-correction --gate` and `validate-data.js` CHECK 0 `[wrong-production-by-date]`. That fix was **abandoned after testing showed it corrupts scores** — see the PR discussion / commit message. `test.yml` is untouched and the `--max=15` ceiling stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)