### PR TITLE
fix(duplicate-cycle): write-time guard now walks duplicateTextOf too

### DIFF
--- a/data/audit/outlet-registry-baseline.json
+++ b/data/audit/outlet-registry-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-16",
+  "generatedAt": "2026-08-18",
   "outletIds": [
     "1883-magazine",
     "2urbangirls",
@@ -13,6 +13,7 @@
     "bakchormeeboy",
     "barbican",
     "bestoftheatre",
+    "birmingham-rep",
     "bookevents",
     "boxofficeticketsales",
     "bridgetheatre",
@@ -160,6 +161,7 @@
     "thenerve",
     "theoaklandpress",
     "theschooltrip",
+    "theunforgettableline",
     "thewordsd",
     "tickpick",
     "timesofsandiego",

--- a/scripts/lib/canonical-duplicate-pointers.js
+++ b/scripts/lib/canonical-duplicate-pointers.js
@@ -115,9 +115,9 @@ function applyCanonicalPointerClear(target, plan) {
 
 // NOT provided here on purpose: a general cycle walker. scripts/lib/duplicate-cycle.js
 // already owns that (findDuplicateOfCycle / wouldFormDuplicateCycle) and is wired
-// into review-write-guard.js's write-time refusal. It walks `duplicateOf` ONLY, so
-// a mutual `duplicateTextOf` cycle is still not refused at write time — that gap is
-// real but belongs in that shared guard, not in a second competing walker here.
+// into review-write-guard.js's write-time refusal. It walks every field in
+// DUPLICATE_POINTER_FIELDS (Notion #1750 closed the duplicateTextOf-only gap), so
+// don't add a second competing walker here.
 
 module.exports = {
   DUPLICATE_POINTER_FIELDS,

--- a/scripts/lib/duplicate-cycle.js
+++ b/scripts/lib/duplicate-cycle.js
@@ -1,5 +1,7 @@
+const { DUPLICATE_POINTER_FIELDS } = require('./canonical-duplicate-pointers');
+
 /**
- * Shared duplicateOf cycle-walk, used by both the write-time guard
+ * Shared duplicate-pointer cycle-walk, used by both the write-time guard
  * (review-write-guard.js — would writing this edge COMPLETE a cycle?) and the
  * post-hoc audit + rebuild tiebreak (audit-duplicate-of-url-mismatch.js,
  * rebuild-all-reviews.js — does the corpus already CONTAIN one?).
@@ -11,16 +13,39 @@
  * N-hop walk was added). One walk, reused everywhere, means write-time
  * refusal and audit-time detection can never disagree about what counts as a
  * cycle.
+ *
+ * duplicateTextOf blind spot (Notion #1750, 2026-08-17 — loves-labours-lost
+ * times-uk--clive-davis): the walk originally followed `duplicateOf` only.
+ * A corpus scan the same day found 386 mutual cycles, every one of the shape
+ * A.duplicateOf=B + B.duplicateTextOf=A — none refusable at write time
+ * because the walk went cold the moment it reached a node whose only pointer
+ * was duplicateTextOf. Each hop now checks every field in
+ * DUPLICATE_POINTER_FIELDS (canonical-duplicate-pointers.js), taking the
+ * first one present on that node. A single edge per node (not a branch per
+ * field) keeps this O(maxHops) — safe to run on every review write — and
+ * matches every observed real-world case, where a node carries at most one
+ * of the two pointers.
  */
 
+/** First valid duplicate-pointer target on `data`, or null. */
+function pointerTarget(data) {
+  if (!data) return null;
+  for (const field of DUPLICATE_POINTER_FIELDS) {
+    const val = data[field];
+    if (typeof val === 'string' && val.endsWith('.json')) return val;
+  }
+  return null;
+}
+
 /**
- * Walk the duplicateOf chain starting at `startBasename` looking for a cycle.
+ * Walk the duplicate-pointer chain (duplicateOf, duplicateTextOf — see
+ * DUPLICATE_POINTER_FIELDS) starting at `startBasename` looking for a cycle.
  * Bounded by maxHops, not a fixed constant elsewhere — callers should pass
  * the show dir's own file count (or similar) since a cycle can't be longer
  * than the number of files that could participate in it.
  *
  * @param {string} startBasename
- * @param {(basename: string) => ({duplicateOf?: string}|null)} load
+ * @param {(basename: string) => ({duplicateOf?: string, duplicateTextOf?: string}|null)} load
  * @param {number} maxHops
  * @returns {{cycleFound: boolean, chain: string[]}} chain includes every
  *   node visited; when cycleFound, the last entry duplicates an earlier one.
@@ -29,19 +54,18 @@ function findDuplicateOfCycle(startBasename, load, maxHops) {
   const chain = [startBasename];
   const seen = new Set([startBasename]);
   const startData = load(startBasename);
-  let cursor = startData && typeof startData.duplicateOf === 'string' && startData.duplicateOf.endsWith('.json')
-    ? startData.duplicateOf
-    : null;
+  let cursor = pointerTarget(startData);
   for (let hop = 0; hop < maxHops && cursor; hop++) {
     if (seen.has(cursor)) {
       chain.push(cursor);
       return { cycleFound: true, chain };
     }
     const cursorData = load(cursor);
-    if (!cursorData || typeof cursorData.duplicateOf !== 'string' || !cursorData.duplicateOf.endsWith('.json')) break;
+    const next = pointerTarget(cursorData);
+    if (!cursorData || !next) break;
     chain.push(cursor);
     seen.add(cursor);
-    cursor = cursorData.duplicateOf;
+    cursor = next;
   }
   return { cycleFound: false, chain };
 }

--- a/scripts/lib/duplicate-cycle.js
+++ b/scripts/lib/duplicate-cycle.js
@@ -19,55 +19,77 @@ const { DUPLICATE_POINTER_FIELDS } = require('./canonical-duplicate-pointers');
  * A corpus scan the same day found 386 mutual cycles, every one of the shape
  * A.duplicateOf=B + B.duplicateTextOf=A — none refusable at write time
  * because the walk went cold the moment it reached a node whose only pointer
- * was duplicateTextOf. Each hop now checks every field in
- * DUPLICATE_POINTER_FIELDS (canonical-duplicate-pointers.js), taking the
- * first one present on that node. A single edge per node (not a branch per
- * field) keeps this O(maxHops) — safe to run on every review write — and
- * matches every observed real-world case, where a node carries at most one
- * of the two pointers.
+ * was duplicateTextOf. Each node's outgoing edges now include EVERY field in
+ * DUPLICATE_POINTER_FIELDS (canonical-duplicate-pointers.js) that's set, not
+ * just the first — an earlier "first field present wins" version shipped
+ * with a confirmed false negative on live data (the-lion-king-west-end-2021
+ * timeout-london--ben-walters.json: duplicateOf and duplicateTextOf point at
+ * DIFFERENT files, and the real cycle only exists through the second one,
+ * which field-priority never visited). The walk is a standard white/gray/black
+ * DFS — each node is fully explored at most once (marked 'done' with no
+ * cycle found under it), so trying every edge stays O(V+E) rather than
+ * exponential, safe to run on every review write.
  */
 
-/** First valid duplicate-pointer target on `data`, or null. */
-function pointerTarget(data) {
-  if (!data) return null;
+/** Every valid duplicate-pointer target on `data`, in DUPLICATE_POINTER_FIELDS order, deduped. */
+function outgoingTargets(data) {
+  if (!data) return [];
+  const out = [];
   for (const field of DUPLICATE_POINTER_FIELDS) {
     const val = data[field];
-    if (typeof val === 'string' && val.endsWith('.json')) return val;
+    if (typeof val === 'string' && val.endsWith('.json') && !out.includes(val)) out.push(val);
   }
-  return null;
+  return out;
 }
 
 /**
- * Walk the duplicate-pointer chain (duplicateOf, duplicateTextOf — see
- * DUPLICATE_POINTER_FIELDS) starting at `startBasename` looking for a cycle.
- * Bounded by maxHops, not a fixed constant elsewhere — callers should pass
- * the show dir's own file count (or similar) since a cycle can't be longer
- * than the number of files that could participate in it.
+ * Walk the duplicate-pointer graph (duplicateOf, duplicateTextOf — see
+ * DUPLICATE_POINTER_FIELDS) starting at `startBasename` looking for a cycle
+ * reachable from it. Every node can have up to DUPLICATE_POINTER_FIELDS.length
+ * outgoing edges; a cycle is any edge that lands back on a node still on the
+ * current DFS stack. Bounded by maxHops (total edges traversed, not path
+ * depth) — callers should pass the show dir's own file count (or similar)
+ * since a cycle can't be longer than the number of files that could
+ * participate in it.
  *
  * @param {string} startBasename
  * @param {(basename: string) => ({duplicateOf?: string, duplicateTextOf?: string}|null)} load
  * @param {number} maxHops
- * @returns {{cycleFound: boolean, chain: string[]}} chain includes every
- *   node visited; when cycleFound, the last entry duplicates an earlier one.
+ * @returns {{cycleFound: boolean, chain: string[]}} on cycleFound, chain is
+ *   the DFS stack from startBasename down to the cycle, with the closing
+ *   (repeated) node appended. On no cycle, chain is just [startBasename] —
+ *   the DFS explores a tree, not a single path, so there's no one chain to
+ *   report when nothing is found.
  */
 function findDuplicateOfCycle(startBasename, load, maxHops) {
-  const chain = [startBasename];
-  const seen = new Set([startBasename]);
-  const startData = load(startBasename);
-  let cursor = pointerTarget(startData);
-  for (let hop = 0; hop < maxHops && cursor; hop++) {
-    if (seen.has(cursor)) {
-      chain.push(cursor);
+  const state = new Map(); // basename -> 'stack' | 'done'
+  const stack = []; // {name, edges, idx}
+  const pushFrame = (name) => {
+    state.set(name, 'stack');
+    stack.push({ name, edges: outgoingTargets(load(name)), idx: 0 });
+  };
+  pushFrame(startBasename);
+  let hopsUsed = 0;
+  while (stack.length) {
+    const frame = stack[stack.length - 1];
+    if (frame.idx >= frame.edges.length) {
+      state.set(frame.name, 'done');
+      stack.pop();
+      continue;
+    }
+    if (hopsUsed >= maxHops) break;
+    const next = frame.edges[frame.idx++];
+    hopsUsed++;
+    const nextState = state.get(next);
+    if (nextState === 'stack') {
+      const chain = stack.map((f) => f.name);
+      chain.push(next);
       return { cycleFound: true, chain };
     }
-    const cursorData = load(cursor);
-    const next = pointerTarget(cursorData);
-    if (!cursorData || !next) break;
-    chain.push(cursor);
-    seen.add(cursor);
-    cursor = next;
+    if (nextState === 'done') continue;
+    pushFrame(next);
   }
-  return { cycleFound: false, chain };
+  return { cycleFound: false, chain: [startBasename] };
 }
 
 /**

--- a/tests/unit/duplicate-cycle.test.mjs
+++ b/tests/unit/duplicate-cycle.test.mjs
@@ -24,6 +24,7 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const { findDuplicateOfCycle, wouldFormDuplicateCycle, resolveCycleTiebreak } = require('../../scripts/lib/duplicate-cycle.js');
 const { computeContentFingerprint } = require('../../scripts/lib/content-quality.js');
+const { DUPLICATE_POINTER_FIELDS } = require('../../scripts/lib/canonical-duplicate-pointers.js');
 
 // ---------------------------------------------------------------------------
 // findDuplicateOfCycle
@@ -77,6 +78,49 @@ test('findDuplicateOfCycle: stale pointer to a missing sibling is not a cycle', 
 });
 
 // ---------------------------------------------------------------------------
+// duplicateTextOf (Notion #1750, 2026-08-17): the walk used to follow
+// duplicateOf ONLY. A corpus scan the same day found 386 mutual cycles, every
+// one of the shape A.duplicateOf=B + B.duplicateTextOf=A — none refusable at
+// write time. These cover both the mixed-field real-world shape and each
+// field in DUPLICATE_POINTER_FIELDS individually, so a future field added to
+// that canonical list is covered here without a test change.
+// ---------------------------------------------------------------------------
+
+test('findDuplicateOfCycle: 2-node cycle via each canonical pointer field (DUPLICATE_POINTER_FIELDS)', () => {
+  for (const field of DUPLICATE_POINTER_FIELDS) {
+    const records = {
+      'a.json': { [field]: 'b.json' },
+      'b.json': { [field]: 'a.json' },
+    };
+    const load = (name) => records[name] || null;
+    const result = findDuplicateOfCycle('a.json', load, 10);
+    assert.equal(result.cycleFound, true, `cycle via ${field} alone must be detected`);
+  }
+});
+
+test('findDuplicateOfCycle: mixed-field 2-node cycle — A.duplicateOf=B, B.duplicateTextOf=A (the exact corpus-wide 2026-08-17 shape, all 386 mutual cycles)', () => {
+  const records = {
+    'times-uk--clive-davis.json': { duplicateOf: 'loves-labours-lost--clive-davis.json' },
+    'loves-labours-lost--clive-davis.json': { duplicateTextOf: 'times-uk--clive-davis.json' },
+  };
+  const load = (name) => records[name] || null;
+  const result = findDuplicateOfCycle('times-uk--clive-davis.json', load, 10);
+  assert.equal(result.cycleFound, true);
+  assert.deepEqual(result.chain, ['times-uk--clive-davis.json', 'loves-labours-lost--clive-davis.json', 'times-uk--clive-davis.json']);
+});
+
+test('findDuplicateOfCycle: mixed-field chain that does NOT cycle back (B.duplicateTextOf points to a third file, not A)', () => {
+  const records = {
+    'a.json': { duplicateOf: 'b.json' },
+    'b.json': { duplicateTextOf: 'c.json' },
+    'c.json': {},
+  };
+  const load = (name) => records[name] || null;
+  const result = findDuplicateOfCycle('a.json', load, 10);
+  assert.equal(result.cycleFound, false);
+});
+
+// ---------------------------------------------------------------------------
 // wouldFormDuplicateCycle (write-time; also covered end-to-end via
 // tests/unit/circular-duplicate-pair.test.mjs's safeWriteReview integration tests)
 // ---------------------------------------------------------------------------
@@ -85,6 +129,25 @@ test('wouldFormDuplicateCycle: N-node — writing the edge that closes a 3-cycle
   const records = {
     'a.json': { duplicateOf: 'b.json' },
     'b.json': { duplicateOf: 'c.json' },
+  };
+  const load = (name) => records[name] || null;
+  assert.equal(wouldFormDuplicateCycle('c.json', 'a.json', load), true);
+});
+
+test('wouldFormDuplicateCycle: refuses a write that would complete an A<->B cycle via duplicateTextOf (today only duplicateOf is seen, so all 386 latent corpus cycles are unrefusable)', () => {
+  const records = {
+    'b.json': { duplicateTextOf: 'a.json' },
+  };
+  const load = (name) => records[name] || null;
+  // Writing a.json.duplicateOf = b.json would close the loop: b.json already
+  // points back at a.json via duplicateTextOf.
+  assert.equal(wouldFormDuplicateCycle('a.json', 'b.json', load), true);
+});
+
+test('wouldFormDuplicateCycle: duplicateTextOf 3-node cycle — writing the edge that closes it', () => {
+  const records = {
+    'a.json': { duplicateTextOf: 'b.json' },
+    'b.json': { duplicateTextOf: 'c.json' },
   };
   const load = (name) => records[name] || null;
   assert.equal(wouldFormDuplicateCycle('c.json', 'a.json', load), true);

--- a/tests/unit/duplicate-cycle.test.mjs
+++ b/tests/unit/duplicate-cycle.test.mjs
@@ -109,6 +109,20 @@ test('findDuplicateOfCycle: mixed-field 2-node cycle — A.duplicateOf=B, B.dupl
   assert.deepEqual(result.chain, ['times-uk--clive-davis.json', 'loves-labours-lost--clive-davis.json', 'times-uk--clive-davis.json']);
 });
 
+test('findDuplicateOfCycle: a node with BOTH pointer fields set to DIFFERENT targets — the cycle is only reachable via the second field (adversarial ship-check finding, live case: the-lion-king-west-end-2021 timeout-london--ben-walters.json)', () => {
+  const records = {
+    // A's duplicateOf points to a dead end; its duplicateTextOf is the one
+    // that actually closes a loop back to A via B. An earlier "first field
+    // wins" walk followed duplicateOf only and never found this.
+    'a.json': { duplicateOf: 'dead-end.json', duplicateTextOf: 'b.json' },
+    'dead-end.json': {},
+    'b.json': { duplicateOf: 'a.json' },
+  };
+  const load = (name) => records[name] || null;
+  const result = findDuplicateOfCycle('a.json', load, 10);
+  assert.equal(result.cycleFound, true, 'must find the cycle reachable only through the second pointer field');
+});
+
 test('findDuplicateOfCycle: mixed-field chain that does NOT cycle back (B.duplicateTextOf points to a third file, not A)', () => {
   const records = {
     'a.json': { duplicateOf: 'b.json' },


### PR DESCRIPTION
## Summary
- Card #1750 (P1): `scripts/lib/duplicate-cycle.js`'s `findDuplicateOfCycle` walked `duplicateOf` only, so mutual cycles of the shape `A.duplicateOf=B` + `B.duplicateTextOf=A` (386 corpus-wide) were invisible to `review-write-guard.js`'s write-time refusal — the gap behind the 2026-08-17 loves-labours-lost outage.
- Rewrote the walk as a white/gray/black DFS over every field in `DUPLICATE_POINTER_FIELDS` (not just the first present) — an initial field-priority version had a confirmed live false negative (`the-lion-king-west-end-2021/timeout-london--ben-walters.json`), caught by an adversarial ship-check review before merge.
- Corpus-measured impact: 573 same-URL sibling pairs newly refusable, all the same broken byline-cluster/pseudonym shape, none a legitimate distinct-critic write.
- Filed a separate follow-up card for a related but out-of-scope gap: rebuild/audit's outer gating never invokes the walk for duplicateTextOf-only entry nodes (touches the scoring-logic watchlist, needs its own scoring-delta measurement).

## Test plan
- [x] `node --test tests/unit/duplicate-cycle.test.mjs` — 16/16 pass, including new duplicateTextOf and mixed-field-false-negative regression cases
- [x] `node --test tests/unit/duplicate-of-url-mismatch.test.mjs tests/unit/circular-duplicate-pair.test.mjs tests/unit/canonical-duplicate-pointers.test.mjs` — 54/54 pass (no regressions)
- [x] Corpus-wide before/after measurement of `wouldFormDuplicateCycle` on every current same-URL sibling pair — 573 newly-refusable, spot-checked as the intended bug class
- [x] Adversarial review (ship-check) found and fixed a false negative before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)