### PR TITLE
fix: scope orphan-tests pre-push audit to the pushed diff (card #1488)

### DIFF
--- a/scripts/audit-orphan-tests.js
+++ b/scripts/audit-orphan-tests.js
@@ -187,6 +187,17 @@ function main() {
   const scope = scopeStdin
     ? fs.readFileSync(0, 'utf8').split('\n').map(s => s.trim()).filter(Boolean)
     : undefined;
+  // Known accepted tradeoff (raised in review — Codex): a push that edits
+  // test.yml/a manifest to REMOVE a test's registration, without touching
+  // that test file's own content, downgrades the newly-orphaned test to
+  // informational here instead of blocking. Making test.yml's mere presence
+  // in scope fall back to full blocking was tried and reverted — it defeats
+  // the fix's actual purpose, since test.yml touched for an UNRELATED reason
+  // is exactly the #483/#1478 trigger this card exists to stop blocking.
+  // There's no cheap way to tell "this push removed a registration line"
+  // apart from "this push touched test.yml for any other reason" without a
+  // content diff, so this stays a real, informational-only gap covered by
+  // CI's unscoped full check as the safety net (test.yml:2566/2600).
   const files = listTestFiles();
   const referenced = collectReferencedTests();
   const rawOrphans = files.filter(f => !referenced.has(f.name));

--- a/scripts/audit-orphan-tests.js
+++ b/scripts/audit-orphan-tests.js
@@ -17,6 +17,18 @@
  * Usage:
  *   node scripts/audit-orphan-tests.js            # exits 1 with a list if orphans found
  *   node scripts/audit-orphan-tests.js --json     # JSON output for CI/scripts
+ *   <changed-files> | node scripts/audit-orphan-tests.js --scope-stdin
+ *                                                  # (card #1488) only orphans whose repo-
+ *                                                  # relative path is in the piped newline-
+ *                                                  # separated list are blocking; other
+ *                                                  # pre-existing orphans print as
+ *                                                  # informational and don't fail the run.
+ *                                                  # Used by scripts/lib/run-push-audits.sh
+ *                                                  # so an unrelated push isn't blocked by
+ *                                                  # someone else's unregistered test. CI's
+ *                                                  # direct calls in test.yml never pass this
+ *                                                  # flag, so the full-repo check there is
+ *                                                  # unchanged.
  *
  * Exempt: files matching tests/unit/_skip-*.test.mjs (intentionally unregistered,
  * e.g., network-dependent tests that can't run in CI).
@@ -26,6 +38,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { decideOrphanGate } = require('./lib/orphan-test-gate.js');
 
 const ROOT = path.resolve(__dirname, '..');
 const TESTS_DIR = path.join(ROOT, 'tests', 'unit');
@@ -165,6 +178,15 @@ function main() {
     process.exit(0);
   }
   const json = process.argv.includes('--json');
+  // --scope-stdin (card #1488): read repo-relative paths from a newline-
+  // separated stdin stream and only treat orphans within that scope as
+  // blocking. Absent this flag, scope is undefined and every orphan blocks —
+  // byte-for-byte the pre-#1488 behavior, which is what CI's direct calls in
+  // test.yml still get (they never pass this flag).
+  const scopeStdin = process.argv.includes('--scope-stdin');
+  const scope = scopeStdin
+    ? fs.readFileSync(0, 'utf8').split('\n').map(s => s.trim()).filter(Boolean)
+    : undefined;
   const files = listTestFiles();
   const referenced = collectReferencedTests();
   const rawOrphans = files.filter(f => !referenced.has(f.name));
@@ -176,26 +198,37 @@ function main() {
   const exemptNeverCi = rawOrphans
     .filter(f => f.name in EXEMPT_NEVER_CI)
     .map(f => ({ file: f.rel, notion: EXEMPT_NEVER_CI[f.name] }));
+  const { blocking, informational } = decideOrphanGate({ orphans, changedFiles: scope });
 
   if (json) {
     console.log(JSON.stringify({
       total: files.length,
       registered: files.length - rawOrphans.length,
       orphans: orphans.map(f => f.rel),
+      blocking: blocking.map(f => f.rel),
+      informational: informational.map(f => f.rel),
       exemptKnownBroken,
       exemptNeverCi,
     }, null, 2));
-  } else if (orphans.length > 0) {
-    console.error(`❌ ${orphans.length} orphan test file(s) — not referenced in any .github/workflows/*.yml:`);
-    for (const f of orphans) console.error(`  ${f.rel}`);
+  } else if (blocking.length > 0) {
+    console.error(`❌ ${blocking.length} orphan test file(s) — not referenced in any .github/workflows/*.yml:`);
+    for (const f of blocking) console.error(`  ${f.rel}`);
+    if (informational.length > 0) {
+      console.error('');
+      console.error(`(${informational.length} more pre-existing orphan(s) elsewhere in the repo, not touched by this push — not blocking:)`);
+      for (const f of informational) console.error(`  ${f.rel}`);
+    }
     console.error('');
     console.error('Fix: add the file to the appropriate `node --test ...` line in .github/workflows/test.yml.');
     console.error('Opt-out (known-broken): add to EXEMPT_KNOWN_BROKEN in scripts/audit-orphan-tests.js with a Notion card.');
     console.error('Opt-out (intentional): rename to `_skip-${name}.test.mjs`.');
+  } else if (informational.length > 0) {
+    console.log(`✅ ${files.length - informational.length} of ${files.length} unit test files registered in CI — ${informational.length} pre-existing orphan(s) elsewhere in the repo not touched by this push (not blocking):`);
+    for (const f of informational) console.log(`  ${f.rel}`);
   } else {
     console.log(`✅ All ${files.length} unit test files registered in CI (${exemptKnownBroken.length} known-broken exempt, ${exemptNeverCi.length} never-CI exempt)`);
   }
-  process.exit(orphans.length > 0 ? 1 : 0);
+  process.exit(blocking.length > 0 ? 1 : 0);
 }
 
 main();

--- a/scripts/lib/orphan-test-gate.js
+++ b/scripts/lib/orphan-test-gate.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// scripts/lib/orphan-test-gate.js — pure decision function for scoping
+// scripts/audit-orphan-tests.js's pass/fail to the diff being pushed.
+//
+// Card #1488: the orphan-tests audit's TRIGGER (whether to run at all) was
+// already diff-scoped in scripts/lib/run-push-audits.sh, but the CHECK itself
+// was not — once triggered, it failed on ANY unregistered test file anywhere
+// in the repo, including ones the current push never touched. Two unrelated
+// merges (cards #483, #1478) were blocked by pre-existing orphans elsewhere.
+//
+// changedFiles === undefined/null means "unscoped" — every orphan blocks.
+// This is what CI's direct, unscoped calls to audit-orphan-tests.js get, so
+// CI keeps acting as the full-repo safety net exactly as before this change.
+//
+// Tested by scripts/lib/orphan-test-gate.test.mjs (CLAUDE.md rule 15 — the
+// test require()s this function, it does not restate the logic).
+
+'use strict';
+
+// orphans: [{ name, rel }] — unregistered test files (already exempt-filtered
+// by the caller). changedFiles: string[] | Set<string> | null | undefined —
+// repo-relative paths touched by the push being gated.
+function decideOrphanGate({ orphans, changedFiles }) {
+  if (changedFiles == null) {
+    return { blocking: orphans, informational: [] };
+  }
+  const scope = changedFiles instanceof Set ? changedFiles : new Set(changedFiles);
+  const blocking = orphans.filter(o => scope.has(o.rel));
+  const informational = orphans.filter(o => !scope.has(o.rel));
+  return { blocking, informational };
+}
+
+module.exports = { decideOrphanGate };

--- a/scripts/lib/orphan-test-gate.test.mjs
+++ b/scripts/lib/orphan-test-gate.test.mjs
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { decideOrphanGate } = require('./orphan-test-gate.js');
+
+const ORPHAN_A = { name: 'a.test.mjs', rel: 'tests/unit/a.test.mjs' };
+const ORPHAN_B = { name: 'b.test.mjs', rel: 'scripts/b.test.mjs' };
+
+test('changedFiles undefined blocks every orphan (CI unscoped behavior)', () => {
+  const gate = decideOrphanGate({ orphans: [ORPHAN_A, ORPHAN_B], changedFiles: undefined });
+  assert.deepEqual(gate.blocking, [ORPHAN_A, ORPHAN_B]);
+  assert.deepEqual(gate.informational, []);
+});
+
+test('changedFiles null blocks every orphan', () => {
+  const gate = decideOrphanGate({ orphans: [ORPHAN_A], changedFiles: null });
+  assert.deepEqual(gate.blocking, [ORPHAN_A]);
+  assert.deepEqual(gate.informational, []);
+});
+
+test('orphan whose path is in changedFiles blocks', () => {
+  const gate = decideOrphanGate({
+    orphans: [ORPHAN_A, ORPHAN_B],
+    changedFiles: ['tests/unit/a.test.mjs', 'src/some-unrelated-file.ts'],
+  });
+  assert.deepEqual(gate.blocking, [ORPHAN_A]);
+  assert.deepEqual(gate.informational, [ORPHAN_B]);
+});
+
+test('orphan whose path is NOT in changedFiles is informational only, never blocks', () => {
+  const gate = decideOrphanGate({
+    orphans: [ORPHAN_A, ORPHAN_B],
+    changedFiles: ['README.md', 'scripts/unrelated.js'],
+  });
+  assert.deepEqual(gate.blocking, []);
+  assert.deepEqual(gate.informational, [ORPHAN_A, ORPHAN_B]);
+});
+
+test('empty changedFiles array blocks nothing, all informational', () => {
+  const gate = decideOrphanGate({ orphans: [ORPHAN_A], changedFiles: [] });
+  assert.deepEqual(gate.blocking, []);
+  assert.deepEqual(gate.informational, [ORPHAN_A]);
+});
+
+test('no orphans never blocks regardless of scope', () => {
+  assert.deepEqual(decideOrphanGate({ orphans: [], changedFiles: undefined }), {
+    blocking: [],
+    informational: [],
+  });
+  assert.deepEqual(decideOrphanGate({ orphans: [], changedFiles: ['x'] }), {
+    blocking: [],
+    informational: [],
+  });
+});
+
+test('accepts a Set for changedFiles, not just an array', () => {
+  const gate = decideOrphanGate({
+    orphans: [ORPHAN_A, ORPHAN_B],
+    changedFiles: new Set(['scripts/b.test.mjs']),
+  });
+  assert.deepEqual(gate.blocking, [ORPHAN_B]);
+  assert.deepEqual(gate.informational, [ORPHAN_A]);
+});

--- a/scripts/lib/run-push-audits.sh
+++ b/scripts/lib/run-push-audits.sh
@@ -53,6 +53,10 @@ FAIL=0
 run_audit() {
   local label="$1"
   local script="$2"
+  shift 2
+  # Remaining args ("$@") are passed straight through to `node "$script"` —
+  # e.g. audit-orphan-tests.js's --scope-stdin (card #1488). Existing callers
+  # that pass no extra args are unaffected.
   if [ "$LIST_ONLY" = "1" ]; then
     echo "$label"
     return 0
@@ -63,7 +67,7 @@ run_audit() {
   # corrupting/blanking the error output it prints (same fix as pre-push's
   # original run_audit()).
   local AUDIT_OUT="/tmp/push-audit.$$.$RANDOM.out"
-  if ! node "$script" >"$AUDIT_OUT" 2>&1; then
+  if ! node "$script" "$@" >"$AUDIT_OUT" 2>&1; then
     echo ""
     echo "=== AUDIT BLOCKED: $label failed ==="
     echo ""
@@ -83,7 +87,12 @@ fi
 # Orphan/unregistered test detection.
 if echo "$CHANGED_FILES" | grep -qE "^tests/unit/.*\.test\.(mjs|ts|js)$|^\.github/workflows/test\.yml$|^scripts/audit-(tests-vs-derived-data|orphan-tests)\.js$"; then
   run_audit "tests-vs-derived-data" "scripts/audit-tests-vs-derived-data.js" || FAIL=1
-  run_audit "orphan-tests" "scripts/audit-orphan-tests.js" || FAIL=1
+  # --scope-stdin (card #1488): only orphans among THIS push's changed files
+  # are blocking; pre-existing orphans elsewhere print informational and
+  # don't fail an unrelated push. CI's own direct calls to
+  # audit-orphan-tests.js (test.yml) never pass this flag, so they keep
+  # doing the full-repo check as the safety net.
+  printf '%s\n' "$CHANGED_FILES" | run_audit "orphan-tests" "scripts/audit-orphan-tests.js" --scope-stdin || FAIL=1
 fi
 
 # Playwright evaluate-click anti-pattern.

--- a/scripts/lib/run-push-audits.sh
+++ b/scripts/lib/run-push-audits.sh
@@ -92,7 +92,19 @@ if echo "$CHANGED_FILES" | grep -qE "^tests/unit/.*\.test\.(mjs|ts|js)$|^\.githu
   # don't fail an unrelated push. CI's own direct calls to
   # audit-orphan-tests.js (test.yml) never pass this flag, so they keep
   # doing the full-repo check as the safety net.
-  printf '%s\n' "$CHANGED_FILES" | run_audit "orphan-tests" "scripts/audit-orphan-tests.js" --scope-stdin || FAIL=1
+  #
+  # LIST_ONLY must skip the pipe entirely, not just let run_audit's early
+  # return not-read it: with `set -o pipefail` (line 27), a $CHANGED_FILES
+  # payload larger than the pipe buffer would make printf block on a full
+  # buffer with nobody draining it (run_audit's LIST_ONLY branch returns
+  # before touching stdin), get SIGPIPE, and fail the pipeline's exit status
+  # even though the (never-run) audit itself didn't fail — silently flipping
+  # `--list` mode to exit 1 on a large diff (found in ship-check review).
+  if [ "$LIST_ONLY" = "1" ]; then
+    run_audit "orphan-tests" "scripts/audit-orphan-tests.js" --scope-stdin || FAIL=1
+  else
+    printf '%s\n' "$CHANGED_FILES" | run_audit "orphan-tests" "scripts/audit-orphan-tests.js" --scope-stdin || FAIL=1
+  fi
 fi
 
 # Playwright evaluate-click anti-pattern.


### PR DESCRIPTION
## Summary
- The orphan-tests pre-push audit's TRIGGER was already diff-scoped, but the CHECK itself scanned the whole repo and failed on any unregistered test file — even ones unrelated to the push. This blocked two unrelated merges (#483, #1478).
- `scripts/audit-orphan-tests.js` now accepts `--scope-stdin` (newline-separated changed files); orphans outside that scope print as informational, not blocking. CI's direct unscoped calls in test.yml are untouched — still the full-repo safety net.
- Decision logic extracted to `scripts/lib/orphan-test-gate.js` (pure `decideOrphanGate`), tested in `scripts/lib/orphan-test-gate.test.mjs` per CLAUDE.md §15.
- Second commit fixes a `--list` mode EPIPE/pipefail hazard found in ship-check review, and documents (without over-fixing, since the naive fix defeated the whole point) a known accepted tradeoff: a push editing test.yml to remove a registration without touching the test file itself stays informational-only locally, caught by CI's unscoped safety net.

## Test plan
- [x] `node --test scripts/lib/orphan-test-gate.test.mjs` — 7/7 pass
- [x] `node --test scripts/lib/run-push-audits.test.mjs` — 8/8 pass (selection logic unaffected)
- [x] End-to-end: reproduced the exact #483/#1478 scenario (diff touches test.yml only, unrelated pre-existing orphan present) — no longer blocks
- [x] End-to-end: diff that touches the orphan itself still blocks
- [x] End-to-end: `--list` mode with a 128KB synthetic changed-file payload — no EPIPE/spurious failure
- [x] `/second-opinion` (plan phase) + `/ship-check` (implementation phase) both recorded via review-gate.mjs per CLAUDE.md §18

🤖 Generated with [Claude Code](https://claude.com/claude-code)