### PR TITLE
BRO-130: carry every referenced show through feedback diagnosis + auto-fix

### DIFF
--- a/.github/workflows/auto-fix-feedback-bug.yml
+++ b/.github/workflows/auto-fix-feedback-bug.yml
@@ -73,7 +73,7 @@ jobs:
         run: node scripts/auto-fix-feedback-bug.js
 
       - name: Commit and push
-        if: always() && steps.fix.outputs.action == 'fixed'
+        if: always() && (steps.fix.outputs.action == 'fixed' || steps.fix.outputs.action == 'partial')
         env:
           ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
         run: |
@@ -138,6 +138,26 @@ jobs:
                 owner: context.repo.owner, repo: context.repo.repo,
                 issue_number: issueNumber,
                 state: 'closed', state_reason: 'completed'
+              });
+            } else if (action === 'partial') {
+              // Multi-show report where only some shows got fixed (issue
+              // #515) — comment with the per-show breakdown and leave the
+              // issue OPEN. Never state_reason:'completed' here: closing
+              // would silently drop the unresolved show(s) exactly like the
+              // original bug.
+              const fs = require('fs');
+              let body = 'Some but not all shows referenced in this report were auto-fixed. Leaving this issue open for the remainder.';
+              try {
+                body = fs.readFileSync('.github-comment.md', 'utf8') || body;
+              } catch (_) { /* fall back to generic message above */ }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issueNumber,
+                body,
+              });
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issueNumber, labels: ['auto-fixed', 'needs-manual-review']
               });
             } else if (action === 'not-a-bug') {
               await github.rest.issues.addLabels({

--- a/.github/workflows/process-feedback.yml
+++ b/.github/workflows/process-feedback.yml
@@ -307,6 +307,7 @@ jobs:
             function resolveShow(name) {
               return resolveShowRanked(name, allShows);
             }
+            const { normalizeDiagnosisShowIds } = require(`${process.env.GITHUB_WORKSPACE}/scripts/lib/feedback-multishow.js`);
 
             // Drain as we go: entries are removed from `remaining` once handled,
             // and whatever is left (mid-loop crash/cancel) is written back in
@@ -316,10 +317,20 @@ jobs:
               for (const entry of diagnosed) {
                 const { item, submission, diagnosis } = entry;
                 const resolvedShow = resolveShow(submission.show);
+                // showIds is the canonical multi-show field: every show this
+                // report references, not just the form's `show` field. Union
+                // of diagnoseBug's deterministic resolvedShowIds (matched
+                // against the message text too) with the form-field show —
+                // the form field is authoritative when present, so it's
+                // guaranteed to be included even if resolvedShowIds missed it.
+                const showIdSet = new Set(normalizeDiagnosisShowIds(diagnosis));
+                if (resolvedShow?.id) showIdSet.add(resolvedShow.id);
+                const showIds = [...showIdSet];
                 const diagPayload = {
                   ...diagnosis,
-                  showId: resolvedShow?.id || null,
+                  showId: resolvedShow?.id || showIds[0] || null,
                   showSlug: resolvedShow?.slug || null,
+                  showIds,
                   submitterName: submission.name || null,
                   submitterEmail: submission.email || null,
                   submitterShow: submission.show || null,
@@ -373,6 +384,7 @@ jobs:
                   diagnosis.proposedFix,
                   `**Confidence:** ${diagnosis.confidence} | **Type:** ${diagnosis.fixType}`,
                   `**Files:** ${diagnosis.relevantFiles.join(', ')}`,
+                  ...(showIds.length > 1 ? [`**Shows referenced:** ${showIds.join(', ')} (auto-fix will attempt all of them)`] : []),
                   '',
                   '---',
                   `*Auto-diagnosed by feedback pipeline*`,

--- a/scripts/auto-fix-feedback-bug.js
+++ b/scripts/auto-fix-feedback-bug.js
@@ -7,7 +7,9 @@
  * and for high-confidence data fixes, calls Claude to generate exact field edits,
  * applies them, and validates.
  *
- * Outputs one of: fixed | skipped | not-a-bug | validation-failed | error
+ * Outputs one of: fixed | partial | skipped | not-a-bug | validation-failed | error
+ * `partial` means the report named multiple shows and only some got fixed —
+ * the issue stays open instead of closing as COMPLETED (issue #515).
  *
  * Env vars:
  *   ISSUE_BODY       - Full GitHub issue body text
@@ -28,6 +30,7 @@ const audienceBuzzWriteGuard = _require('./lib/audience-buzz-write-guard.js');
 const { hasHelpFlag } = _require('./lib/cli-help.js');
 const { foldDiacritics } = _require('./lib/title-match.js');
 const { pickEditableFields, AUTO_FIX_EDITABLE_FIELDS } = _require('./lib/feedback-pipeline-fields.js');
+const { normalizeDiagnosisShowIds, summarizeShowFixOutcomes } = _require('./lib/feedback-multishow.js');
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -164,25 +167,40 @@ async function main() {
     return;
   }
 
-  // 4. Gate: need a show ID
-  if (!diagnosis.showId) {
+  // 4. Gate: need at least one show ID. A report can name more than one show
+  // (issue #515) — showIds is the canonical multi-show list, normalized from
+  // whatever form the diagnosis carries (showIds / resolvedShowIds / legacy
+  // singular showId).
+  const showIds = normalizeDiagnosisShowIds(diagnosis);
+  if (showIds.length === 0) {
     writeComment('## Requires Manual Review\n\nCould not resolve the show mentioned in this report. A maintainer will review.\n\n---\n*Auto-processed by feedback pipeline*');
     output('skipped');
     return;
   }
 
-  // 5. Verify show exists
+  // 5. Verify shows exist — resolve every showId independently so one bad ID
+  // doesn't block fixing the others.
   const showsData = loadJsonFile('data/shows.json');
   const shows = showsData.shows || showsData;
-  const showIndex = shows.findIndex(s => s.id === diagnosis.showId);
-  if (showIndex === -1) {
-    writeComment(`## Requires Manual Review\n\nShow \`${diagnosis.showId}\` not found in shows.json. A maintainer will review.\n\n---\n*Auto-processed by feedback pipeline*`);
+  const resolvedShows = [];
+  const unresolvedShowIds = [];
+  for (const id of showIds) {
+    const idx = shows.findIndex(s => s.id === id);
+    if (idx === -1) unresolvedShowIds.push(id);
+    else resolvedShows.push({ id, index: idx, show: shows[idx] });
+  }
+  if (resolvedShows.length === 0) {
+    writeComment(`## Requires Manual Review\n\nNone of the shows referenced (\`${showIds.join('`, `')}\`) were found in shows.json. A maintainer will review.\n\n---\n*Auto-processed by feedback pipeline*`);
     output('skipped');
     return;
   }
+  console.log(`Found ${resolvedShows.length}/${showIds.length} show(s): ${resolvedShows.map(r => `${r.show.title} (${r.id})`).join(', ')}`);
 
-  const show = shows[showIndex];
-  console.log(`Found show: ${show.title} (${show.id})`);
+  // The awards co-winner path (6a below) is inherently single-show — a co-
+  // winner report names one ceremony/category for one production. Use the
+  // first resolved show for it, matching prior behavior when showIds had
+  // exactly one entry.
+  const show = resolvedShows[0].show;
 
   // 6a. Awards co-winner fix: applied directly from diagnosis — no second Claude call needed.
   //     Tony ties route to manual (require awards-confirmed-ties.json update).
@@ -270,10 +288,70 @@ async function main() {
     return;
   }
 
-  // 6. Call Claude to generate exact edits
+  // 6. Call Claude to generate exact edits — once per resolved show. Each
+  // show gets its own Claude call scoped to its own current data, so a fix
+  // for show A can never be misapplied against show B's fields.
   const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  const allowedFieldsList = Object.entries(EDITABLE_FIELDS)
+    .map(([file, fields]) => `  ${file}: ${fields.join(', ')}`)
+    .join('\n');
 
-  // Build context: current show data from relevant files
+  const perShowResults = [];
+  for (const { index: showIndex, show: showEntry } of resolvedShows) {
+    const result = await generateAndApplyFixForShow({
+      show: showEntry,
+      showIndex,
+      shows,
+      diagnosis,
+      anthropic,
+      allowedFieldsList,
+      isMultiShow: resolvedShows.length > 1,
+    });
+    perShowResults.push({ show: showEntry, ...result });
+  }
+
+  const { action, comment } = summarizeShowFixOutcomes(perShowResults, unresolvedShowIds);
+
+  if (action === 'skipped') {
+    writeComment(comment);
+    output('skipped');
+    return;
+  }
+
+  // Save shows.json if any show's fields were mutated in place
+  if (perShowResults.some(r => r.applied.some(a => a.startsWith('shows.json')))) {
+    // `shows` was mutated in place and (for the object-root shape) IS
+    // `showsData.shows` — pass `showsData` itself, not a rebuilt copy, so
+    // shows-write-guard's object-identity snapshot lookup still matches and
+    // the concurrent-writer merge fires.
+    saveJsonFile('data/shows.json', Array.isArray(showsData) ? shows : showsData);
+  }
+
+  // 8. Validate once for every show's changes together
+  console.log('Running validation...');
+  if (!runValidation()) {
+    console.error('Validation failed — rolling back');
+    rollbackDataFiles();
+    writeComment('## Validation Failed\n\nThe auto-fix was applied but failed data validation. Changes have been rolled back. A maintainer will review.\n\n---\n*Auto-processed by feedback pipeline*');
+    output('validation-failed');
+    return;
+  }
+
+  // 9. Success (fully or partially — action is 'fixed' or 'partial')
+  writeComment(comment);
+  output(action);
+  const totalApplied = perShowResults.reduce((n, r) => n + r.applied.length, 0);
+  console.log(`${action}: applied ${totalApplied} edit(s) across ${perShowResults.filter(r => r.applied.length > 0).length}/${resolvedShows.length + unresolvedShowIds.length} show(s)`);
+}
+
+/**
+ * Generates and applies data-file edits for ONE show via a scoped Claude
+ * call. Mutates `shows[showIndex]` in place for shows.json changes (caller
+ * saves once after every show has run); writes commercial.json /
+ * audience-buzz.json immediately per change, same as the pre-multi-show
+ * behavior.
+ */
+async function generateAndApplyFixForShow({ show, showIndex, shows, diagnosis, anthropic, allowedFieldsList, isMultiShow }) {
   const currentData = { show: { ...show } };
   try {
     const commercial = loadJsonFile('data/commercial.json');
@@ -285,9 +363,9 @@ async function main() {
     if (buzz.shows?.[show.id]) currentData.audienceBuzz = buzz.shows[show.id];
   } catch { /* skip */ }
 
-  const allowedFieldsList = Object.entries(EDITABLE_FIELDS)
-    .map(([file, fields]) => `  ${file}: ${fields.join(', ')}`)
-    .join('\n');
+  const scopeNote = isMultiShow
+    ? `\n- This bug report names more than one show. Only propose edits for THIS show (${show.title}, id: ${show.id}) — the other show(s) are handled by separate calls. If the diagnosis findings don't clearly apply to this specific show, set canFix to false.`
+    : '';
 
   const prompt = `You are fixing a data bug in Broadway Scorecard's database.
 
@@ -311,7 +389,7 @@ ${JSON.stringify(currentData, null, 2)}
 ${allowedFieldsList}
 - You must specify the EXACT current value (oldValue) and the corrected value (newValue)
 - If you cannot determine the correct new value with certainty, set canFix to false
-- NEVER guess or fabricate data — only fix what the diagnosis clearly identifies
+- NEVER guess or fabricate data — only fix what the diagnosis clearly identifies${scopeNote}
 
 Respond with ONLY a JSON object:
 {
@@ -342,22 +420,16 @@ If you cannot fix it, respond: { "canFix": false, "reason": "why" }`;
     if (!jsonMatch) throw new Error('No JSON in Claude response');
     edits = JSON.parse(jsonMatch[0]);
   } catch (err) {
-    console.error('Claude API error:', err.message);
-    writeComment(`## Error\n\nFailed to generate fix edits: ${err.message}\n\n---\n*Auto-processed by feedback pipeline*`);
-    output('error');
-    return;
+    console.error(`Claude API error for ${show.id}:`, err.message);
+    return { applied: [], skipped: [], error: `Claude API error: ${err.message}` };
   }
 
   if (!edits.canFix) {
-    writeComment(`## Requires Manual Review\n\nAuto-fix could not determine the correct edit: ${edits.reason}\n\n---\n*Auto-processed by feedback pipeline*`);
-    output('skipped');
-    return;
+    return { applied: [], skipped: [], error: edits.reason || 'could not determine the correct edit' };
   }
 
   if (!edits.changes || edits.changes.length === 0) {
-    writeComment('## Requires Manual Review\n\nNo specific changes identified.\n\n---\n*Auto-processed by feedback pipeline*');
-    output('skipped');
-    return;
+    return { applied: [], skipped: [], error: 'no specific changes identified' };
   }
 
   // 7. Validate and apply edits
@@ -424,39 +496,7 @@ If you cannot fix it, respond: { "canFix": false, "reason": "why" }`;
     }
   }
 
-  if (applied.length === 0) {
-    const reasons = skipped.length > 0 ? `\n\nSkipped edits:\n${skipped.map(s => `- ${s}`).join('\n')}` : '';
-    writeComment(`## Requires Manual Review\n\nNo edits could be applied.${reasons}\n\n---\n*Auto-processed by feedback pipeline*`);
-    output('skipped');
-    return;
-  }
-
-  // Save shows.json if we modified it
-  if (applied.some(a => a.startsWith('shows.json'))) {
-    // `shows` was mutated in place and (for the object-root shape) IS
-    // `showsData.shows` — pass `showsData` itself, not a rebuilt copy, so
-    // shows-write-guard's object-identity snapshot lookup still matches and
-    // the concurrent-writer merge fires.
-    saveJsonFile('data/shows.json', Array.isArray(showsData) ? shows : showsData);
-  }
-
-  // 8. Validate
-  console.log('Running validation...');
-  if (!runValidation()) {
-    console.error('Validation failed — rolling back');
-    rollbackDataFiles();
-    writeComment('## Validation Failed\n\nThe auto-fix was applied but failed data validation. Changes have been rolled back. A maintainer will review.\n\n---\n*Auto-processed by feedback pipeline*');
-    output('validation-failed');
-    return;
-  }
-
-  // 9. Success
-  const appliedList = applied.map(a => `- ${a}`).join('\n');
-  const skippedList = skipped.length > 0 ? `\n\n**Skipped:**\n${skipped.map(s => `- ${s}`).join('\n')}` : '';
-
-  writeComment(`## Fix Applied\n\n**Show:** ${show.title}\n**Explanation:** ${edits.explanation}\n\n**Changes:**\n${appliedList}${skippedList}\n\nThe fix will be live within a few minutes after deployment.\n\n---\n*Auto-fixed by feedback pipeline*`);
-  output('fixed');
-  console.log(`Successfully applied ${applied.length} edit(s)`);
+  return { applied, skipped, explanation: edits.explanation };
 }
 
 main().catch(err => {

--- a/scripts/diagnose-feedback-bug.js
+++ b/scripts/diagnose-feedback-bug.js
@@ -354,6 +354,13 @@ export async function diagnoseBug(message, showName, userCategory) {
     }).join('\n\n');
   }
 
+  // Deterministic show-ID resolution — computed from the catalog matches
+  // above, NOT from what the LLM chooses to name in its JSON response. A
+  // multi-show report (issue #515: two shows sharing the same venue-city
+  // bug) must carry every matched show through to the auto-fix step, not
+  // just whichever one the model happened to mention.
+  const resolvedShowIds = [...new Set(allShowData.map(d => (d.show || d).id).filter(Boolean))];
+
   // 4. Build diagnosis prompt
   const awardsInstructions = isAwardsBug ? `
 
@@ -409,7 +416,13 @@ Respond with ONLY a JSON object in this exact format:
 }`;
 
   // 5. Call Claude
-  return await callClaude(prompt);
+  const diagnosis = await callClaude(prompt);
+
+  // Attach the deterministic show-ID list regardless of what the LLM echoed
+  // — process-feedback.yml and auto-fix-feedback-bug.js key off this, not
+  // off diagnosis.relevantFiles.
+  diagnosis.resolvedShowIds = resolvedShowIds;
+  return diagnosis;
 }
 
 // CLI entry point. realpath both sides: the ESM loader realpaths

--- a/scripts/generate-remediation-plan.js
+++ b/scripts/generate-remediation-plan.js
@@ -354,9 +354,17 @@ async function main() {
   const showsData = loadJsonSafe('data/shows.json');
   const shows = showsData?.shows || showsData || [];
 
-  // Find relevant shows — by showId if available, otherwise extract from message text
+  // Find relevant shows — prefer the canonical multi-show showIds[] (issue
+  // #515: a report can name more than one show), fall back to the legacy
+  // singular showId, then to extracting names from the message text.
   let relevantShows = [];
-  if (diagnosis.showId) {
+  const diagShowIds = Array.isArray(diagnosis.showIds) ? diagnosis.showIds.filter(Boolean) : [];
+  if (diagShowIds.length > 0) {
+    for (const id of diagShowIds) {
+      const show = shows.find(s => s.id === id);
+      if (show) relevantShows.push(show);
+    }
+  } else if (diagnosis.showId) {
     const show = shows.find(s => s.id === diagnosis.showId);
     if (show) relevantShows.push(show);
   }

--- a/scripts/generate-remediation-plan.js
+++ b/scripts/generate-remediation-plan.js
@@ -601,6 +601,7 @@ ${diagnosis.originalMessage
       confidence: diagnosis.confidence,
       showId: diagnosis.showId,
       showSlug: diagnosis.showSlug,
+      showIds: diagShowIds.length > 0 ? diagShowIds : (diagnosis.showId ? [diagnosis.showId] : []),
     },
     // PII stays OUT of the persisted plan file — data/pending-fixes/ is
     // committed to the PUBLIC repo (it was gitignored 2026-03-08 for exactly

--- a/scripts/lib/feedback-multishow.js
+++ b/scripts/lib/feedback-multishow.js
@@ -1,0 +1,89 @@
+/**
+ * Multi-show feedback report handling.
+ *
+ * The feedback pipeline used to carry exactly one showId end-to-end. A report
+ * naming TWO shows with the same bug (issue #515: "3 Summers of Lincoln" +
+ * "The Family Album" both had a wrong venue city) got a single showId
+ * resolved by the diagnosis step, so relevantFiles/auto-fix only ever
+ * touched the first show and the second one silently stayed broken while the
+ * GitHub issue closed as COMPLETED.
+ *
+ * These are the pure decision functions the diagnosis step (which show IDs
+ * does this report reference?) and the auto-fix executor (did every
+ * referenced show get fixed, or only some?) both need — kept here and
+ * required by both scripts + their tests instead of re-implemented per file.
+ */
+
+/**
+ * Normalizes a diagnosis payload's show reference into a canonical showIds[]
+ * array. Prefers an already-set `showIds` (the canonical field once a
+ * DIAGNOSIS_JSON has been through process-feedback.yml's payload builder),
+ * falls back to `resolvedShowIds` (set by diagnoseBug from real catalog
+ * matches against the report's show field + message text), then falls back
+ * to the single legacy `showId` field for diagnoses created before either
+ * array existed.
+ */
+function normalizeDiagnosisShowIds(diagnosis) {
+  if (Array.isArray(diagnosis?.showIds) && diagnosis.showIds.length > 0) {
+    return [...new Set(diagnosis.showIds.filter(Boolean))];
+  }
+  if (Array.isArray(diagnosis?.resolvedShowIds) && diagnosis.resolvedShowIds.length > 0) {
+    return [...new Set(diagnosis.resolvedShowIds.filter(Boolean))];
+  }
+  if (diagnosis?.showId) return [diagnosis.showId];
+  return [];
+}
+
+/**
+ * Given per-show auto-fix outcomes, decides whether the bug report is fully
+ * resolved, partially resolved, or not resolved at all — and builds the
+ * comment body auto-fix-feedback-bug.js posts to the GitHub issue either way.
+ *
+ * A report naming N shows must NEVER report `action: 'fixed'` (which closes
+ * the issue as COMPLETED) unless every one of those N shows actually got a
+ * change applied. That is the bug this function exists to prevent.
+ *
+ * @param {Array<{show: {id: string, title?: string}, applied: string[], skipped?: string[], error?: string}>} perShowResults
+ * @param {string[]} [unresolvedShowIds] - show IDs referenced in the diagnosis that weren't found in shows.json at all
+ * @returns {{action: 'fixed'|'partial'|'skipped', comment: string}}
+ */
+function summarizeShowFixOutcomes(perShowResults, unresolvedShowIds = []) {
+  const anyApplied = perShowResults.some((r) => r.applied && r.applied.length > 0);
+  const totalShows = perShowResults.length + unresolvedShowIds.length;
+
+  const showLines = perShowResults.map((r) => {
+    const title = r.show?.title || r.show?.id || 'unknown show';
+    if (r.applied && r.applied.length > 0) {
+      return `**${title}** — Fixed\n${r.applied.map((a) => `  - ${a}`).join('\n')}`;
+    }
+    const reason = (r.skipped && r.skipped[0]) || r.error || 'no changes identified';
+    return `**${title}** — Not fixed (${reason})`;
+  });
+  for (const id of unresolvedShowIds) {
+    showLines.push(`**${id}** — Not fixed (show not found in shows.json)`);
+  }
+
+  if (!anyApplied) {
+    return {
+      action: 'skipped',
+      comment: `## Requires Manual Review\n\nNo edits could be applied.\n\n${showLines.join('\n\n')}\n\n---\n*Auto-processed by feedback pipeline*`,
+    };
+  }
+
+  const allFixed = unresolvedShowIds.length === 0 &&
+    perShowResults.every((r) => r.applied && r.applied.length > 0);
+
+  if (allFixed) {
+    return {
+      action: 'fixed',
+      comment: `## Fix Applied\n\n${showLines.join('\n\n')}\n\nThe fix will be live within a few minutes after deployment.\n\n---\n*Auto-fixed by feedback pipeline*`,
+    };
+  }
+
+  return {
+    action: 'partial',
+    comment: `## Partially Fixed\n\nThis report named ${totalShows} show(s). Not every show could be auto-fixed — leaving this issue open for manual review of the remainder.\n\n${showLines.join('\n\n')}\n\nThe applied fix(es) will be live within a few minutes after deployment.\n\n---\n*Auto-processed by feedback pipeline*`,
+  };
+}
+
+module.exports = { normalizeDiagnosisShowIds, summarizeShowFixOutcomes };

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -272,6 +272,7 @@ tests/unit/extract-stagedoor-preserves-exclusion-flags.test.mjs
 tests/unit/feedback-categorize.test.mjs
 tests/unit/feedback-dedup.test.mjs
 tests/unit/feedback-form-validation.test.mjs
+tests/unit/feedback-multi-show-fix.test.mjs
 tests/unit/feedback-owner-reports.test.mjs
 tests/unit/feedback-pipeline-fields.test.mjs
 tests/unit/feedback-request-ledger.test.mjs

--- a/tests/unit/feedback-multi-show-fix.test.mjs
+++ b/tests/unit/feedback-multi-show-fix.test.mjs
@@ -1,0 +1,130 @@
+// Regression test for issue #515 / BRO-130: a feedback report naming TWO
+// shows with the same bug used to resolve only one showId, so the second
+// show was silently dropped from relevantFiles and the auto-fix issue closed
+// as COMPLETED having fixed only one of the two shows named.
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const {
+  normalizeDiagnosisShowIds,
+  summarizeShowFixOutcomes,
+} = require('../../scripts/lib/feedback-multishow.js');
+
+describe('normalizeDiagnosisShowIds', () => {
+  test('prefers an existing showIds[] array', () => {
+    const ids = normalizeDiagnosisShowIds({
+      showIds: ['a', 'b'],
+      resolvedShowIds: ['c'],
+      showId: 'd',
+    });
+    assert.deepEqual(ids, ['a', 'b']);
+  });
+
+  test('falls back to resolvedShowIds when showIds is absent', () => {
+    const ids = normalizeDiagnosisShowIds({
+      resolvedShowIds: ['3-summers-of-lincoln-regional-2025', 'the-family-album-off-broadway-2026'],
+      showId: '3-summers-of-lincoln-regional-2025',
+    });
+    assert.deepEqual(ids, [
+      '3-summers-of-lincoln-regional-2025',
+      'the-family-album-off-broadway-2026',
+    ]);
+  });
+
+  test('falls back to the legacy singular showId when no array is present', () => {
+    const ids = normalizeDiagnosisShowIds({ showId: 'hamilton-2015' });
+    assert.deepEqual(ids, ['hamilton-2015']);
+  });
+
+  test('returns an empty array when nothing resolved', () => {
+    assert.deepEqual(normalizeDiagnosisShowIds({}), []);
+    assert.deepEqual(normalizeDiagnosisShowIds({ showIds: [] }), []);
+  });
+
+  test('dedupes and drops falsy entries', () => {
+    const ids = normalizeDiagnosisShowIds({ showIds: ['a', 'a', null, 'b', undefined] });
+    assert.deepEqual(ids, ['a', 'b']);
+  });
+});
+
+describe('summarizeShowFixOutcomes', () => {
+  // Fixture mirrors the real bug: "3 Summers of Lincoln" + "The Family
+  // Album" both reported with the same wrong-venue-city error.
+  const lincoln = { id: '3-summers-of-lincoln-regional-2025', title: '3 Summers of Lincoln' };
+  const familyAlbum = { id: 'the-family-album-off-broadway-2026', title: 'The Family Album' };
+
+  test('both shows fixed => action fixed, issue can close', () => {
+    const { action, comment } = summarizeShowFixOutcomes([
+      { show: lincoln, applied: ['shows.json: venue = "..."'] },
+      { show: familyAlbum, applied: ['shows.json: venue = "..."'] },
+    ]);
+    assert.equal(action, 'fixed');
+    assert.match(comment, /Fix Applied/);
+    assert.match(comment, /3 Summers of Lincoln/);
+    assert.match(comment, /The Family Album/);
+  });
+
+  test('only ONE of two shows fixed => action partial, NOT fixed (issue #515 regression)', () => {
+    const { action, comment } = summarizeShowFixOutcomes([
+      { show: lincoln, applied: ['shows.json: venue = "..."'] },
+      { show: familyAlbum, applied: [], skipped: ['no changes identified'] },
+    ]);
+    assert.equal(action, 'partial');
+    assert.notEqual(action, 'fixed'); // the exact bug: this used to be reported 'fixed'
+    assert.match(comment, /Partially Fixed/);
+    assert.match(comment, /3 Summers of Lincoln.*Fixed/s);
+    assert.match(comment, /The Family Album.*Not fixed/s);
+  });
+
+  test('a show unresolved in shows.json also blocks the fixed verdict', () => {
+    const { action, comment } = summarizeShowFixOutcomes(
+      [{ show: lincoln, applied: ['shows.json: venue = "..."'] }],
+      ['ghost-show-id'],
+    );
+    assert.equal(action, 'partial');
+    assert.match(comment, /ghost-show-id.*Not fixed \(show not found in shows\.json\)/s);
+  });
+
+  test('no shows fixed at all => action skipped, not partial or fixed', () => {
+    const { action, comment } = summarizeShowFixOutcomes([
+      { show: lincoln, applied: [], error: 'could not determine the correct edit' },
+      { show: familyAlbum, applied: [], error: 'could not determine the correct edit' },
+    ]);
+    assert.equal(action, 'skipped');
+    assert.match(comment, /Requires Manual Review/);
+  });
+
+  test('single-show report still resolves to fixed exactly as before', () => {
+    const { action } = summarizeShowFixOutcomes([
+      { show: lincoln, applied: ['shows.json: venue = "..."'] },
+    ]);
+    assert.equal(action, 'fixed');
+  });
+});
+
+describe('end-to-end: two-show report produces a non-silent partial outcome', () => {
+  test('diagnosis carrying resolvedShowIds for both shows, only one fixable, never reports fixed', () => {
+    const diagnosis = {
+      summary: 'Wrong venue city for two regional productions',
+      resolvedShowIds: [
+        '3-summers-of-lincoln-regional-2025',
+        'the-family-album-off-broadway-2026',
+      ],
+    };
+
+    const showIds = normalizeDiagnosisShowIds(diagnosis);
+    assert.equal(showIds.length, 2, 'both shows referenced in the report must be carried through');
+
+    // Simulate the auto-fix executor: show 1 gets fixed, show 2 (per the
+    // real incident) has no clean fix available this pass.
+    const perShowResults = [
+      { show: { id: showIds[0], title: '3 Summers of Lincoln' }, applied: ['shows.json: venue = "Lincoln, NE"'] },
+      { show: { id: showIds[1], title: 'The Family Album' }, applied: [], error: 'could not determine the correct edit' },
+    ];
+
+    const { action } = summarizeShowFixOutcomes(perShowResults);
+    assert.equal(action, 'partial', 'must not silently report fixed when only one of two shows was resolved');
+  });
+});


### PR DESCRIPTION
Opens a PR for finished-but-unlanded work. The BRO-130 headless job completed
successfully and pushed `job/linear-BRO-130-mt1qcg5s`, but exited while waiting
on CI and never opened a PR, so the branch has been sitting on origin unmerged.

Verified before opening:
- `git merge-base --is-ancestor origin/job/linear-BRO-130-mt1qcg5s origin/main` -> exit 1 (NOT merged).
- 2 commits, 8 files, 377 insertions / 63 deletions.
- Ships a registered unit test: `tests/unit/feedback-multi-show-fix.test.mjs`, added to
  `tests/unit-test-manifest.txt` (so it actually runs in CI rather than being silently skipped).

What it fixes: multi-show feedback reports previously dropped all but the first
referenced show during diagnosis and auto-fix; this carries `showIds[]` through
diagnosis, the remediation plan metadata, and both feedback workflows.

Touches `.github/workflows/**` (Rule 18 critical shared infrastructure), which is
why this is a PR for CI to validate rather than a direct push to main.

Note: the originating job also carded a known follow-up — feedback dedup still
keys same-bug matching off a single showId, so `scripts/lib/feedback-dedup.js`
was deliberately not extended here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>