### PR TITLE
BRO-554: dedup redundant Vercel deploys within a 30-min window

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -251,7 +251,7 @@ gh workflow run "Rebuild Reviews Data" -f reason="Post bulk import sync"
 - **Manual trigger:** `gh workflow run gather-reviews.yml -f shows=show-id-here`
 - **Job pipeline:** `prepare → gather-reviews → scrape-aggregators (non-blocking) → rebuild → deploy`
   - `scrape-aggregators`: Runs Playbill Verdict + NYC Theatre for the target shows (`--shows=`). Uses `continue-on-error: true` so rebuild always runs even if scrapers fail. 30-minute timeout.
-  - `rebuild` job: rebuilds reviews.json, pushes to both private repos, **dispatches Deploy to Vercel** (15-min dedup), then auto-triggers text collection if >20 reviews need it, and **auto-triggers LLM scoring** if any unscored reviews exist for the gathered shows.
+  - `rebuild` job: rebuilds reviews.json, pushes to both private repos, **dispatches Deploy to Vercel** (30-min dedup via `scripts/check-recent-deploy.js`, BRO-554), then auto-triggers text collection if >20 reviews need it, and **auto-triggers LLM scoring** if any unscored reviews exist for the gathered shows.
 - **Technical notes:**
   - Installs Playwright Chromium for Show Score carousel scraping
   - Show Score extraction uses Playwright to scroll through ALL critic reviews (not just first 8)

--- a/.github/workflows/gather-reviews.yml
+++ b/.github/workflows/gather-reviews.yml
@@ -559,23 +559,16 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          GATE_DISABLED: ${{ vars.DEPLOY_GATE_DISABLED }}
         run: |
