### PR TITLE
feat(BRO-457): enforce done-semantics-gate at linear-brain.js update --state Done

### DIFF
--- a/scripts/lib/linear-done-gate.js
+++ b/scripts/lib/linear-done-gate.js
@@ -1,0 +1,63 @@
+/**
+ * linear-done-gate.js — the enforcement point for BRO-457: may THIS
+ * `linear-brain.js update --state <name>` call actually land a
+ * completed-type state?
+ *
+ * Pure glue, no I/O. scripts/linear-brain.js's update command supplies the
+ * target state's `type` (from Linear's own team.states, already fetched
+ * during resolveState) plus the issue's description and any --comment text
+ * being posted in the same call, and this file wires them through
+ * done-semantics-gate.js's evaluateDoneTransition() — the module BRO-379
+ * built and unit-tested but never called from anywhere (that's the drift
+ * risk this ticket exists to close).
+ *
+ * Only gates a transition INTO a `type: 'completed'` state. Linear's state
+ * types are per-team but stable across renames (linear-cap-policy.js and
+ * linear-dispatch.js already key on `stateType === 'completed'` for the same
+ * reason) — matching on the literal name "Done" would silently stop gating
+ * the moment a team renamed that column, same trap linear-state-resolve.js's
+ * header explains for the state-name lookup itself.
+ *
+ * commentText is folded in because the established close flow (both
+ * notion-brain.js and this file's own caller) posts the closing comment and
+ * THEN moves the state, in the same CLI invocation — a closer recording
+ * `--comment "PR-EVIDENCE: merged deployed checked (url)"` together with
+ * `--state Done` must have that comment count as evidence in the same call,
+ * not require a second round-trip that reads it back from Linear first.
+ *
+ * existingComments is separate from commentText for the same reason: evidence
+ * recorded on the issue in an EARLIER call (e.g. an operator posts
+ * "PR-EVIDENCE: ..." today, comes back tomorrow to move the state with no
+ * --comment at all) must still count. linear-client.js's getIssue() already
+ * fetches `comments(first: 20) { nodes { body } }` on every call (ship-check
+ * finding on the first version of this gate, which read description +
+ * in-flight commentText only and would silently re-refuse a close whose
+ * evidence was sitting right there in issue history) — the caller passes
+ * those bodies through unchanged, this file does no I/O of its own.
+ */
+
+'use strict';
+
+const { evaluateDoneTransition } = require('./done-semantics-gate.js');
+const { extractPrRef } = require('./linear-pr-evidence.js');
+
+/**
+ * @param {{targetStateType:string, description?:string, commentText?:string, existingComments?:string[]}} args
+ * @returns {{gated:false}|({gated:true}&ReturnType<typeof evaluateDoneTransition>)}
+ *   gated:false means this call is not moving into a completed-type state at
+ *   all, so the gate has nothing to say — evaluateDoneTransition is not even
+ *   called. When gated:true, the rest of the object is exactly
+ *   evaluateDoneTransition's return shape (allowed/verdict/cmd/reason).
+ */
+function checkLinearDoneTransition({ targetStateType, description = '', commentText = '', existingComments = [] } = {}) {
+  if (targetStateType !== 'completed') return { gated: false };
+
+  const combinedText = [description, ...(Array.isArray(existingComments) ? existingComments : []), commentText]
+    .filter(Boolean)
+    .join('\n');
+  const prRef = extractPrRef(combinedText);
+  const result = evaluateDoneTransition({ prRef, notes: combinedText });
+  return { gated: true, ...result };
+}
+
+module.exports = { checkLinearDoneTransition };

