### PR TITLE
fix: Broadway.com scraper CI bot-block — widen rating fallback trigger (BRO-547)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -508,6 +508,14 @@ on:
       # path-listed — top-level scripts/ file, no scripts/** glob (task #1763).
       - 'scripts/audit-aggregator-archive-integrity.js'
       - 'scripts/audit-critic-consensus-contamination.js'
+      # BRO-547: top-level scripts/ file (no scripts/** glob) with a colocated
+      # test registered explicitly in tests/unit-test-manifest.txt (root-level
+      # scripts/*.test.mjs files are NOT globbed) — both need their own entry
+      # so a solo edit to either triggers CI. Its lib dependency
+      # (scripts/lib/broadway-com-rating-parser.js) is already covered by the
+      # scripts/lib/** glob above.
+      - 'scripts/scrape-broadway-com-audience.js'
+      - 'scripts/scrape-broadway-com-audience.test.mjs'
       # Canonical Broadway-only scope + designation criteria for the commercial-
       # research pipeline (2026-07-14 market-vs-category leak). Colocated test
       # runs in the lib-test glob; path-listed so a solo edit triggers CI.

--- a/scripts/lib/broadway-com-rating-parser.js
+++ b/scripts/lib/broadway-com-rating-parser.js
@@ -1,0 +1,119 @@
+'use strict';
+
+/**
+ * Pure parsing/decision functions for the Broadway.com audience scraper.
+ * Extracted so scripts/scrape-broadway-com-audience.test.mjs can require()
+ * the real logic instead of copying it (CLAUDE.md rule 15).
+ */
+
+/**
+ * Detect bot challenge pages (Cloudflare/Fastly, etc.) that return a valid
+ * HTTP 200 but no real content — small pages with known challenge markers.
+ */
+function isBotChallenge(html) {
+  return html.length < 10000 && (
+    html.includes('Client Challenge') ||
+    html.includes('Just a moment') ||
+    html.includes('cf-browser-verification') ||
+    html.includes('_fs-ch-')
+  );
+}
+
+/**
+ * Extract aggregateRating from JSON-LD on a Broadway.com show page.
+ * Returns { ratingValue, ratingCount } or null if not found.
+ */
+function extractJsonLdRating(html) {
+  const jsonLdPattern = /<script[^>]+type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi;
+  let match;
+
+  while ((match = jsonLdPattern.exec(html)) !== null) {
+    try {
+      const data = JSON.parse(match[1]);
+      const items = Array.isArray(data) ? data : [data];
+
+      for (const item of items) {
+        if (item.aggregateRating) {
+          const rating = item.aggregateRating;
+          const ratingValue = parseFloat(rating.ratingValue);
+          const ratingCount = parseInt(rating.ratingCount || rating.reviewCount, 10);
+
+          if (!isNaN(ratingValue) && !isNaN(ratingCount) && ratingCount > 0) {
+            return { ratingValue, ratingCount };
+          }
+        }
+      }
+    } catch {
+      // Invalid JSON — skip this block
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Fallback: extract rating from rendered HTML when JSON-LD is absent.
+ * Looks for patterns like "Customer Reviews (270)" and a nearby score like "4.8".
+ * Returns { ratingValue, ratingCount } or null.
+ */
+function extractHtmlRating(html) {
+  // Pattern 1: "Customer Reviews (N)" — count in parentheses
+  const countMatch = html.match(/Customer\s+Reviews?\s*\((\d+)\)/i);
+  if (!countMatch) return null;
+  const ratingCount = parseInt(countMatch[1], 10);
+  if (!ratingCount || ratingCount < 1) return null;
+
+  // Pattern 2: Standalone score near the reviews section
+  // Look for a rating value like "4.8" in the vicinity (within 2000 chars of "Customer Reviews")
+  const countIdx = html.indexOf(countMatch[0]);
+  const vicinity = html.substring(Math.max(0, countIdx - 1000), countIdx + 2000);
+
+  // Look for a decimal rating (1.0-5.0) that appears as text content, not in URLs
+  // Common patterns: ">4.8<", ">4.8 ", aria-label with rating
+  const ratingPatterns = [
+    // Score in text content: >4.8< or >4.8 out of
+    />\s*([1-5]\.\d)\s*</,
+    // aria-label pattern
+    /aria-label="([1-5]\.\d)/,
+    // Score followed by "out of 5" or "/ 5"
+    /([1-5]\.\d)\s*(?:out of|\/)\s*5/,
+    // Score in a data attribute
+    /data-(?:rating|score)="([1-5]\.\d)"/,
+  ];
+
+  for (const pattern of ratingPatterns) {
+    const match = vicinity.match(pattern);
+    if (match) {
+      const ratingValue = parseFloat(match[1]);
+      if (ratingValue >= 1.0 && ratingValue <= 5.0) {
+        return { ratingValue, ratingCount };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Decide whether to retry a show page fetch via the shared scraper fallback
+ * chain (Playwright -> Bright Data -> ScrapingBee).
+ *
+ * BRO-547: GitHub Actions CI gets bot-blocked by Broadway.com in a way that
+ * doesn't always look like an obvious challenge page. Sometimes it's a
+ * full-size HTTP 200 response that's simply missing the JSON-LD block, so
+ * isBotChallenge()'s short-page/marker heuristics never match and the old
+ * `!rating && isBotChallenge(html)` gate skipped the fallback entirely.
+ * Retrying is cheap — Playwright is tried first for broadway.com and is
+ * free — so retry any time rating extraction failed, not only when
+ * isBotChallenge() also matches.
+ */
+function shouldUseScraperFallback(html, rating) {
+  return !rating;
+}
+
+module.exports = {
+  isBotChallenge,
+  extractJsonLdRating,
+  extractHtmlRating,
+  shouldUseScraperFallback,
+};

--- a/scripts/scrape-broadway-com-audience.js
+++ b/scripts/scrape-broadway-com-audience.js
@@ -21,6 +21,12 @@ const { calculateCombinedScore, getDesignation } = require('./lib/audience-weigh
 const { isLondonMarket, isBroadwayCategory } = require('./lib/venue-classification');
 const { fetchPage } = require('./lib/scraper');
 const { loadAudienceBuzz, saveAudienceBuzz } = require('./lib/audience-buzz-write-guard');
+const {
+  isBotChallenge,
+  extractJsonLdRating,
+  extractHtmlRating,
+  shouldUseScraperFallback,
+} = require('./lib/broadway-com-rating-parser');
 
 // Parse command line args
 const args = process.argv.slice(2);
@@ -76,18 +82,6 @@ async function fetchPageWithTimeout(url, options = {}, timeoutMs = 30000) {
       setTimeout(() => reject(new Error(`fetchPage timeout after ${timeoutMs / 1000}s`)), timeoutMs)
     ),
   ]);
-}
-
-/**
- * Detect bot challenge pages (Cloudflare, etc.) that return valid 200 but no real content.
- */
-function isBotChallenge(html) {
-  return html.length < 10000 && (
-    html.includes('Client Challenge') ||
-    html.includes('Just a moment') ||
-    html.includes('cf-browser-verification') ||
-    html.includes('_fs-ch-')
-  );
 }
 
 // ---- Discovery: Parse /shows/ listing page ----
@@ -205,84 +199,6 @@ async function discoverFromSitemap() {
 
   console.log(`  Found ${slugs.length} show slugs in sitemap`);
   return slugs;
-}
-
-// ---- Extraction: Parse JSON-LD from show page ----
-
-/**
- * Extract aggregateRating from JSON-LD on a Broadway.com show page.
- * Returns { ratingValue, ratingCount } or null if not found.
- */
-function extractJsonLdRating(html) {
-  // Find all JSON-LD script blocks
-  const jsonLdPattern = /<script[^>]+type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi;
-  let match;
-
-  while ((match = jsonLdPattern.exec(html)) !== null) {
-    try {
-      const data = JSON.parse(match[1]);
-      const items = Array.isArray(data) ? data : [data];
-
-      for (const item of items) {
-        if (item.aggregateRating) {
-          const rating = item.aggregateRating;
-          const ratingValue = parseFloat(rating.ratingValue);
-          const ratingCount = parseInt(rating.ratingCount || rating.reviewCount, 10);
-
-          if (!isNaN(ratingValue) && !isNaN(ratingCount) && ratingCount > 0) {
-            return { ratingValue, ratingCount };
-          }
-        }
-      }
-    } catch {
-      // Invalid JSON — skip this block
-    }
-  }
-
-  return null;
-}
-
-/**
- * Fallback: extract rating from rendered HTML when JSON-LD is absent.
- * Looks for patterns like "Customer Reviews (270)" and a nearby score like "4.8".
- * Returns { ratingValue, ratingCount } or null.
- */
-function extractHtmlRating(html) {
-  // Pattern 1: "Customer Reviews (N)" — count in parentheses
-  const countMatch = html.match(/Customer\s+Reviews?\s*\((\d+)\)/i);
-  if (!countMatch) return null;
-  const ratingCount = parseInt(countMatch[1], 10);
-  if (!ratingCount || ratingCount < 1) return null;
-
-  // Pattern 2: Standalone score near the reviews section
-  // Look for a rating value like "4.8" in the vicinity (within 2000 chars of "Customer Reviews")
-  const countIdx = html.indexOf(countMatch[0]);
-  const vicinity = html.substring(Math.max(0, countIdx - 1000), countIdx + 2000);
-
-  // Look for a decimal rating (1.0-5.0) that appears as text content, not in URLs
-  // Common patterns: ">4.8<", ">4.8 ", aria-label with rating
-  const ratingPatterns = [
-    // Score in text content: >4.8< or >4.8 out of
-    />\s*([1-5]\.\d)\s*</,
-    // aria-label pattern
-    /aria-label="([1-5]\.\d)/,
-    // Score followed by "out of 5" or "/ 5"
-    /([1-5]\.\d)\s*(?:out of|\/)\s*5/,
-    // Score in a data attribute
-    /data-(?:rating|score)="([1-5]\.\d)"/,
-  ];
-
-  for (const pattern of ratingPatterns) {
-    const match = vicinity.match(pattern);
-    if (match) {
-      const ratingValue = parseFloat(match[1]);
-      if (ratingValue >= 1.0 && ratingValue <= 5.0) {
-        return { ratingValue, ratingCount };
-      }
-    }
-  }
-
-  return null;
 }
 
 // ---- Title matching ----
@@ -552,7 +468,20 @@ async function main() {
   let skipped = 0;
   let errors = 0;
 
-  let scrapingBeeUsed = 0;
+  let fallbackUsed = 0;
+
+  // Circuit breaker: retrying every "no rating" via the scraper fallback
+  // (widened below for BRO-547) is fine when the cause is CI bot-blocking —
+  // Playwright's separate execution path should recover the rating for most
+  // of those. But a `--include-closed` sitemap run mixes in old/closed shows
+  // that legitimately have no Broadway.com rating at all; retrying every one
+  // of those wastes a full Playwright round-trip (up to 30s) with no benefit,
+  // and that path has no --limit or timeout wrapper. If several fallback
+  // attempts IN A ROW also come back empty, stop retrying for the rest of
+  // this run — a real bot-block would keep recovering via Playwright, so a
+  // miss streak signals "no data exists" rather than "still blocked."
+  const FALLBACK_MISS_CIRCUIT_BREAKER = 5;
+  let consecutiveFallbackMisses = 0;
 
   for (let i = 0; i < toProcess.length; i++) {
     const { bc, show, confidence } = toProcess[i];
@@ -573,23 +502,41 @@ async function main() {
 
       let rating = extractJsonLdRating(html) || extractHtmlRating(html);
 
-      // If no rating found and page looks like a bot challenge, retry via shared scraper
-      if (!rating && isBotChallenge(html)) {
-        if (verbose) console.log(`  Bot challenge detected for ${show.id}, trying scraper fallback...`);
-        try {
-          const result = await fetchPageWithTimeout(bc.url, { renderJs: true });
-          const scraperHtml = result?.content || '';
-          if (scraperHtml && !isBotChallenge(scraperHtml)) {
-            rating = extractJsonLdRating(scraperHtml) || extractHtmlRating(scraperHtml);
-            scrapingBeeUsed++;
-            if (!rating && verbose) {
-              console.log(`  SKIP ${show.id}: no rating data found (even via scraper, ${scraperHtml.length} bytes)`);
+      // If no rating found, retry via the shared scraper fallback chain.
+      // BRO-547: CI bot-blocking doesn't always look like an obvious
+      // challenge page (isBotChallenge()'s short-page/marker heuristics) —
+      // sometimes it's a full-size 200 response that's just missing the
+      // JSON-LD block. Retry whenever extraction failed, not only when
+      // isBotChallenge() also matches (Playwright is tried first and is
+      // free for broadway.com, so this isn't an expensive retry) — unless
+      // the circuit breaker above has tripped.
+      if (shouldUseScraperFallback(html, rating)) {
+        if (consecutiveFallbackMisses >= FALLBACK_MISS_CIRCUIT_BREAKER) {
+          if (verbose) console.log(`  SKIP ${show.id}: no rating data found (fallback circuit breaker open after ${consecutiveFallbackMisses} consecutive misses)`);
+        } else {
+          if (verbose) console.log(`  No rating found for ${show.id}${isBotChallenge(html) ? ' (bot challenge)' : ''}, trying scraper fallback...`);
+          try {
+            const result = await fetchPageWithTimeout(bc.url, { renderJs: true });
+            const scraperHtml = result?.content || '';
+            if (scraperHtml && !isBotChallenge(scraperHtml)) {
+              rating = extractJsonLdRating(scraperHtml) || extractHtmlRating(scraperHtml);
+              if (rating) {
+                fallbackUsed++;
+                consecutiveFallbackMisses = 0;
+              } else {
+                consecutiveFallbackMisses++;
+                if (verbose) {
+                  console.log(`  SKIP ${show.id}: no rating data found (even via scraper, ${scraperHtml.length} bytes)`);
+                }
+              }
+            } else {
+              consecutiveFallbackMisses++;
+              if (verbose) console.log(`  Scraper fallback failed for ${show.id} (${scraperHtml.length} bytes)`);
             }
-          } else if (verbose) {
-            console.log(`  Scraper fallback failed for ${show.id} (${scraperHtml.length} bytes)`);
+          } catch (e) {
+            consecutiveFallbackMisses++;
+            if (verbose) console.log(`  Scraper fallback error for ${show.id}: ${e.message}`);
           }
-        } catch (e) {
-          if (verbose) console.log(`  Scraper fallback error for ${show.id}: ${e.message}`);
         }
       }
 
@@ -622,8 +569,8 @@ async function main() {
     }
   }
 
-  if (scrapingBeeUsed > 0) {
-    console.log(`\nScrapingBee used for ${scrapingBeeUsed} bot-challenged pages`);
+  if (fallbackUsed > 0) {
+    console.log(`\nScraper fallback recovered rating data for ${fallbackUsed} pages`);
   }
 
   console.log(`\nResults: ${updated} updated, ${skipped} skipped, ${errors} errors`);

--- a/scripts/scrape-broadway-com-audience.test.mjs
+++ b/scripts/scrape-broadway-com-audience.test.mjs
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isBotChallenge,
+  extractJsonLdRating,
+  extractHtmlRating,
+  shouldUseScraperFallback,
+} from './lib/broadway-com-rating-parser.js';
+
+const VALID_JSON_LD_PAGE = `<!DOCTYPE html><html><head>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"Product","name":"Hamilton",
+"aggregateRating":{"@type":"AggregateRating","ratingValue":"4.8","ratingCount":"631"}}
+</script>
+</head><body>${'x'.repeat(10500)}</body></html>`;
+
+const SMALL_CLIENT_CHALLENGE_PAGE = `<!DOCTYPE html><html><head><title>Client Challenge</title>
+<link href="/_fs-ch-1T1wmsGaOgGaSxcX/assets/styles.css" rel="stylesheet" /></head>
+<body>Please enable JavaScript to proceed.</body></html>`;
+
+// BRO-547 regression fixture: a full-size 200 response that is NOT flagged by
+// isBotChallenge() (no known challenge markers, well over the 10000-byte
+// floor) but is still missing the JSON-LD aggregateRating block — the shape
+// CI's bot-blocked responses actually took.
+const FULL_PAGE_MISSING_JSON_LD = `<!DOCTYPE html><html><head><title>Hamilton | Broadway.com</title></head>
+<body><nav>...normal site chrome...</nav>${'y'.repeat(11000)}<footer>© Broadway.com</footer></body></html>`;
+
+test('extractJsonLdRating parses a valid aggregateRating block', () => {
+  const rating = extractJsonLdRating(VALID_JSON_LD_PAGE);
+  assert.deepEqual(rating, { ratingValue: 4.8, ratingCount: 631 });
+});
+
+test('extractJsonLdRating returns null when no JSON-LD is present', () => {
+  assert.equal(extractJsonLdRating(FULL_PAGE_MISSING_JSON_LD), null);
+});
+
+test('extractHtmlRating finds a rating in the "Customer Reviews" fallback pattern', () => {
+  const html = `<div>Customer Reviews (270)</div><span>4.6</span>`;
+  const rating = extractHtmlRating(html);
+  assert.deepEqual(rating, { ratingValue: 4.6, ratingCount: 270 });
+});
+
+test('extractHtmlRating returns null when no review-count text exists', () => {
+  assert.equal(extractHtmlRating(FULL_PAGE_MISSING_JSON_LD), null);
+});
+
+test('isBotChallenge detects the small Fastly/Cloudflare challenge page', () => {
+  assert.equal(isBotChallenge(SMALL_CLIENT_CHALLENGE_PAGE), true);
+});
+
+test('isBotChallenge does NOT flag a full-size page missing JSON-LD (BRO-547 shape)', () => {
+  // This is the exact gap that let the bug through: the CI-blocked response
+  // is large and has no challenge markers, so isBotChallenge() alone can't
+  // catch it — shouldUseScraperFallback() has to catch it instead.
+  assert.equal(isBotChallenge(FULL_PAGE_MISSING_JSON_LD), false);
+});
+
+test('isBotChallenge does not false-positive on a valid, rating-bearing page', () => {
+  assert.equal(isBotChallenge(VALID_JSON_LD_PAGE), false);
+});
+
+test('shouldUseScraperFallback retries on a classic bot-challenge page (pre-existing behavior)', () => {
+  const rating = extractJsonLdRating(SMALL_CLIENT_CHALLENGE_PAGE) || extractHtmlRating(SMALL_CLIENT_CHALLENGE_PAGE);
+  assert.equal(shouldUseScraperFallback(SMALL_CLIENT_CHALLENGE_PAGE, rating), true);
+});
+
+test('shouldUseScraperFallback retries on a full-size CI-bot-blocked page even though isBotChallenge is false (BRO-547 fix)', () => {
+  const rating = extractJsonLdRating(FULL_PAGE_MISSING_JSON_LD) || extractHtmlRating(FULL_PAGE_MISSING_JSON_LD);
+  assert.equal(rating, null);
+  assert.equal(isBotChallenge(FULL_PAGE_MISSING_JSON_LD), false);
+  assert.equal(shouldUseScraperFallback(FULL_PAGE_MISSING_JSON_LD, rating), true);
+});
+
+test('shouldUseScraperFallback does not retry when a rating was already found', () => {
+  const rating = extractJsonLdRating(VALID_JSON_LD_PAGE);
+  assert.equal(shouldUseScraperFallback(VALID_JSON_LD_PAGE, rating), false);
+});

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -72,6 +72,7 @@ scripts/opening-night-checklist.test.mjs
 scripts/produce-coverage-digest-snapshot.test.mjs
 scripts/reconcile-dead-completions.test.mjs
 scripts/scoring-delta-autoclear-coverage.test.mjs
+scripts/scrape-broadway-com-audience.test.mjs
 scripts/telegraph-reviews-index.test.mjs
 scripts/tests/agent-auth-preflight.test.mjs
 scripts/tests/audit-card-relevance.test.mjs


### PR DESCRIPTION
## Summary
- CI's bot-blocked Broadway.com response is a full-size 200 page missing the JSON-LD `aggregateRating` block — not the small "Client Challenge" shell `isBotChallenge()` was built to detect — so the retry-via-shared-scraper-fallback branch never fired in GitHub Actions CI.
- Widened the retry trigger to fire whenever rating extraction fails (Playwright is tried first for broadway.com and is free), instead of only when `isBotChallenge()` also matches.
- Added a circuit breaker (5 consecutive fallback misses) so the `--include-closed` monthly sitemap cron doesn't burn a full Playwright round-trip on every closed show that legitimately has no rating.
- Extracted the pure parsing/decision functions to `scripts/lib/broadway-com-rating-parser.js` and added a colocated test (CLAUDE.md rule 15), registered in `tests/unit-test-manifest.txt` + `test.yml` push-path allowlist (the script previously had zero push-path CI coverage).

## Test plan
- [x] `node --test scripts/scrape-broadway-com-audience.test.mjs` — 10/10 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint` — no new warnings
- [x] `node scripts/scrape-broadway-com-audience.js --show=hamilton-2015 --dry-run --verbose` — real data, 1 updated / 0 skipped / 0 errors
- [x] `/second-opinion` (plan) + `/ship-check` (implementation, Claude + Codex adversarial review) — no blockers
- [ ] Confirm on the next scheduled/manual `update-broadway-com.yml` CI run that the fallback actually recovers ratings for bot-blocked shows (can only be confirmed live in CI, not locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)