-          # Deploy dedup: skip only if a deploy was triggered AFTER this run started
-          OUR_RUN_START=$(gh run view ${{ github.run_id }} --json createdAt -q '.createdAt' 2>/dev/null || echo "")
-          RECENT=$(gh run list --workflow=vercel-deploy.yml --limit=1 --json createdAt -q '.[0].createdAt' 2>/dev/null || echo "")
-
-          if [ -n "$RECENT" ] && [ -n "$OUR_RUN_START" ]; then
-            RECENT_TS=$(date -d "$RECENT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$RECENT" +%s 2>/dev/null || echo "0")
-            OUR_TS=$(date -d "$OUR_RUN_START" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$OUR_RUN_START" +%s 2>/dev/null || echo "0")
-            NOW_TS=$(date +%s)
-            DIFF=$((NOW_TS - RECENT_TS))
-
-            if [ "$RECENT_TS" -gt "$OUR_TS" ] && [ "$DIFF" -lt 900 ]; then
-              echo "Skipping deploy — one was already triggered after this run started (${DIFF}s ago)"
-              exit 0
-            fi
+          # Deploy dedup (BRO-554): scripts/check-recent-deploy.js — skips only
+          # when a real prod deploy landed within the last 30 min (shared
+          # DEDUP_WINDOW_SEC with scripts/lib/should-deploy-gate.js).
+          if ! node scripts/check-recent-deploy.js; then
+            echo "Skipping deploy — a recent prod deploy already covers this change"
+            exit 0
           fi
-
           echo "Triggering deploy..."
           gh workflow run vercel-deploy.yml || echo "Deploy dispatch failed — will deploy on next schedule"
       - name: Auto-trigger text collection if needed

--- a/.github/workflows/rebuild-fast.yml
+++ b/.github/workflows/rebuild-fast.yml
@@ -345,18 +345,15 @@ jobs:
         if: always() && steps.push-core-data.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          GATE_DISABLED: ${{ vars.DEPLOY_GATE_DISABLED }}
         run: |
-          OUR_RUN_START=$(gh run view ${{ github.run_id }} --json createdAt -q '.createdAt' 2>/dev/null || echo "")
-          RECENT=$(gh run list --workflow=vercel-deploy.yml --limit=1 --json createdAt -q '.[0].createdAt' 2>/dev/null || echo "")
-          if [ -n "$RECENT" ] && [ -n "$OUR_RUN_START" ]; then
-            RECENT_TS=$(date -d "$RECENT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$RECENT" +%s 2>/dev/null || echo "0")
-            OUR_TS=$(date -d "$OUR_RUN_START" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$OUR_RUN_START" +%s 2>/dev/null || echo "0")
-            NOW_TS=$(date +%s)
-            DIFF=$((NOW_TS - RECENT_TS))
-            if [ "$RECENT_TS" -gt "$OUR_TS" ] && [ "$DIFF" -lt 900 ]; then
-              echo "Skipping deploy — already triggered after this run started (${DIFF}s ago)"
-              exit 0
-            fi
+          # Deploy dedup (BRO-554): scripts/check-recent-deploy.js — skips only
+          # when a real prod deploy landed within the last 30 min (shared
+          # DEDUP_WINDOW_SEC with scripts/lib/should-deploy-gate.js).
+          if ! node scripts/check-recent-deploy.js; then
+            echo "Skipping deploy — a recent prod deploy already covers this change"
+            exit 0
           fi
           echo "Triggering deploy..."
           gh workflow run vercel-deploy.yml || echo "Deploy dispatch failed — workflow_run will catch successful conclusions"

--- a/.github/workflows/rebuild-reviews.yml
+++ b/.github/workflows/rebuild-reviews.yml
@@ -563,18 +563,15 @@ jobs:
         if: always() && steps.push-core-data.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          GATE_DISABLED: ${{ vars.DEPLOY_GATE_DISABLED }}
         run: |
-          OUR_RUN_START=$(gh run view ${{ github.run_id }} --json createdAt -q '.createdAt' 2>/dev/null || echo "")
-          RECENT=$(gh run list --workflow=vercel-deploy.yml --limit=1 --json createdAt -q '.[0].createdAt' 2>/dev/null || echo "")
-          if [ -n "$RECENT" ] && [ -n "$OUR_RUN_START" ]; then
-            RECENT_TS=$(date -d "$RECENT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$RECENT" +%s 2>/dev/null || echo "0")
-            OUR_TS=$(date -d "$OUR_RUN_START" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$OUR_RUN_START" +%s 2>/dev/null || echo "0")
-            NOW_TS=$(date +%s)
-            DIFF=$((NOW_TS - RECENT_TS))
-            if [ "$RECENT_TS" -gt "$OUR_TS" ] && [ "$DIFF" -lt 900 ]; then
-              echo "Skipping deploy — already triggered after this run started (${DIFF}s ago)"
-              exit 0
-            fi
+          # Deploy dedup (BRO-554): scripts/check-recent-deploy.js — skips only
+          # when a real prod deploy landed within the last 30 min (shared
+          # DEDUP_WINDOW_SEC with scripts/lib/should-deploy-gate.js).
+          if ! node scripts/check-recent-deploy.js; then
+            echo "Skipping deploy — a recent prod deploy already covers this change"
+            exit 0
           fi
           echo "Triggering deploy..."
           gh workflow run vercel-deploy.yml || echo "Deploy dispatch failed — workflow_run will catch successful conclusions"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,15 @@ on:
       # would trigger zero CI without this entry (task #1581, same gap class
       # as scripts/check-orphan-commits.js above).
       - 'scripts/audit-workflow-concurrency.js'
+      # BRO-554 deploy dedup: scripts/check-recent-deploy.js is a top-level
+      # script (outside the scripts/lib/** glob above) and its required test
+      # scripts/vercel-deploy.test.mjs lives at scripts/ root per the Linear
+      # ticket's acceptance criteria (`node --test scripts/vercel-deploy.test.mjs`),
+      # not scripts/lib/ — neither is covered by any existing glob, so both
+      # need their own entry (same gap class as scripts/check-orphan-commits.js
+      # above). Registered in tests/unit-test-manifest.txt.
+      - 'scripts/check-recent-deploy.js'
+      - 'scripts/vercel-deploy.test.mjs'
       # Push-path coverage self-audit (task #1745): catches the remaining gap
       # shape scripts/lib/** doesn't cover — a scripts/lib test requiring a
       # file outside scripts/lib/. Advisory step wired into lint-workflows.

--- a/.github/workflows/update-show-status.yml
+++ b/.github/workflows/update-show-status.yml
@@ -791,23 +791,16 @@ jobs:
         if: always() && steps.git-check.outputs.changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          GATE_DISABLED: ${{ vars.DEPLOY_GATE_DISABLED }}
         run: |
-          # Deploy dedup: skip if a deploy was ALREADY triggered after our rebuild started
-          OUR_RUN_START=$(gh run view ${{ github.run_id }} --json createdAt -q '.createdAt' 2>/dev/null || echo "")
-          RECENT=$(gh run list --workflow=vercel-deploy.yml --limit=1 --json createdAt -q '.[0].createdAt' 2>/dev/null || echo "")
-
-          if [ -n "$RECENT" ] && [ -n "$OUR_RUN_START" ]; then
-            RECENT_TS=$(date -d "$RECENT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$RECENT" +%s 2>/dev/null || echo "0")
-            OUR_TS=$(date -d "$OUR_RUN_START" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$OUR_RUN_START" +%s 2>/dev/null || echo "0")
-            NOW_TS=$(date +%s)
-            DIFF=$((NOW_TS - RECENT_TS))
-
-            if [ "$RECENT_TS" -gt "$OUR_TS" ] && [ "$DIFF" -lt 900 ]; then
-              echo "Skipping deploy — already triggered after this run started (${DIFF}s ago)"
-              exit 0
-            fi
+          # Deploy dedup (BRO-554): scripts/check-recent-deploy.js — skips only
+          # when a real prod deploy landed within the last 30 min (shared
+          # DEDUP_WINDOW_SEC with scripts/lib/should-deploy-gate.js).
+          if ! node scripts/check-recent-deploy.js; then
+            echo "Skipping deploy — a recent prod deploy already covers this change"
+            exit 0
           fi
-
           echo "Triggering deploy..."
           gh workflow run vercel-deploy.yml || echo "Deploy dispatch failed — will deploy on next schedule"
 

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -38,14 +38,22 @@ jobs:
   #     report success while its Vercel deploy was CANCELED (2026-06-26), and
   #     skipped preflights also conclude "success" (stale-baseline bug in the
   #     old gh-run-list lookup).
-  #   - Scheduled ticks skip only on positive proof: HEAD already live, or no
-  #     site-path diff vs the live SHA while the live deploy is <6h old
-  #     (content-aware gate, 2026-07-19 cost fix: ~93% of main commits are
-  #     bookkeeping that rebuilt an identical site ~139x/day).
+  #   - Scheduled ticks skip only on positive proof: HEAD already live, a real
+  #     prod deploy landed <30min ago (recently-deployed dedup, BRO-554 —
+  #     prevents a burst of small commits each invalidating Vercel's ISR
+  #     cache), or no site-path diff vs the live SHA while the live deploy is
+  #     <6h old (content-aware gate, 2026-07-19 cost fix: ~93% of main
+  #     commits are bookkeeping that rebuilt an identical site ~139x/day).
   #   - The 6h staleness backstop bounds staleness for private core-data
   #     changes (shows.json etc.) that never touch this repo's tree.
   #   - workflow_dispatch / workflow_run stay "ship NOW" lanes, deduped only
   #     when HEAD is already live. Any gate-input failure fails OPEN (deploy).
+  #     The same 30-min dedup window is enforced one layer up, before the
+  #     workflow_dispatch call itself, for the 5 automated (non-emergency)
+  #     pipeline workflows that dispatch this workflow directly (see
+  #     scripts/check-recent-deploy.js) — opening-night-broadcast.yml,
+  #     opening-night-express.yml, and opening-night-poller.yml are
+  #     deliberately excluded from that pre-dispatch check.
   # Kill switch: set repo variable DEPLOY_GATE_DISABLED=true to force every
   # trigger through (phone-operable; no code change).
   # Carries the Beaches #9 race guard (workflow_run conclusion check).

--- a/.github/workflows/weekly-grosses.yml
+++ b/.github/workflows/weekly-grosses.yml
@@ -159,23 +159,16 @@ jobs:
         if: always() && steps.changes.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          GATE_DISABLED: ${{ vars.DEPLOY_GATE_DISABLED }}
         run: |
-          # Deploy dedup: skip if a deploy was ALREADY triggered after our rebuild started
-          OUR_RUN_START=$(gh run view ${{ github.run_id }} --json createdAt -q '.createdAt' 2>/dev/null || echo "")
-          RECENT=$(gh run list --workflow=vercel-deploy.yml --limit=1 --json createdAt -q '.[0].createdAt' 2>/dev/null || echo "")
-
-          if [ -n "$RECENT" ] && [ -n "$OUR_RUN_START" ]; then
-            RECENT_TS=$(date -d "$RECENT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$RECENT" +%s 2>/dev/null || echo "0")
-            OUR_TS=$(date -d "$OUR_RUN_START" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$OUR_RUN_START" +%s 2>/dev/null || echo "0")
-            NOW_TS=$(date +%s)
-            DIFF=$((NOW_TS - RECENT_TS))
-
-            if [ "$RECENT_TS" -gt "$OUR_TS" ] && [ "$DIFF" -lt 900 ]; then
-              echo "Skipping deploy — already triggered after this run started (${DIFF}s ago)"
-              exit 0
-            fi
+          # Deploy dedup (BRO-554): scripts/check-recent-deploy.js — skips only
+          # when a real prod deploy landed within the last 30 min (shared
+          # DEDUP_WINDOW_SEC with scripts/lib/should-deploy-gate.js).
+          if ! node scripts/check-recent-deploy.js; then
+            echo "Skipping deploy — a recent prod deploy already covers this change"
+            exit 0
           fi
-
           echo "Triggering deploy..."
           gh workflow run vercel-deploy.yml || echo "Deploy dispatch failed — will deploy on next schedule"
 

--- a/scripts/check-recent-deploy.js
+++ b/scripts/check-recent-deploy.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Shared pre-dispatch dedup check for workflows that manually trigger
+ * vercel-deploy.yml via `gh workflow run vercel-deploy.yml` (fires
+ * workflow_dispatch — scripts/lib/should-deploy-gate.js's unconditional
+ * "ship now" lane, by design, reserved for genuine manual/emergency use).
+ *
+ * BRO-554: five automated pipeline dispatchers (gather-reviews.yml,
+ * rebuild-fast.yml, rebuild-reviews.yml, update-show-status.yml,
+ * weekly-grosses.yml) are not emergencies — they should respect the same
+ * 30-min floor the schedule-tick gate now enforces. They each carried an
+ * identical copy-pasted "was a NEWER vercel-deploy run created after mine"
+ * check, which is a race check, not an age check — it never caught
+ * sequential runs minutes apart each redeploying after the previous one had
+ * already landed. This script replaces all five copies with one real
+ * "how long ago did production actually deploy" check, using the same
+ * ground-truth lookup (check-prod-deploy.js --json) the gate itself uses.
+ *
+ * Deliberately NOT wired into opening-night-broadcast.yml,
+ * opening-night-express.yml, or opening-night-poller.yml — those are the
+ * documented "ship NOW" opening-night paths, and opening-night-checklist.yml
+ * pages the owner if a review sits un-deployed 30-60 minutes; silently
+ * throttling those dispatchers would work against that alarm instead of it.
+ *
+ * Exit 0 = ok to dispatch a deploy (no recent deploy, or lookup failed/
+ *          unknown — fails OPEN, since this script's only job is to reduce
+ *          deploys, not to risk hiding a needed one)
+ * Exit 1 = skip (a prod deploy landed within the window)
+ *
+ * Usage: node scripts/check-recent-deploy.js [--window-sec=1800]
+ * Requires VERCEL_TOKEN (same as check-prod-deploy.js).
+ * Kill switch: repo variable DEPLOY_GATE_DISABLED=true (same one
+ * scripts/lib/should-deploy-gate.js honors, passed as GATE_DISABLED) always
+ * exits 0.
+ */
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+const { DEDUP_WINDOW_SEC } = require('./lib/should-deploy-gate.js');
+
+/**
+ * Pure decision — kept separate from the I/O below so it's directly
+ * testable (CLAUDE.md rule 15: extract pure decision functions, require()
+ * the real thing in tests rather than restating the logic there).
+ * @param {object} i
+ * @param {number|null} i.ageSec seconds since the last known prod deploy (null = unknown)
+ * @param {number} i.windowSec dedup window
+ * @param {boolean} i.gateDisabled kill switch
+ * @returns {{skip: boolean, reason: string}}
+ */
+function shouldSkipDispatch({ ageSec, windowSec, gateDisabled }) {
+  if (gateDisabled) return { skip: false, reason: 'kill-switch' };
+  if (ageSec == null) return { skip: false, reason: 'no-age-fail-open' };
+  if (ageSec < windowSec) return { skip: true, reason: 'recently-deployed' };
+  return { skip: false, reason: 'window-elapsed' };
+}
+
+function getAgeSec() {
+  try {
+    const out = execFileSync(
+      'node',
+      [path.join(__dirname, 'check-prod-deploy.js'), '--json'],
+      { encoding: 'utf8', timeout: 30000 }
+    );
+    const j = JSON.parse(out);
+    return j.ageSec != null ? j.ageSec : null;
+  } catch (e) {
+    console.log(`::warning::[deploy-dedup] baseline lookup failed (${e.message.split('\n')[0]}) — failing open`);
+    return null;
+  }
+}
+
+function main() {
+  const gateDisabled = process.env.GATE_DISABLED === 'true';
+  const windowArg = process.argv.find((a) => a.startsWith('--window-sec='));
+  const windowSec = windowArg ? Number(windowArg.split('=')[1]) : DEDUP_WINDOW_SEC;
+
+  const ageSec = gateDisabled ? null : getAgeSec();
+  const { skip, reason } = shouldSkipDispatch({ ageSec, windowSec, gateDisabled });
+
+  const ageDisplay = ageSec != null ? `${ageSec}s` : 'unknown';
+  console.log(`::notice::[deploy-dedup] ${skip ? 'SKIP' : 'PROCEED'} — reason=${reason} deployAge=${ageDisplay} window=${windowSec}s`);
+
+  process.exit(skip ? 1 : 0);
+}
+
+module.exports = { shouldSkipDispatch, DEFAULT_WINDOW_SEC: DEDUP_WINDOW_SEC };
+
+if (require.main === module) main();

--- a/scripts/lib/should-deploy-gate.js
+++ b/scripts/lib/should-deploy-gate.js
@@ -14,14 +14,27 @@
  * charges dominating the Vercel bill (2026-07 cost analysis).
  *
  * Skip rules (scheduled ticks only — the gate ONLY skips on positive proof):
- *   - baseline known AND baseline == HEAD                    → skip (no-new-commits)
- *   - baseline known AND site-path diff empty AND deploy <6h → skip (content-gate)
+ *   - baseline known AND baseline == HEAD                     → skip (no-new-commits)
+ *   - baseline known AND deploy age < 30min (BRO-554)         → skip (recently-deployed)
+ *   - baseline known AND site-path diff empty AND deploy <6h  → skip (content-gate)
  * EVERYTHING else proceeds: unknown baseline, Vercel API failure, git fetch or
  * diff failure, deploy older than 6h (staleness backstop — private core-data
  * changes don't touch this repo, the backstop bounds their staleness), any
  * non-schedule event (workflow_dispatch / workflow_run keep their "ship now"
- * semantics, deduped only when HEAD is already live).
- * A wrongly-run build costs cents; a wrongly-skipped deploy is silent staleness.
+ * semantics, deduped only when HEAD is already live — those triggers are either
+ * genuine manual/emergency use or a post-rebuild refresh with its own SLA in
+ * opening-night-checklist.yml; throttling them risked reintroducing the
+ * "deploy-before-rebuild race" this file's workflow_run handling exists to
+ * avoid). A wrongly-run build costs cents; a wrongly-skipped deploy is silent
+ * staleness.
+ *
+ * The recently-deployed rule (BRO-554, 2026-08-20) exists because a burst of
+ * small commits minutes apart could each pass the content-gate and deploy —
+ * every deploy invalidates Vercel's ISR cache, so back-to-back deploys mean a
+ * page never serves a second cached request. scripts/check-recent-deploy.js
+ * applies the same DEDUP_WINDOW_SEC to the workflow_dispatch callers that
+ * bypass this gate entirely (gather-reviews.yml etc. — see that script's
+ * header for why this gate's own workflow_dispatch branch can't cover them).
  *
  * Kill switch: repo variable DEPLOY_GATE_DISABLED=true (passed as GATE_DISABLED)
  * forces proceed on every trigger — the 2am phone-operable escape hatch.
@@ -66,6 +79,10 @@ const SITE_PATHS = [
 
 const STALENESS_BACKSTOP_SEC = 6 * 3600;
 
+// Minimum time between deploys for scheduled ticks (BRO-554). Shared with
+// scripts/check-recent-deploy.js so both dedup paths use the same window.
+const DEDUP_WINDOW_SEC = 30 * 60;
+
 // git diff --quiet exit codes: 0 = no diff, 1 = diff, anything else = error.
 function classifyDiffExit(code) {
   if (code === 0) return 'clean';
@@ -103,6 +120,7 @@ function decide({ eventName, gateDisabled, baselineSha, deployAgeSec, headSha, d
   if (baselineSha === headSha) return { proceed: false, reason: 'no-new-commits' };
   if (deployAgeSec == null) return { proceed: true, reason: 'no-age-fail-open' };
   if (deployAgeSec > STALENESS_BACKSTOP_SEC) return { proceed: true, reason: 'staleness-backstop' };
+  if (deployAgeSec < DEDUP_WINDOW_SEC) return { proceed: false, reason: 'recently-deployed' };
   if (diffResult === 'dirty') return { proceed: true, reason: 'content-changed' };
   if (diffResult === 'clean') return { proceed: false, reason: 'content-gate' };
   return { proceed: true, reason: 'diff-error-fail-open' };
@@ -179,7 +197,7 @@ function main() {
     !gateDisabled &&
     eventName === 'schedule' &&
     baseline.sha && baseline.sha !== headSha &&
-    baseline.ageSec != null && baseline.ageSec <= STALENESS_BACKSTOP_SEC
+    baseline.ageSec != null && baseline.ageSec >= DEDUP_WINDOW_SEC && baseline.ageSec <= STALENESS_BACKSTOP_SEC
   ) {
     diff = runDiff(baseline.sha, headSha);
   }
@@ -203,6 +221,6 @@ function main() {
   writeOutput(proceed, reason);
 }
 
-module.exports = { decide, classifyDiffExit, SITE_PATHS, STALENESS_BACKSTOP_SEC };
+module.exports = { decide, classifyDiffExit, SITE_PATHS, STALENESS_BACKSTOP_SEC, DEDUP_WINDOW_SEC };
 
 if (require.main === module) main();

--- a/scripts/lib/should-deploy-gate.test.mjs
+++ b/scripts/lib/should-deploy-gate.test.mjs
@@ -5,16 +5,19 @@ import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { decide, classifyDiffExit, SITE_PATHS, STALENESS_BACKSTOP_SEC } = require('./should-deploy-gate.js');
+const { decide, classifyDiffExit, SITE_PATHS, STALENESS_BACKSTOP_SEC, DEDUP_WINDOW_SEC } = require('./should-deploy-gate.js');
 
 const A = 'a'.repeat(40);
 const B = 'b'.repeat(40);
 
+// deployAgeSec must clear DEDUP_WINDOW_SEC (30min) so tests below that aren't
+// specifically about the recently-deployed rule exercise the diff/staleness
+// logic instead of tripping the dedup check first.
 const base = {
   eventName: 'schedule',
   gateDisabled: false,
   baselineSha: A,
-  deployAgeSec: 600,
+  deployAgeSec: DEDUP_WINDOW_SEC + 600,
   headSha: B,
   diffResult: 'clean',
 };
@@ -38,6 +41,23 @@ test('schedule: clean site diff + fresh deploy skips (content-gate)', () => {
 test('schedule: dirty site diff deploys (content-changed)', () => {
   const r = decide({ ...base, diffResult: 'dirty' });
   assert.deepEqual(r, { proceed: true, reason: 'content-changed' });
+});
+
+test('schedule: recently-deployed skips even with a dirty (content-changed) diff (BRO-554)', () => {
+  // The whole point of the dedup rule: content DID change, but we just
+  // deployed — wait for the window to clear instead of shipping again.
+  const r = decide({ ...base, diffResult: 'dirty', deployAgeSec: 300 });
+  assert.deepEqual(r, { proceed: false, reason: 'recently-deployed' });
+});
+
+test('schedule: recently-deployed boundary is exact (< DEDUP_WINDOW_SEC only)', () => {
+  const justUnder = decide({ ...base, diffResult: 'dirty', deployAgeSec: DEDUP_WINDOW_SEC - 1 });
+  assert.deepEqual(justUnder, { proceed: false, reason: 'recently-deployed' });
+  // At exactly the boundary, dedup does NOT fire — falls through to the
+  // content-diff check (base's diffResult is 'clean' here, so content-gate).
+  const atBoundary = decide({ ...base, deployAgeSec: DEDUP_WINDOW_SEC });
+  assert.deepEqual(atBoundary, { proceed: false, reason: 'content-gate' });
+  assert.equal(DEDUP_WINDOW_SEC, 1800);
 });
 
 test('schedule: staleness backstop fires at >6h even with clean diff (seconds math)', () => {

--- a/scripts/vercel-deploy.test.mjs
+++ b/scripts/vercel-deploy.test.mjs
@@ -1,0 +1,80 @@
+// End-to-end deploy-dedup scenario tests for BRO-554 (reduce 48 deploys/day).
+// Thin by design: the exhaustive per-branch coverage of decide() lives in
+// scripts/lib/should-deploy-gate.test.mjs and shouldSkipDispatch() is a
+// one-line decision, so this file requires both real functions (CLAUDE.md
+// rule 15 — no logic duplication) and asserts the two dedup paths from the
+// workflow's own perspective: the schedule-tick gate inside
+// vercel-deploy.yml, and the pre-dispatch check the 5 automated pipeline
+// workflows (gather-reviews.yml etc.) run before calling
+// `gh workflow run vercel-deploy.yml`.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { decide, DEDUP_WINDOW_SEC } = require('./lib/should-deploy-gate.js');
+const { shouldSkipDispatch, DEFAULT_WINDOW_SEC } = require('./check-recent-deploy.js');
+
+const SHA_LIVE = 'a'.repeat(40);
+const SHA_NEW = 'b'.repeat(40);
+
+test('a burst of schedule ticks within the dedup window only deploys once', () => {
+  // Tick 1: content changed, nothing deployed recently — ships.
+  const tick1 = decide({
+    eventName: 'schedule', gateDisabled: false,
+    baselineSha: SHA_LIVE, headSha: SHA_NEW,
+    deployAgeSec: DEDUP_WINDOW_SEC + 1, diffResult: 'dirty',
+  });
+  assert.equal(tick1.proceed, true);
+
+  // Tick 2, five minutes later: tick 1's deploy is now live and recent —
+  // even with a further content diff, this tick waits for the window.
+  const tick2 = decide({
+    eventName: 'schedule', gateDisabled: false,
+    baselineSha: SHA_NEW, headSha: 'c'.repeat(40),
+    deployAgeSec: 300, diffResult: 'dirty',
+  });
+  assert.deepEqual(tick2, { proceed: false, reason: 'recently-deployed' });
+});
+
+test('once the 30-min window elapses, the next dirty tick deploys', () => {
+  const r = decide({
+    eventName: 'schedule', gateDisabled: false,
+    baselineSha: SHA_LIVE, headSha: SHA_NEW,
+    deployAgeSec: DEDUP_WINDOW_SEC + 1, diffResult: 'dirty',
+  });
+  assert.deepEqual(r, { proceed: true, reason: 'content-changed' });
+});
+
+test('pipeline dispatchers (gather-reviews.yml etc.) skip gh workflow run when a deploy is recent', () => {
+  const recent = shouldSkipDispatch({ ageSec: 300, windowSec: DEFAULT_WINDOW_SEC, gateDisabled: false });
+  assert.deepEqual(recent, { skip: true, reason: 'recently-deployed' });
+
+  const stale = shouldSkipDispatch({ ageSec: DEFAULT_WINDOW_SEC + 1, windowSec: DEFAULT_WINDOW_SEC, gateDisabled: false });
+  assert.deepEqual(stale, { skip: false, reason: 'window-elapsed' });
+});
+
+test('pipeline dispatchers fail open on unknown deploy age or the kill switch', () => {
+  assert.deepEqual(
+    shouldSkipDispatch({ ageSec: null, windowSec: DEFAULT_WINDOW_SEC, gateDisabled: false }),
+    { skip: false, reason: 'no-age-fail-open' }
+  );
+  assert.deepEqual(
+    shouldSkipDispatch({ ageSec: 1, windowSec: DEFAULT_WINDOW_SEC, gateDisabled: true }),
+    { skip: false, reason: 'kill-switch' }
+  );
+});
+
+test('shared window constant stays in sync between the gate and the pre-dispatch check', () => {
+  assert.equal(DEFAULT_WINDOW_SEC, DEDUP_WINDOW_SEC);
+  assert.equal(DEDUP_WINDOW_SEC, 1800);
+});
+
+test('emergency/manual dispatch (workflow_dispatch) is never dedup-throttled by the gate itself', () => {
+  const r = decide({
+    eventName: 'workflow_dispatch', gateDisabled: false,
+    baselineSha: SHA_LIVE, headSha: SHA_NEW,
+    deployAgeSec: 1, diffResult: null,
+  });
+  assert.deepEqual(r, { proceed: true, reason: 'explicit-ship' });
+});

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -109,6 +109,7 @@ scripts/tests/test-data-write-guard.test.mjs
 scripts/tests/tracked-and-ignored-guard.test.mjs
 scripts/tests/trunk-status.test.mjs
 scripts/tests/verify-edits-heredoc.test.mjs
+scripts/vercel-deploy.test.mjs
 scripts/verify-contamination-gate.test.mjs
 tests/unit/1minutecritic-extractor.test.mjs
 tests/unit/aggregator-url-latent.test.mjs


### PR DESCRIPTION
**DRAFT — preserved, not endorsed. Do not merge without a completed review.**

The BRO-554 headless job produced this commit and then exited while still
waiting on its own backgrounded Codex adversarial review. Its ship-check
verdict was never recorded. The commit existed ONLY inside its local worktree
(`git ls-remote` showed no such branch on origin), so it would have been lost
the moment that worktree was cleaned up. Pushing the branch and opening this
draft preserves the work and puts it where CI can evaluate it.

What it does: adds `scripts/check-recent-deploy.js` and extends
`scripts/lib/should-deploy-gate.js` so a deploy is skipped when one already
landed inside a 30-minute window, to cut the ~48 deploys/day.

Why it is a DRAFT and not a merge:
- It touches `.github/workflows/vercel-deploy.yml` and `weekly-grosses.yml`.
  Per CLAUDE.md rule 18, `.github/workflows/**` is critical shared
  infrastructure and needs a recorded pre-implementation review verdict.
- Deploy gating is precisely the class of change that fails silently: too
  aggressive a skip means a content change sits unpublished until the 6h
  backstop, and nothing alerts on it.
- Its originating job's own review never finished, so no reviewer — human or
  model — has actually signed off on this diff.

Before this merges, someone should confirm: what happens to a genuinely urgent
content change that lands 5 minutes after a deploy, and does the skip path
still honor the existing `DEPLOY_GATE_DISABLED=true` kill switch?

It does ship tests (`scripts/vercel-deploy.test.mjs`,
`scripts/lib/should-deploy-gate.test.mjs`) and registers them in
`tests/unit-test-manifest.txt`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>