--- a/scripts/lib/linear-pr-evidence.js
+++ b/scripts/lib/linear-pr-evidence.js
@@ -1,0 +1,66 @@
+/**
+ * linear-pr-evidence.js — parse a hand-recorded "PR-EVIDENCE:" marker off a
+ * Linear issue's text into the {merged, deployed, checked} shape
+ * done-semantics-gate.js's evaluateDoneTransition() expects as `prRef`
+ * (BRO-457).
+ *
+ * WHY A HAND-WRITTEN MARKER, NOT LINEAR'S NATIVE GITHUB ATTACHMENTS. BRO-457
+ * named three options for sourcing PR evidence on an issue: (a) a marker
+ * convention, (b) Linear's GitHub integration attachments, (c) cross-checking
+ * scripts/check-prod-deploy.js against a PR number named on the issue.
+ * Queried live before choosing: this workspace DOES have a `github`
+ * integration connected (`integrations { nodes { service } }` returns it),
+ * but issue.attachments came back empty on every sampled issue, including a
+ * closed one (BRO-379, state "In Review", zero attachments) — the app isn't
+ * auto-linking PRs to issues here, so (b) would silently block every close
+ * regardless of real evidence. (c) needs a PR-number-on-the-issue convention
+ * anyway, plus a live check-prod-deploy.js run inside a gate a person is
+ * synchronously blocked on. (a) needs no new Linear schema, costs one line on
+ * the issue, and reuses the exact "backticked/line-marker in free text" shape
+ * this repo already established for VERIFY: lines (owner-judgment-marker.js,
+ * autonomous-verify-cmd.js's VERIFY_LINE_RE) — so a closer types one more line
+ * next to the one they're already used to writing, instead of learning a
+ * second sourcing mechanism. If Linear's GitHub integration later starts
+ * populating attachments for this team, that becomes a second, additive
+ * source — this file only owns the marker half.
+ *
+ * Leaf module (no requires), same reasoning as owner-judgment-marker.js: kept
+ * dependency-free so nothing that requires this can end up in a require
+ * cycle.
+ */
+
+'use strict';
+
+// Same shape as autonomous-verify-cmd.js's VERIFY_LINE_RE: an optional
+// list-bullet and bold-markdown wrapper, then the marker, then free text.
+// Global+multiline so a later marker in the same text (e.g. a corrected
+// re-post) overrides an earlier one — last one wins, mirroring how a human
+// reads the issue top-to-bottom and takes the most recent statement as true.
+const PR_EVIDENCE_LINE_RE = /^\s*(?:[-*]\s*)?(?:\*\*)?PR-EVIDENCE(?:\*\*)?:\s*(.+)$/gim;
+
+/**
+ * @param {string} text - issue description and/or comment text to scan
+ * @returns {{merged:boolean, deployed:boolean, checked:boolean, url:string|null}|null}
+ *   null when no PR-EVIDENCE: line is present at all. When present, each of
+ *   merged/deployed/checked is true only if that exact word appears on the
+ *   line — a line that only says "PR-EVIDENCE: merged" records
+ *   deployed:false, checked:false, same as done-semantics-gate.js expects for
+ *   a genuinely partial claim (it must not silently upgrade to `true`).
+ */
+function extractPrRef(text) {
+  const s = String(text == null ? '' : text);
+  let lastBody = null;
+  for (const m of s.matchAll(PR_EVIDENCE_LINE_RE)) lastBody = m[1];
+  if (lastBody == null) return null;
+
+  const body = lastBody.trim();
+  const urlMatch = body.match(/https?:\/\/\S+/);
+  return {
+    merged: /\bmerged\b/i.test(body),
+    deployed: /\bdeployed\b/i.test(body),
+    checked: /\bchecked\b/i.test(body),
+    url: urlMatch ? urlMatch[0] : null,
+  };
+}
+
+module.exports = { extractPrRef, PR_EVIDENCE_LINE_RE };

--- a/scripts/linear-brain.js
+++ b/scripts/linear-brain.js
@@ -23,6 +23,8 @@ require('./lib/load-env').loadEnv();
 
 const { createLinearIssue } = require('./lib/linear-issue-create');
 const { hasHelpFlag } = require('./lib/cli-help');
