### PR TITLE
fix: reject same-title Broadway-transfer articles for regional predecessor shows (#1650)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,6 +157,14 @@ on:
       # path-listed so a solo edit triggers CI.
       - 'scripts/lib/silent-exclusion-detectors.js'
       - 'scripts/lib/silent-exclusion-detectors.test.mjs'
+      # Broadway-transfer market mismatch (#1650): a same-title Broadway
+      # transfer's own review roundup was accepted as a match for its
+      # regional predecessor on title-word match alone (heading never
+      # mentions a year, so the existing year-mismatch layers never fire).
+      # Colocated *.test.mjs runs in the scripts/lib/*.test.mjs glob;
+      # path-listed so a solo edit triggers CI.
+      - 'scripts/lib/page-validator.js'
+      - 'scripts/lib/page-validator.test.mjs'
       # Shared host-suffix source of truth: which dot-label of a hostname is the
       # outlet identity. provisionalOutletIdFromHost (registration),
       # normalizeHostSlug (domain-move detection) and registrableHost (review-gap

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,7 +157,7 @@ on:
       # path-listed so a solo edit triggers CI.
       - 'scripts/lib/silent-exclusion-detectors.js'
       - 'scripts/lib/silent-exclusion-detectors.test.mjs'
-      # Broadway-transfer market mismatch (#1650): a same-title Broadway
+      # Broadway-transfer production-category mismatch (#1650): a same-title Broadway
       # transfer's own review roundup was accepted as a match for its
       # regional predecessor on title-word match alone (heading never
       # mentions a year, so the existing year-mismatch layers never fire).

--- a/scripts/lib/page-validator.js
+++ b/scripts/lib/page-validator.js
@@ -233,6 +233,7 @@ function extractYearFromUrl(url) {
  * @param {number} [options.openingYear] - Show's opening year for year-mismatch detection
  * @param {string} [options.pageUrl] - URL of the fetched page for URL-based date extraction
  * @param {string} [options.pageType] - 'audience-aggregator' broadens the LLM's page-type framing beyond "review" (e.g. Show Score ratings pages)
+ * @param {string} [options.category] - Target show's shows.json `category` ('broadway'/'off-broadway'/'west-end'/'off-west-end'/'regional'). When set and not 'broadway', rejects headings that explicitly say "on Broadway" (same-title Broadway-transfer mismatch, #1650)
  * @returns {Promise<{ valid: boolean, confidence: number, reason: string, provider?: string }>}
  */
 async function validatePageMatchesShow(html, showTitle, options = {}) {
@@ -272,19 +273,27 @@ async function validatePageMatchesShow(html, showTitle, options = {}) {
     }
   }
 
-  // Layer 0c: Broadway-transfer market mismatch (fast, pre-word-match).
+  // Layer 0c: Broadway-transfer production-category mismatch (fast, pre-word-match).
   // A regional/off-Broadway/tour production shares its title with a same-title
   // Broadway transfer, and word-match alone can't tell them apart — the title
   // matches either way. But a roundup for the wrong (Broadway) production says
   // so explicitly in its own heading ("What Do Critics Think of TITLE on
   // Broadway?", "Review Roundup: TITLE Opens On Broadway"). When the caller
-  // tells us the target is NOT the Broadway run, that phrase is a same-title,
-  // different-production signal — reject before Layer 1's title match short-
-  // circuits past it. Confirmed: The Outsiders world-premiere-regional-2023 vs
-  // the-outsiders-2024 (#1650) — Playbill's own Broadway verdict roundup was
-  // accepted for the regional show on title match alone.
-  if (options.market && options.market !== 'broadway' && /\bon broadway\b/i.test(headingText)) {
-    return { valid: false, confidence: 0, reason: `market mismatch: headings mention "on Broadway" but target show market is "${options.market}"` };
+  // tells us the target show's own category is NOT 'broadway', that phrase is
+  // a same-title, different-production signal — reject before Layer 1's title
+  // match short-circuits past it. Only scans title/h1/first-h2 (not body prose,
+  // per this function's own headingText scope above), so incidental "belongs
+  // on Broadway" commentary inside review prose can't trigger a false reject.
+  // options.category is the show's own shows.json `category` field
+  // ('broadway'/'off-broadway'/'west-end'/'off-west-end'/'regional') — NOT
+  // the broader "market" grouping used elsewhere (isLondonMarket, NYC market
+  // pool) that lumps off-Broadway in with Broadway; deliberately named
+  // differently to avoid that collision. Confirmed: The Outsiders
+  // world-premiere-regional-2023 vs the-outsiders-2024 (#1650) — Playbill's
+  // own Broadway verdict roundup was accepted for the regional show on title
+  // match alone.
+  if (options.category && options.category !== 'broadway' && /\bon broadway\b/i.test(headingText)) {
+    return { valid: false, confidence: 0, reason: `production-category mismatch: headings mention "on Broadway" but target show category is "${options.category}"` };
   }
 
   // Layer 1: Word-match with confidence

--- a/scripts/lib/page-validator.js
+++ b/scripts/lib/page-validator.js
@@ -272,6 +272,21 @@ async function validatePageMatchesShow(html, showTitle, options = {}) {
     }
   }
 
+  // Layer 0c: Broadway-transfer market mismatch (fast, pre-word-match).
+  // A regional/off-Broadway/tour production shares its title with a same-title
+  // Broadway transfer, and word-match alone can't tell them apart — the title
+  // matches either way. But a roundup for the wrong (Broadway) production says
+  // so explicitly in its own heading ("What Do Critics Think of TITLE on
+  // Broadway?", "Review Roundup: TITLE Opens On Broadway"). When the caller
+  // tells us the target is NOT the Broadway run, that phrase is a same-title,
+  // different-production signal — reject before Layer 1's title match short-
+  // circuits past it. Confirmed: The Outsiders world-premiere-regional-2023 vs
+  // the-outsiders-2024 (#1650) — Playbill's own Broadway verdict roundup was
+  // accepted for the regional show on title match alone.
+  if (options.market && options.market !== 'broadway' && /\bon broadway\b/i.test(headingText)) {
+    return { valid: false, confidence: 0, reason: `market mismatch: headings mention "on Broadway" but target show market is "${options.market}"` };
+  }
+
   // Layer 1: Word-match with confidence
   const match = titleWordsMatchWithConfidence(showTitle, headingText);
 

--- a/scripts/lib/page-validator.test.mjs
+++ b/scripts/lib/page-validator.test.mjs
@@ -1,0 +1,58 @@
+/**
+ * Regression test for #1650: same-title Broadway transfer contaminating a
+ * regional predecessor's aggregator scrape. Playbill's own "What Do Critics
+ * Think of The Outsiders on Broadway?" roundup was accepted as a match for
+ * the-outsiders-world-premiere-regional-2023 (La Jolla Playhouse, 2023) on
+ * title-word match alone — the heading never mentions a year, so the
+ * existing year-mismatch layers never fire. Per CLAUDE.md rule 15 this
+ * require()s the real function — no logic is copied.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { validatePageMatchesShow } = require('./page-validator.js');
+
+const BROADWAY_ROUNDUP_HTML =
+  '<html><head><title>Reviews: What Do Critics Think of The Outsiders on Broadway? | Playbill</title></head>' +
+  '<body><h1 style="display:none;"></h1></body></html>';
+
+test('rejects a Broadway roundup for a regional target show (market mismatch)', async () => {
+  const result = await validatePageMatchesShow(BROADWAY_ROUNDUP_HTML, 'The Outsiders', {
+    openingYear: 2023,
+    market: 'regional',
+    skipLlm: true,
+  });
+  assert.equal(result.valid, false);
+  assert.match(result.reason, /market mismatch/);
+});
+
+test('still accepts the same roundup for the actual Broadway show', async () => {
+  const result = await validatePageMatchesShow(BROADWAY_ROUNDUP_HTML, 'The Outsiders', {
+    openingYear: 2024,
+    market: 'broadway',
+    skipLlm: true,
+  });
+  assert.equal(result.valid, true);
+});
+
+test('does not reject on "on Broadway" phrasing when market is unspecified (back-compat)', async () => {
+  const result = await validatePageMatchesShow(BROADWAY_ROUNDUP_HTML, 'The Outsiders', {
+    openingYear: 2023,
+    skipLlm: true,
+  });
+  assert.equal(result.valid, true);
+});
+
+test('market mismatch check is case-insensitive on "on Broadway"', async () => {
+  const html =
+    '<html><head><title>THE OUTSIDERS Opens ON BROADWAY — Review Roundup</title></head><body></body></html>';
+  const result = await validatePageMatchesShow(html, 'The Outsiders', {
+    openingYear: 2023,
+    market: 'off-broadway',
+    skipLlm: true,
+  });
+  assert.equal(result.valid, false);
+  assert.match(result.reason, /market mismatch/);
+});

--- a/scripts/lib/page-validator.test.mjs
+++ b/scripts/lib/page-validator.test.mjs
@@ -18,26 +18,26 @@ const BROADWAY_ROUNDUP_HTML =
   '<html><head><title>Reviews: What Do Critics Think of The Outsiders on Broadway? | Playbill</title></head>' +
   '<body><h1 style="display:none;"></h1></body></html>';
 
-test('rejects a Broadway roundup for a regional target show (market mismatch)', async () => {
+test('rejects a Broadway roundup for a regional target show (production-category mismatch)', async () => {
   const result = await validatePageMatchesShow(BROADWAY_ROUNDUP_HTML, 'The Outsiders', {
     openingYear: 2023,
-    market: 'regional',
+    category: 'regional',
     skipLlm: true,
   });
   assert.equal(result.valid, false);
-  assert.match(result.reason, /market mismatch/);
+  assert.match(result.reason, /production-category mismatch/);
 });
 
 test('still accepts the same roundup for the actual Broadway show', async () => {
   const result = await validatePageMatchesShow(BROADWAY_ROUNDUP_HTML, 'The Outsiders', {
     openingYear: 2024,
-    market: 'broadway',
+    category: 'broadway',
     skipLlm: true,
   });
   assert.equal(result.valid, true);
 });
 
-test('does not reject on "on Broadway" phrasing when market is unspecified (back-compat)', async () => {
+test('does not reject on "on Broadway" phrasing when category is unspecified (back-compat)', async () => {
   const result = await validatePageMatchesShow(BROADWAY_ROUNDUP_HTML, 'The Outsiders', {
     openingYear: 2023,
     skipLlm: true,
@@ -45,14 +45,14 @@ test('does not reject on "on Broadway" phrasing when market is unspecified (back
   assert.equal(result.valid, true);
 });
 
-test('market mismatch check is case-insensitive on "on Broadway"', async () => {
+test('production-category mismatch check is case-insensitive on "on Broadway"', async () => {
   const html =
     '<html><head><title>THE OUTSIDERS Opens ON BROADWAY — Review Roundup</title></head><body></body></html>';
   const result = await validatePageMatchesShow(html, 'The Outsiders', {
     openingYear: 2023,
-    market: 'off-broadway',
+    category: 'off-broadway',
     skipLlm: true,
   });
   assert.equal(result.valid, false);
-  assert.match(result.reason, /market mismatch/);
+  assert.match(result.reason, /production-category mismatch/);
 });

--- a/scripts/scrape-playbill-verdict.js
+++ b/scripts/scrape-playbill-verdict.js
@@ -422,7 +422,7 @@ async function processShowViaGoogle(show, showId, shows) {
   if (fs.existsSync(effectiveArchive)) {
     const html = fs.readFileSync(effectiveArchive, 'utf8');
     // Validate cached page matches this show
-    const cacheValidation = await validatePageMatchesShow(html, show.title, { openingYear: show.openingDate ? new Date(show.openingDate).getFullYear() : null, market: show.category });
+    const cacheValidation = await validatePageMatchesShow(html, show.title, { openingYear: show.openingDate ? new Date(show.openingDate).getFullYear() : null, category: show.category });
     if (!cacheValidation.valid) {
       console.log(`  [CACHE] ${showId}: Cached page is WRONG show — ${cacheValidation.reason}. Deleting cache.`);
       fs.unlinkSync(effectiveArchive);
@@ -516,7 +516,7 @@ async function processShowViaGoogle(show, showId, shows) {
         }
 
         // Validate article matches target show (LLM tiebreaker for edge cases)
-        const articleValidation = await validatePageMatchesShow(html, show.title, { openingYear: show.openingDate ? new Date(show.openingDate).getFullYear() : null, market: show.category });
+        const articleValidation = await validatePageMatchesShow(html, show.title, { openingYear: show.openingDate ? new Date(show.openingDate).getFullYear() : null, category: show.category });
         if (!articleValidation.valid) {
           console.log(`    [SKIP] Article doesn't match show "${show.title}": ${articleValidation.reason}`);
           continue;

--- a/scripts/scrape-playbill-verdict.js
+++ b/scripts/scrape-playbill-verdict.js
@@ -422,7 +422,7 @@ async function processShowViaGoogle(show, showId, shows) {
   if (fs.existsSync(effectiveArchive)) {
     const html = fs.readFileSync(effectiveArchive, 'utf8');
     // Validate cached page matches this show
-    const cacheValidation = await validatePageMatchesShow(html, show.title, { openingYear: show.openingDate ? new Date(show.openingDate).getFullYear() : null });
+    const cacheValidation = await validatePageMatchesShow(html, show.title, { openingYear: show.openingDate ? new Date(show.openingDate).getFullYear() : null, market: show.category });
     if (!cacheValidation.valid) {
       console.log(`  [CACHE] ${showId}: Cached page is WRONG show — ${cacheValidation.reason}. Deleting cache.`);
       fs.unlinkSync(effectiveArchive);
@@ -516,7 +516,7 @@ async function processShowViaGoogle(show, showId, shows) {
         }
 
         // Validate article matches target show (LLM tiebreaker for edge cases)
-        const articleValidation = await validatePageMatchesShow(html, show.title, { openingYear: show.openingDate ? new Date(show.openingDate).getFullYear() : null });
+        const articleValidation = await validatePageMatchesShow(html, show.title, { openingYear: show.openingDate ? new Date(show.openingDate).getFullYear() : null, market: show.category });
         if (!articleValidation.valid) {
           console.log(`    [SKIP] Article doesn't match show "${show.title}": ${articleValidation.reason}`);
           continue;


### PR DESCRIPTION
## Summary
- validatePageMatchesShow() had no production-category disambiguation, so Playbill's own "What Do Critics Think of The Outsiders on Broadway?" roundup was accepted as a match for the-outsiders-world-premiere-regional-2023 (La Jolla Playhouse, 2023) on title-word match alone.
- Confirmed both washpost/wsj review-text files under the-outsiders-2024 are genuinely about the Broadway run — the regional show had the phantom claim, not the Broadway one.
- Adds a category-aware Layer 0c check in scripts/lib/page-validator.js: rejects headings that say "on Broadway" when the target show's own category isn't 'broadway'. Wired into scrape-playbill-verdict.js's two validatePageMatchesShow call sites. Other ~15 call sites unaffected (opt-in option).
- Reviewed via /second-opinion (CLAUDE.md rule 18 gate for the test.yml CI path-list edit) + Codex adversarial review (renamed market->category per its finding that "market" collided with this codebase's broader market-grouping concept).

## Test plan
- [x] `node --test scripts/lib/page-validator.test.mjs` — 4/4 new unit tests pass
- [x] Real end-to-end run: `node scripts/scrape-playbill-verdict.js --shows=the-outsiders-world-premiere-regional-2023` against the actual cached buggy article — confirmed zero "Cross-show URL ownership" warnings, stale wrong cache self-healed and replaced with the legitimate La Jolla Playhouse roundup, no washpost/wsj files written under the regional show

Pushed via PR instead of direct main push — this repo's main had sustained non-fast-forward contention (32 failed push-retry attempts across 3 cycles, ~17 min) from concurrent automated CI + another parallel session's fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)