### PR TITLE
fix(date-guard): carve out awaiting-URL-correction-refetch records from CHECK 0

### DIFF
--- a/scripts/lib/date-plausibility.js
+++ b/scripts/lib/date-plausibility.js
@@ -28,6 +28,27 @@ function evaluateDatePlausibility({ review, show }) {
   const empty = { implausible: false, daysBefore: null, earliestDate: null, reason: null };
   if (!review || !show) return empty;
 
+  // Awaiting-URL-correction-refetch carve-out (Notion 3bc637c5, the #483 /
+  // CHECK 0 deadlock). A record mid-URL-correction (`_urlChangedClear`
+  // breadcrumb present, body not yet refetched) still carries the OLD
+  // article's publishDate, which is not evidence about THIS article's
+  // production — the body that would confirm or refute it hasn't been
+  // fetched yet. Producers already refuse to WRITE wrongProduction/wrongShow
+  // onto these records (shouldWithholdStaleExclusionFlag in
+  // stale-flag-after-url-correction.js), so once drained, this guard was the
+  // only thing still demanding that flag — recreating the exact state the
+  // producer-side guard exists to prevent. Checked ahead of the flag
+  // early-return below (not folded into it) because it must also cover
+  // records where the flag is currently false/absent.
+  //
+  // Lazy require: stale-flag-after-url-correction.js is a leaf module today
+  // (no requires of its own), but review-write-guard.js's own use of this
+  // same evaluateDatePlausibility function (line ~876) is itself a lazy
+  // require to dodge a require cycle one edge over — matching that existing
+  // convention here rather than assuming the graph never grows an edge back.
+  const { isAwaitingUrlCorrectionRefetch } = require('./stale-flag-after-url-correction');
+  if (isAwaitingUrlCorrectionRefetch(review)) return empty;
+
   // Already-flagged / operator-scored reviews are out of scope — same
   // carve-out as validate-data.js CHECK 0. An operator-trust override
   // (allowEarlyDate etc.) is deliberately NOT exempted here, matching CHECK 0.

--- a/scripts/lib/date-plausibility.test.mjs
+++ b/scripts/lib/date-plausibility.test.mjs
@@ -112,6 +112,42 @@ test('exactly at the 180-day boundary is plausible; one day past is implausible'
   assert.equal(pastBoundary.implausible, true);
 });
 
+test('#1463 deadlock fix: a record awaiting URL-correction refetch (breadcrumb + no fullText) with an implausible date is NOT implausible', () => {
+  // This is the exact deadlock: audit-contradicted-flag-basis / the producer
+  // guard (shouldWithholdStaleExclusionFlag) refuses to WRITE wrongProduction
+  // on this record because it is mid-URL-correction, while CHECK 0 used to
+  // demand it be set — no value passed both. The old publishDate here is not
+  // evidence about this article; the body that would confirm it hasn't been
+  // refetched yet.
+  const show = { id: 'a-christmas-carol-west-end-2026', previewsStartDate: '2026-11-01', openingDate: '2026-11-20' };
+  const review = {
+    publishDate: '2025-01-01',
+    wrongProduction: false,
+    _urlChangedClear: { at: '2026-08-01T00:00:00Z', cleared: ['publishDate'] },
+  };
+  const verdict = evaluateDatePlausibility({ review, show });
+  assert.equal(verdict.implausible, false);
+});
+
+test('#1463 deadlock fix: the SAME record once fullText has landed (refetch complete) is judged normally — still implausible', () => {
+  const show = { id: 'a-christmas-carol-west-end-2026', previewsStartDate: '2026-11-01', openingDate: '2026-11-20' };
+  const review = {
+    publishDate: '2025-01-01',
+    wrongProduction: false,
+    fullText: 'The refetched article body, confirming this really is the old date.',
+    _urlChangedClear: { at: '2026-08-01T00:00:00Z', cleared: ['publishDate'] },
+  };
+  const verdict = evaluateDatePlausibility({ review, show });
+  assert.equal(verdict.implausible, true);
+});
+
+test('#1463 deadlock fix: an implausible date with NO breadcrumb at all is still implausible (carve-out is narrowly scoped)', () => {
+  const show = { id: 'a-christmas-carol-west-end-2026', previewsStartDate: '2026-11-01', openingDate: '2026-11-20' };
+  const review = { publishDate: '2025-01-01', wrongProduction: false };
+  const verdict = evaluateDatePlausibility({ review, show });
+  assert.equal(verdict.implausible, true);
+});
+
 // --- safeWriteReview() ingest-time quarantine routing -----------------------
 
 test('safeWriteReview quarantines a brand-new date-implausible review to _pending/{showId}/ instead of the show dir', () => {


### PR DESCRIPTION
## Summary
- Card #1463 (Notion 3bc637c5): validate-data.js CHECK 0 (evaluateDatePlausibility) demanded wrongProduction=true on records mid-URL-correction-refetch, while producers already refuse to write it there — no value passed both.
- evaluateDatePlausibility() now carves out any record where isAwaitingUrlCorrectionRefetch() is true, regardless of the record's current wrongProduction value.

## Test plan
- [x] node --test scripts/lib/date-plausibility.test.mjs — 20/20 pass (3 new cases per acceptance criteria)
- [x] node scripts/validate-data.js — [wrong-production-by-date] errors: 59 -> 0 on real corpus
- [x] node scripts/scoring-delta.js — 0 newly included/excluded, 0 T1 flips
- [x] node scripts/test-temporal-override-regression.js — PASS
- [x] npx tsc --noEmit / npx next lint — clean (pre-existing unrelated warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)