+const linearClient = require('./lib/linear-client');
+const { checkLinearDoneTransition } = require('./lib/linear-done-gate');
 
 const USAGE = `linear-brain.js — file a Linear issue through the one creation chokepoint.
 
@@ -30,7 +32,8 @@ Usage:
   node scripts/linear-brain.js create "Issue title" --notes "description" \\
     [--dispatch | --park "<reason>"] [--priority 0-4] [--project-id <id>]
   node scripts/linear-brain.js find "search term"
-  node scripts/linear-brain.js update <BRO-N> [--state "<name>"] [--comment "<text>"]
+  node scripts/linear-brain.js update <BRO-N> [--state "<name>"] [--comment "<text>"] \\
+    [--force "<reason ≥10 chars>"]
 
   node scripts/linear-brain.js --probe [--timeout-ms N]
 
@@ -45,6 +48,13 @@ Usage:
   update: moves an issue's workflow state and/or posts a comment. --state takes
           a REAL Linear state name (not notion-brain's Done|Paused vocabulary);
           an unknown name exits 1 and lists the team's actual states.
+          Moving into a completed-type state is REFUSED (exit 5) unless the
+          issue carries done-evidence: a PR recorded via a "PR-EVIDENCE:
+          merged deployed checked (<url>)" line (issue description or this
+          call's --comment), or a safe-form verification command in an
+          "## Acceptance criteria" section / "VERIFY: <cmd>" line. Bypass
+          with --force "<reason ≥10 chars>", or LINEAR_DONE_GATE_DISABLED=1
+          for automation that must not block (BRO-457).
 `;
 
 function parseArgs(argv) {
@@ -135,8 +145,20 @@ async function runProbe(args) {
   process.exit(probe.EXIT_CODES[verdict]);
 }
 
-async function main() {
-  const argv = process.argv.slice(2);
+async function main(argv = process.argv.slice(2), deps = {}) {
+  // Injectable I/O seams — real Linear client by default, same convention
+  // scripts/linear-next.js's main() uses (deps default to the live module,
+  // tests pass stubs so no live Linear API call or gate side effect happens
+  // under `node --test`). Only the `update` command's Done-transition path
+  // needs these; every other command still lazily requires linear-client.js
+  // inline, unchanged.
+  const {
+    getIssue: getIssueFn = linearClient.getIssue,
+    getTeam: getTeamFn = linearClient.getTeam,
+    updateIssue: updateIssueFn = linearClient.updateIssue,
+    createComment: createCommentFn = linearClient.createComment,
+  } = deps;
+
   if (hasHelpFlag(argv)) {
     console.log(USAGE);
     return;
@@ -210,10 +232,9 @@ async function main() {
       process.exit(1);
     }
 
-    const linearClient = require('./lib/linear-client');
     const { resolveState, formatStateError } = require('./lib/linear-state-resolve');
     try {
-      const issue = await linearClient.getIssue(identifier);
+      const issue = await getIssueFn(identifier);
       if (!issue) {
         console.error(`❌ no such issue: ${identifier}`);
         process.exit(2);
@@ -223,13 +244,52 @@ async function main() {
       // `team.states` is passed whole — resolveState normalizes both shapes.
       let target = null;
       if (args.state !== undefined) {
-        const team = await linearClient.getTeam();
+        const team = await getTeamFn();
         const resolved = resolveState(args.state, team.states);
         if (!resolved.ok) {
           console.error(`❌ ${formatStateError(resolved)}`);
           process.exit(1);
         }
         target = resolved.state;
+      }
+
+      // BRO-457: refuse a move into a completed-type state unless the issue
+      // carries one of done-semantics-gate.js's two accepted evidence shapes.
+      // Resolved (not written) so far — same "costs nothing on refusal" shape
+      // as the state-name resolve above. Gated on `target.type`, not the
+      // literal state NAME, so a team rename of "Done" doesn't silently stop
+      // gating (see linear-done-gate.js's header).
+      if (target && target.type === 'completed') {
+        const bypassReason =
+          args.force && typeof args.force === 'string' && args.force.length >= 10 ? args.force : null;
+        if (args.force && !bypassReason) {
+          console.error('⚠️  --force ignored by done-semantics gate: the reason must be a string of ≥10 characters.');
+        }
+        if (!bypassReason && process.env.LINEAR_DONE_GATE_DISABLED !== '1') {
+          const commentText = typeof args.comment === 'string' ? args.comment : '';
+          // getIssue()'s query already fetches comments(first: 20) — reuse
+          // that read rather than a second round-trip. Evidence posted as a
+          // PAST comment (a prior session's "PR-EVIDENCE: ..." or a VERIFY:
+          // line) must count too, not just this call's own --comment.
+          const existingComments = ((issue.comments && issue.comments.nodes) || [])
+            .map((c) => c && c.body)
+            .filter(Boolean);
+          const gate = checkLinearDoneTransition({
+            targetStateType: target.type,
+            description: issue.description || '',
+            commentText,
+            existingComments,
+          });
+          if (gate.gated && !gate.allowed) {
+            console.error(`\n❌ REFUSED (${gate.verdict}) — ${issue.identifier} not moved to ${target.name}\n`);
+            console.error(gate.reason);
+            console.error(
+              `\nTo move it anyway, pass --force "<reason ≥10 chars>", ` +
+                `or set LINEAR_DONE_GATE_DISABLED=1 for automation that must not block.\n`
+            );
+            process.exit(5);
+          }
+        }
       }
 
       // ORDER MATTERS, and the first version had it backwards. It moved the
@@ -241,12 +301,12 @@ async function main() {
       const landed = [];
       try {
         if (args.comment !== undefined) {
-          await linearClient.createComment(issue.id, args.comment);
+          await createCommentFn(issue.id, args.comment);
           commented = true;
           landed.push('comment posted');
         }
         if (target) {
-          await linearClient.updateIssue(issue.id, { stateId: target.id });
+          await updateIssueFn(issue.id, { stateId: target.id });
           landed.push(`state → ${target.name}`);
         }
       } catch (err) {
@@ -317,4 +377,12 @@ async function main() {
   }
 }
 
-main();
+// Exported (not auto-invoked) when required as a module — the injectable
+// `deps` param above only exists so tests can drive `update`'s Done-gate
+// end-to-end without a live LINEAR_API_KEY, same convention as
+// scripts/linear-next.js's main(argv, deps).
+if (require.main === module) {
+  main();
+}
+
+module.exports = { main };

--- a/scripts/linear-session.js
+++ b/scripts/linear-session.js
@@ -32,12 +32,21 @@
 const linear = require('./lib/linear-client');
 const { createLinearIssue } = require('./lib/linear-issue-create');
 const lsr = require('./lib/linear-session-reporting');
+const { checkLinearDoneTransition } = require('./lib/linear-done-gate');
 
 const USAGE = `Usage:
   node scripts/linear-session.js claim --issue=BRO-123
   node scripts/linear-session.js claim --title="..." --description="..." [--priority=2] [--project="Name"]
-  node scripts/linear-session.js report --issue=<id-or-identifier> --status=<done|in-review|paused|blocked> --summary="..." [--key-files="a,b"] [--verification="..."]
-  node scripts/linear-session.js ping`;
+  node scripts/linear-session.js report --issue=<id-or-identifier> --status=<done|in-review|paused|blocked> --summary="..." [--key-files="a,b"] [--verification="..."] [--force="<reason ≥10 chars>"]
+  node scripts/linear-session.js ping
+
+  report --status=done is REFUSED (exit 5) unless the issue carries
+  done-evidence: a "PR-EVIDENCE: merged deployed checked (<url>)" line, or a
+  safe-form verification command in an "## Acceptance criteria" section /
+  "VERIFY: <cmd>" line — read from the issue description, its existing
+  comments, and this call's own outcome comment. Bypass with
+  --force="<reason ≥10 chars>", or LINEAR_DONE_GATE_DISABLED=1 for automation
+  that must not block (BRO-457).`;
 
 function parseArgs(argv) {
   const args = { _: [] };
@@ -198,19 +207,75 @@ async function cmdReport(args) {
 
   const team = await linear.getTeam();
   const completion = lsr.planCompletion({ status: args.status, states: team.states });
+
+  // BRO-457: this is the OTHER call site that ever moves a Linear issue to a
+  // completed state (the one --status=done sessions actually use, not
+  // linear-brain.js's `update`) — done-semantics-gate.js had zero real-world
+  // effect until both were wired. Gated on the literal 'done' status, not a
+  // resolved state `type`: planCompletion() only returns {stateId,
+  // stateName}, and every completion this branch ever runs for was already
+  // requested via status==='done', so the semantic intent is unambiguous
+  // without adding a type field to that return shape.
+  let stateMoved = false;
+  let refusal = null;
   if (completion.stateId) {
-    await linear.updateIssue(issue.id, { stateId: completion.stateId });
+    if (args.status === 'done') {
+      const bypassReason =
+        args.force && typeof args.force === 'string' && args.force.length >= 10 ? args.force : null;
+      if (args.force && !bypassReason) {
+        console.error('⚠️  --force ignored by done-semantics gate: the reason must be a string of ≥10 characters.');
+      }
+      if (!bypassReason && process.env.LINEAR_DONE_GATE_DISABLED !== '1') {
+        // Same three text sources linear-brain.js's update gate reads:
+        // description, prior comments (already on `issue` from getIssue()'s
+        // comments(first: 20)), and this call's own outcome comment — which
+        // was already posted above, so it counts as commentText here too.
+        const existingComments = ((issue.comments && issue.comments.nodes) || [])
+          .map((c) => c && c.body)
+          .filter(Boolean);
+        const gate = checkLinearDoneTransition({
+          targetStateType: 'completed',
+          description: issue.description || '',
+          commentText: body,
+          existingComments,
+        });
+        if (gate.gated && !gate.allowed) refusal = gate;
+      }
+    }
+    if (!refusal) {
+      await linear.updateIssue(issue.id, { stateId: completion.stateId });
+      stateMoved = true;
+    }
   }
 
+  // Marker printed regardless of refusal — the outcome comment above IS the
+  // report the Stop-hook "reported" sentinel tracks (see file header); a
+  // refused Done still means this session communicated status honestly, it
+  // just didn't get to change the issue's state.
   console.log(lsr.buildIssueIdMarker(issue.id));
   console.log(
     JSON.stringify({
       id: issue.id,
       identifier: issue.identifier,
       status: args.status,
-      stateName: completion.stateName || (issue.state && issue.state.name) || null,
+      stateName: stateMoved ? completion.stateName : (issue.state && issue.state.name) || null,
+      doneGateRefused: !!refusal,
     })
   );
+
+  if (refusal) {
+    console.error(
+      `\n❌ REFUSED (${refusal.verdict}) — ${issue.identifier} stays in "${
+        (issue.state && issue.state.name) || 'its current state'
+      }", not moved to ${completion.stateName}\n`
+    );
+    console.error(refusal.reason);
+    console.error(
+      `\nTo move it anyway, pass --force="<reason ≥10 chars>", ` +
+        `or set LINEAR_DONE_GATE_DISABLED=1 for automation that must not block.\n`
+    );
+    process.exit(5);
+  }
 }
 
 async function cmdPing() {

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -327,6 +327,7 @@ tests/unit/late-star-anchor.test.mjs
 tests/unit/lbo-first-party-downgrade.test.mjs
 tests/unit/lbo-individual-star-extraction.test.mjs
 tests/unit/lbo-roundup-page-validation.test.mjs
+tests/unit/linear-brain-done-gate.test.mjs
 tests/unit/linear-cap.test.mjs
 tests/unit/linear-client-archived-issue.test.mjs
 tests/unit/linear-client-backoff.test.mjs

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -332,6 +332,7 @@ tests/unit/linear-cap.test.mjs
 tests/unit/linear-client-archived-issue.test.mjs
 tests/unit/linear-client-backoff.test.mjs
 tests/unit/linear-next.test.mjs
+tests/unit/linear-session-done-gate.test.mjs
 tests/unit/lint-canonical-writers.test.mjs
 tests/unit/lint-committed-pii.test.mjs
 tests/unit/live-rc-missing-drift.test.mjs

--- a/tests/unit/linear-brain-done-gate.test.mjs
+++ b/tests/unit/linear-brain-done-gate.test.mjs
@@ -1,0 +1,169 @@
+// Tests scripts/linear-brain.js's `update --state <Done-type>` path wired to
+// scripts/lib/linear-done-gate.js / done-semantics-gate.js (BRO-457).
+// done-semantics-gate.js's evaluateDoneTransition() was built and unit-tested
+// in BRO-379 but had zero callers — this proves it's now actually enforced at
+// the one place a Linear issue's state moves to a completed-type state.
+//
+// Driven end-to-end IN A REAL SUBPROCESS, not an in-process call with
+// process.exit stubbed to throw: the refusal's process.exit(5) sits inside
+// the same `try { ... } catch (err) { ...; process.exit(2); }` that wraps the
+// whole update body (pre-existing shape — the "unknown state name" exit(1)
+// a few lines above it has the identical nesting), so a throwing stub would
+// be caught by that same catch and re-exit(2), masking the real refusal
+// code. tests/unit/linear-next.test.mjs's "guard parity" test documents this
+// exact class of problem and uses the same real-subprocess fix. No
+// LINEAR_API_KEY, no live Linear call — getIssue/getTeam/updateIssue/
+// createComment are all injected via main()'s `deps` param.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+const TEAM_STATES = [
+  { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+  { id: 'state-progress', name: 'In Progress', type: 'started' },
+  { id: 'state-done', name: 'Done', type: 'completed' },
+];
+
+function makeIssue(description, commentBodies = []) {
+  return {
+    id: 'issue-uuid-457',
+    identifier: 'BRO-9457',
+    title: 'Fixture issue for the done-semantics gate',
+    url: 'https://linear.app/broadway-scorecard/issue/BRO-9457/fixture',
+    description,
+    state: { id: 'state-progress', name: 'In Progress', type: 'started' },
+    // getIssue()'s real query already fetches comments(first: 20) — this
+    // fixture matches that shape so the gate's existingComments read is
+    // exercised, not just its description/commentText reads.
+    comments: { nodes: commentBodies.map((body, i) => ({ id: `c${i}`, body, createdAt: null, user: null })) },
+  };
+}
+
+// Builds a runnable fixture script that requires the real linear-brain.js,
+// injects stub I/O via main()'s deps param, and calls it with the given argv.
+function runUpdate({ argv, description, comments = [], updateShouldBeCalled }) {
+  const script = `
+    const { main } = require('./scripts/linear-brain.js');
+    const issue = ${JSON.stringify(makeIssue(description, comments))};
+    main(${JSON.stringify(argv)}, {
+      getIssue: async () => issue,
+      getTeam: async () => ({ states: ${JSON.stringify(TEAM_STATES)} }),
+      updateIssue: async () => {
+        ${updateShouldBeCalled ? "console.error('UPDATE_ISSUE_CALLED');" : "throw new Error('updateIssue must not be called — the gate refused before any write');"}
+      },
+      createComment: async () => {
+        ${updateShouldBeCalled ? "console.error('CREATE_COMMENT_CALLED');" : "throw new Error('createComment must not be called — the gate refused before any write');"}
+      },
+    });
+  `;
+  return spawnSync(process.execPath, ['-e', script], { cwd: REPO_ROOT, encoding: 'utf8', timeout: 15000 });
+}
+
+test('refused: moving to a completed-type state with neither PR evidence nor a verify command', () => {
+  const res = runUpdate({
+    argv: ['update', 'BRO-9457', '--state', 'Done'],
+    description: 'Fixed the thing, looks good.',
+    updateShouldBeCalled: false,
+  });
+  assert.equal(res.status, 5, `expected exit 5 (done-gate refusal), got ${res.status}. stderr:\n${res.stderr}`);
+  assert.match(res.stderr, /REFUSED \(no-done-evidence\)/);
+  assert.match(res.stderr, /no PR reference recorded/);
+  assert.doesNotMatch(res.stderr, /UPDATE_ISSUE_CALLED/, 'updateIssue must never run once the gate refuses');
+  assert.doesNotMatch(res.stderr, /CREATE_COMMENT_CALLED/);
+});
+
+test('allowed: a safe-form verify command in the acceptance criteria', () => {
+  const res = runUpdate({
+    argv: ['update', 'BRO-9457', '--state', 'Done'],
+    description: '## Acceptance criteria\n- `node --test tests/unit/done-semantics-gate.test.mjs` passes',
+    updateShouldBeCalled: true,
+  });
+  assert.equal(res.status, 0, `expected exit 0, got ${res.status}. stderr:\n${res.stderr}`);
+  assert.match(res.stderr, /UPDATE_ISSUE_CALLED/);
+  assert.doesNotMatch(res.stderr, /REFUSED/);
+});
+
+test('allowed: a PR-EVIDENCE marker recording merged+deployed+checked', () => {
+  const res = runUpdate({
+    argv: ['update', 'BRO-9457', '--state', 'Done'],
+    description: 'PR-EVIDENCE: merged deployed checked (https://github.com/thomaspryor/Broadwayscore/pull/999)',
+    updateShouldBeCalled: true,
+  });
+  assert.equal(res.status, 0, `expected exit 0, got ${res.status}. stderr:\n${res.stderr}`);
+  assert.match(res.stderr, /UPDATE_ISSUE_CALLED/);
+  assert.doesNotMatch(res.stderr, /REFUSED/);
+});
+
+test('allowed: PR-EVIDENCE arrives via the --comment posted in the same call, not the description', () => {
+  const res = runUpdate({
+    argv: ['update', 'BRO-9457', '--state', 'Done', '--comment', 'PR-EVIDENCE: merged deployed checked'],
+    description: 'Fixed the thing, looks good.',
+    updateShouldBeCalled: true,
+  });
+  assert.equal(res.status, 0, `expected exit 0, got ${res.status}. stderr:\n${res.stderr}`);
+  assert.match(res.stderr, /UPDATE_ISSUE_CALLED/);
+  assert.match(res.stderr, /CREATE_COMMENT_CALLED/);
+});
+
+test('allowed: PR-EVIDENCE recorded in a PAST comment (no --comment on this call) — getIssue()\'s comments(first: 20) read must be consulted, not just description', () => {
+  const res = runUpdate({
+    argv: ['update', 'BRO-9457', '--state', 'Done'],
+    description: 'Fixed the thing, looks good.',
+    comments: ['Started work.', 'PR-EVIDENCE: merged deployed checked (https://github.com/thomaspryor/Broadwayscore/pull/1000)'],
+    updateShouldBeCalled: true,
+  });
+  assert.equal(res.status, 0, `expected exit 0, got ${res.status}. stderr:\n${res.stderr}`);
+  assert.match(res.stderr, /UPDATE_ISSUE_CALLED/);
+  assert.doesNotMatch(res.stderr, /REFUSED/);
+});
+
+test('refused: a PR-EVIDENCE marker present but only partially true (not deployed)', () => {
+  const res = runUpdate({
+    argv: ['update', 'BRO-9457', '--state', 'Done'],
+    description: 'PR-EVIDENCE: merged',
+    updateShouldBeCalled: false,
+  });
+  assert.equal(res.status, 5, `expected exit 5, got ${res.status}. stderr:\n${res.stderr}`);
+  assert.match(res.stderr, /not merged\+deployed\+checked/);
+  assert.match(res.stderr, /deployed=false/);
+});
+
+test('not gated: moving to a non-completed state (In Progress) never consults the gate', () => {
+  const res = runUpdate({
+    argv: ['update', 'BRO-9457', '--state', 'In Progress'],
+    description: 'Fixed the thing, looks good.',
+    updateShouldBeCalled: true,
+  });
+  assert.equal(res.status, 0, `expected exit 0, got ${res.status}. stderr:\n${res.stderr}`);
+  assert.match(res.stderr, /UPDATE_ISSUE_CALLED/);
+});
+
+test('--force with a reason ≥10 chars bypasses the gate', () => {
+  const res = runUpdate({
+    argv: ['update', 'BRO-9457', '--state', 'Done', '--force', 'owner said ship it now'],
+    description: 'Fixed the thing, looks good.',
+    updateShouldBeCalled: true,
+  });
+  assert.equal(res.status, 0, `expected exit 0, got ${res.status}. stderr:\n${res.stderr}`);
+  assert.match(res.stderr, /UPDATE_ISSUE_CALLED/);
+});
+
+test('LINEAR_DONE_GATE_DISABLED=1 bypasses the gate for automation', () => {
+  const script = `
+    process.env.LINEAR_DONE_GATE_DISABLED = '1';
+    const { main } = require('./scripts/linear-brain.js');
+    const issue = ${JSON.stringify(makeIssue('Fixed the thing, looks good.'))};
+    main(['update', 'BRO-9457', '--state', 'Done'], {
+      getIssue: async () => issue,
+      getTeam: async () => ({ states: ${JSON.stringify(TEAM_STATES)} }),
+      updateIssue: async () => { console.error('UPDATE_ISSUE_CALLED'); },
+      createComment: async () => {},
+    });
+  `;
+  const res = spawnSync(process.execPath, ['-e', script], { cwd: REPO_ROOT, encoding: 'utf8', timeout: 15000 });
+  assert.equal(res.status, 0, `expected exit 0, got ${res.status}. stderr:\n${res.stderr}`);
+  assert.match(res.stderr, /UPDATE_ISSUE_CALLED/);
+});

--- a/tests/unit/linear-session-done-gate.test.mjs
+++ b/tests/unit/linear-session-done-gate.test.mjs
@@ -1,0 +1,166 @@
+// Tests scripts/linear-session.js's `report --status=done` path wired to
+// scripts/lib/linear-done-gate.js (BRO-457, follow-up to the linear-brain.js
+// wiring). `report --status=done` — not `linear-brain.js update` — is the
+// call site every session actually uses to close out Linear work (it's what
+// the file's own header says the Stop-hook gates on), so done-semantics-gate
+// had no real-world effect until this path was gated too.
+//
+// Mocks global.fetch — no live Linear API calls — same convention as
+// tests/unit/linear-client-archived-issue.test.mjs. cmdReport() is called
+// in-process (not a subprocess): unlike linear-brain.js's `update`,
+// cmdReport's process.exit(5) refusal path has no surrounding try/catch to
+// swallow a thrown process.exit stub (main()'s own .catch() only wraps
+// main(), never a direct cmdReport() call), so a stub-that-throws propagates
+// cleanly as a rejected promise here.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+process.env.LINEAR_API_KEY = 'test-key';
+const { cmdReport } = require('../../scripts/linear-session.js');
+
+// Mirrors this team's real states (queried live: In Review, Canceled, Todo,
+// Backlog, Duplicate, Done, In Progress) closely enough to exercise
+// planCompletion()'s exact-name matching rather than falling back to
+// type-based matching, which would silently mask a wrong-state bug here.
+const TEAM_STATES = [
+  { id: 'state-todo', name: 'Todo', type: 'unstarted' },
+  { id: 'state-progress', name: 'In Progress', type: 'started' },
+  { id: 'state-review', name: 'In Review', type: 'started' },
+  { id: 'state-done', name: 'Done', type: 'completed' },
+];
+
+function makeIssueResponse({ description, commentBodies = [] }) {
+  return {
+    data: {
+      issue: {
+        id: 'issue-uuid-457b',
+        identifier: 'BRO-9458',
+        title: 'Fixture issue for the report --status=done gate',
+        description,
+        priority: 2,
+        url: 'https://linear.app/broadway-scorecard/issue/BRO-9458/fixture',
+        state: { id: 'state-progress', name: 'In Progress', type: 'started' },
+        labels: { nodes: [] },
+        comments: { nodes: commentBodies.map((body, i) => ({ id: `c${i}`, body, createdAt: null, user: null })) },
+      },
+    },
+  };
+}
+
+// Queues responses keyed by a substring match against the outgoing query
+// text, same op-detection style as linear-client-archived-issue.test.mjs's
+// mockFetch — order-independent since cmdReport's call order across
+// getIssue/createComment/getTeam/updateIssue is exactly what this proves.
+function mockFetch({ issue, updateShouldBeCalled }) {
+  const calls = [];
+  global.fetch = async (_url, opts) => {
+    const body = JSON.parse(opts.body);
+    const q = body.query;
+    calls.push({ query: q, variables: body.variables });
+    if (q.includes('issue(id:')) return { json: async () => makeIssueResponse(issue) };
+    if (q.includes('commentCreate')) return { json: async () => ({ data: { commentCreate: { success: true, comment: { id: 'c-new' } } } }) };
+    if (q.includes('teams(filter:')) {
+      return { json: async () => ({ data: { teams: { nodes: [{ id: 'team-1', key: 'BRO', states: { nodes: TEAM_STATES } }] } } }) };
+    }
+    if (q.includes('issueUpdate')) {
+      if (!updateShouldBeCalled) throw new Error('issueUpdate must not be called — the gate refused before any write');
+      return { json: async () => ({ data: { issueUpdate: { success: true } } }) };
+    }
+    throw new Error(`no mock handler for query: ${q.slice(0, 80)}`);
+  };
+  return calls;
+}
+
+function withStubbedExit(fn) {
+  let exitCode = null;
+  const origExit = process.exit;
+  process.exit = (code) => {
+    exitCode = code;
+    throw new Error('EXIT');
+  };
+  const origError = console.error;
+  const errors = [];
+  console.error = (...a) => errors.push(a.join(' '));
+  const origLog = console.log;
+  const logs = [];
+  console.log = (...a) => logs.push(a.join(' '));
+  return fn({ getExitCode: () => exitCode, getErrors: () => errors.join('\n'), getLogs: () => logs.join('\n') })
+    .finally(() => {
+      process.exit = origExit;
+      console.error = origError;
+      console.log = origLog;
+    });
+}
+
+test('refused: report --status=done with neither PR evidence nor a verify command', async () => {
+  await withStubbedExit(async (h) => {
+    mockFetch({ issue: { description: 'Fixed the thing, looks good.' }, updateShouldBeCalled: false });
+    await assert.rejects(
+      () => cmdReport({ issue: 'BRO-9458', status: 'done', summary: 'did the work' }),
+      /EXIT/
+    );
+    assert.equal(h.getExitCode(), 5);
+    assert.match(h.getErrors(), /REFUSED \(no-done-evidence\)/);
+    // The outcome comment still posts (the marker is still printed) — only
+    // the state move is refused.
+    assert.match(h.getLogs(), /__LINEAR_ISSUE_ID__=issue-uuid-457b/);
+    assert.match(h.getLogs(), /"doneGateRefused":true/);
+  });
+});
+
+test('allowed: a safe-form verify command in the issue description', async () => {
+  await withStubbedExit(async (h) => {
+    mockFetch({
+      issue: { description: '## Acceptance criteria\n- `node --test tests/unit/done-semantics-gate.test.mjs` passes' },
+      updateShouldBeCalled: true,
+    });
+    await cmdReport({ issue: 'BRO-9458', status: 'done', summary: 'did the work' });
+    assert.match(h.getLogs(), /"doneGateRefused":false/);
+    assert.match(h.getLogs(), /"stateName":"Done"/);
+  });
+});
+
+test('allowed: PR-EVIDENCE recorded in a past comment (not the description or this report)', async () => {
+  await withStubbedExit(async (h) => {
+    mockFetch({
+      issue: {
+        description: 'Fixed the thing, looks good.',
+        commentBodies: ['PR-EVIDENCE: merged deployed checked (https://github.com/thomaspryor/Broadwayscore/pull/1001)'],
+      },
+      updateShouldBeCalled: true,
+    });
+    await cmdReport({ issue: 'BRO-9458', status: 'done', summary: 'did the work' });
+    assert.match(h.getLogs(), /"doneGateRefused":false/);
+  });
+});
+
+test('not gated: report --status=in-review never consults the gate even with zero evidence', async () => {
+  await withStubbedExit(async (h) => {
+    mockFetch({ issue: { description: 'Fixed the thing, looks good.' }, updateShouldBeCalled: true });
+    await cmdReport({ issue: 'BRO-9458', status: 'in-review', summary: 'did the work' });
+    assert.match(h.getLogs(), /"stateName":"In Review"/);
+  });
+});
+
+test('--force with a reason ≥10 chars bypasses the gate', async () => {
+  await withStubbedExit(async (h) => {
+    mockFetch({ issue: { description: 'Fixed the thing, looks good.' }, updateShouldBeCalled: true });
+    await cmdReport({ issue: 'BRO-9458', status: 'done', summary: 'did the work', force: 'owner said ship it now' });
+    assert.match(h.getLogs(), /"doneGateRefused":false/);
+  });
+});
+
+test('LINEAR_DONE_GATE_DISABLED=1 bypasses the gate for automation', async () => {
+  await withStubbedExit(async (h) => {
+    process.env.LINEAR_DONE_GATE_DISABLED = '1';
+    try {
+      mockFetch({ issue: { description: 'Fixed the thing, looks good.' }, updateShouldBeCalled: true });
+      await cmdReport({ issue: 'BRO-9458', status: 'done', summary: 'did the work' });
+      assert.match(h.getLogs(), /"doneGateRefused":false/);
+    } finally {
+      delete process.env.LINEAR_DONE_GATE_DISABLED;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Wires `scripts/lib/done-semantics-gate.js` (built + unit-tested in BRO-379, zero callers until now) into `scripts/linear-brain.js`'s `update --state <name>` command — moving a Linear issue into a completed-type state is refused (exit 5) unless it carries PR-merged+deployed+checked evidence or a safe-form verify command.
- New `scripts/lib/linear-pr-evidence.js` parses a hand-written `PR-EVIDENCE: merged deployed checked (<url>)` marker — chosen over Linear's native GitHub attachments after confirming live that this workspace's integration exists but populates zero attachments on sampled issues.
- Evidence is read from issue description, the in-flight `--comment`, and (ship-check finding, fixed) the issue's existing comment history via `getIssue()`'s already-fetched `comments(first: 20)`.
- `--force "<reason>=10 chars"` and `LINEAR_DONE_GATE_DISABLED=1` escape hatches mirror `notion-brain.js`'s `enforceCloseTimeVerify`.

## Test plan
- [x] `node --test tests/unit/done-semantics-gate.test.mjs` (10/10 pass, unmodified)
- [x] `node --test tests/unit/linear-brain-done-gate.test.mjs` (9/9 pass, new — real-subprocess integration test proving refuse/allow/bypass behavior end-to-end)
- [x] `node --test tests/unit/linear-next.test.mjs tests/unit/linear-client-archived-issue.test.mjs` (no regressions)
- [x] `npx next lint` on changed files — clean
- [x] Live-verified against real Linear API: `getTeam()` confirms this team's "Done" state has `type: 'completed'`; `integrations`/`attachments` queries confirmed the PR-evidence design choice
- [x] ship-check: codebase review + adversarial GPT-5.4-mini review (Codex CLI blocked by this sandbox's missing private-data preflight); one real gap found and fixed (existing-comment evidence wasn't read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)