### PR TITLE
fix(BRO-2232): sanitize unsanctioned commands already present in a card's notes

### DIFF
--- a/scripts/enrich-card-acceptance.js
+++ b/scripts/enrich-card-acceptance.js
@@ -64,14 +64,15 @@ const path = require('path');
 const https = require('https');
 const { execFileSync } = require('child_process');
 const { hasHelpFlag } = require('./lib/cli-help.js');
-const { evaluateVerifiability, isSafeCheckCommand, candidatesFrom, SECTION_RE } = (() => {
+const { evaluateVerifiability, isSafeCheckCommand, candidatesFrom, SECTION_RE, VERIFY_LINE_RE } = (() => {
   const gate = require('./lib/verify-gate.js');
-  const { SECTION_RE } = require('./lib/autonomous-verify-cmd.js');
+  const { SECTION_RE, VERIFY_LINE_RE } = require('./lib/autonomous-verify-cmd.js');
   return {
     evaluateVerifiability: gate.evaluateVerifiability,
     isSafeCheckCommand: gate.isSafeCheckCommand,
     candidatesFrom: gate.candidatesFrom,
     SECTION_RE,
+    VERIFY_LINE_RE,
   };
 })();
 const { isCardEligible } = require('./lib/autonomous-eligibility.js');
@@ -360,6 +361,46 @@ function unsanctionedRenderedSpans(section, finalCommand) {
     .filter(c => c !== finalCommand && !isSafeCheckCommand(c));
 }
 
+// Guardrail 4 (BRO-2232): spliceNotes() only ever rewrites the "##
+// Acceptance criteria" section it finds via SECTION_RE, and the
+// owner-judgment path only ever APPENDS — neither examines a VERIFY: line
+// living anywhere else in the card's OWN pre-existing notes. But
+// extractVerifyCmd() (autonomous-verify-cmd.js) scopes its command search to
+// exactly two places: the Acceptance-criteria section, AND every VERIFY:
+// line in the whole text — so a VERIFY: line outside the section IS part of
+// the surface a dispatcher can read a command out of, and it rode through
+// every write path unexamined.
+//
+// Narrowly scoped on purpose (task description option 3): only lines
+// matching VERIFY_LINE_RE are touched. Ordinary owner-authored prose
+// elsewhere in the card — including a backticked word that happens to sit
+// outside a VERIFY: line — is never rewritten. VERIFY_LINE_RE's capture
+// group is intentionally single-line (`(.+)$` under 'm', not 's'), matching
+// extractVerifyCmd's own candidatesFrom() scan, which also never reads
+// across a newline — so this can't miss a candidate extractVerifyCmd itself
+// would have missed too.
+function demoteUnsafeVerifyLines(text) {
+  const demoted = [];
+  const rewritten = String(text).replace(VERIFY_LINE_RE, (whole, captured) => {
+    const { section: rewrittenCaptured, demoted: lineDemoted } = demoteUnsafeSpans(captured, undefined);
+    if (!lineDemoted.length) return whole;
+    demoted.push(...lineDemoted);
+    return whole.slice(0, whole.length - captured.length) + rewrittenCaptured;
+  });
+  return { text: rewritten, demoted };
+}
+
+// Structural assertion mirroring unsanctionedRenderedSpans, scoped to VERIFY:
+// lines only — the re-check that makes demoteUnsafeVerifyLines a proof
+// rather than a hope.
+function unsanctionedVerifyLineSpans(text) {
+  const out = [];
+  for (const m of String(text).matchAll(VERIFY_LINE_RE)) {
+    out.push(...unsanctionedRenderedSpans(m[1], undefined));
+  }
+  return out;
+}
+
 function buildEnrichPrompt(card) {
   return `You are drafting the missing "## Acceptance criteria" section for a software backlog card so a dispatcher can verify it was actually done, by RE-RUNNING one command.
 
@@ -558,6 +599,12 @@ async function enrichOneCard(card, opts = {}) {
     return { id: card.id, name: card.name, action: 'skipped', detail: 'already tagged auto-enriched' };
   }
 
+  // Guardrail 4 (BRO-2232): sanitize the card's OWN pre-existing notes before
+  // either write path touches them — see demoteUnsafeVerifyLines above for
+  // why neither path examines a VERIFY: line outside the section it
+  // explicitly rewrites.
+  const { text: sanitizedNotes, demoted: preexistingDemoted } = demoteUnsafeVerifyLines(card.notes || '');
+
   const eligibility = isCardEligible({ name: card.name, category: card.category, tags: card.tags });
   // Only a genuinely human-territory rejection (category/title/owner-action —
   // see isCardEligible's `kind` docstring) gets the hard-blocking marker.
@@ -569,9 +616,16 @@ async function enrichOneCard(card, opts = {}) {
   // `bsc-next --id` (task #1186). Those fall through to the same
   // LLM-drafted-acceptance-criteria path as an eligible card, below.
   if (!eligibility.eligible && eligibility.kind === 'human-territory') {
-    const newNotes = `${card.notes || ''}\n\nVERIFY: owner-judgment`.trim();
+    const newNotes = `${sanitizedNotes}\n\nVERIFY: owner-judgment`.trim();
+    // Structural assertion (defense in depth): if a demotion somehow failed
+    // to clear a pre-existing VERIFY line (re-paired backticks, nesting),
+    // refuse the write rather than let it through half-sanitized.
+    const survivingPreexisting = unsanctionedVerifyLineSpans(newNotes);
+    if (survivingPreexisting.length) {
+      return { id: card.id, name: card.name, action: 'failed', detail: `pre-existing VERIFY line still names an unsanctioned command: ${survivingPreexisting[0].slice(0, 120)}` };
+    }
     if (!opts.dryRun) {
-      logEnrichmentWrite(card, 'owner-judgment', newNotes, opts.logPath);
+      logEnrichmentWrite(card, 'owner-judgment', newNotes, opts.logPath, { demotedSpans: preexistingDemoted });
       // ship-check/Codex + QA-subagent finding (task #1830): a Linear write is
       // 3 sequential network calls (updateIssue, findOrCreateLabel,
       // addLabelToIssue — see makeLinearWriteCard), any of which can throw a
@@ -698,7 +752,18 @@ async function enrichOneCard(card, opts = {}) {
     return { id: card.id, name: card.name, action: 'failed', detail: `drafted section names an additional unsafe command: ${survivingUnsafe[0].slice(0, 120)}` };
   }
 
-  const newNotes = spliceNotes(card.notes, sectionToWrite);
+  const newNotes = spliceNotes(sanitizedNotes, sectionToWrite);
+  const allDemotedSpans = [...demotedSpans, ...preexistingDemoted];
+
+  // Guardrail 4 structural re-check (BRO-2232): sectionToWrite alone
+  // (guardrail 3, above) can't see a pre-existing VERIFY: line living
+  // outside the drafted section — demoteUnsafeVerifyLines is a best-effort
+  // rewrite, not a proof by itself. Re-run the detector across the FULL
+  // written notes and refuse the write if anything survives.
+  const survivingVerifyUnsafe = unsanctionedVerifyLineSpans(newNotes);
+  if (survivingVerifyUnsafe.length) {
+    return { id: card.id, name: card.name, action: 'failed', detail: `pre-existing VERIFY line still names an unsanctioned command: ${survivingVerifyUnsafe[0].slice(0, 120)}` };
+  }
 
   // Final safety net: re-run the SAME gate the audit/dispatch use before ever
   // writing — an LLM that ignored instructions must not slip a bad or
@@ -709,7 +774,7 @@ async function enrichOneCard(card, opts = {}) {
   }
 
   if (!opts.dryRun) {
-    logEnrichmentWrite(card, 'llm-enriched', newNotes, opts.logPath, { demotedSpans });
+    logEnrichmentWrite(card, 'llm-enriched', newNotes, opts.logPath, { demotedSpans: allDemotedSpans });
     // See the owner-judgment write above for why this is caught rather than
     // left to propagate.
     try {
@@ -726,10 +791,10 @@ async function enrichOneCard(card, opts = {}) {
     // a guardrail that fires 40 times in a 60-card sweep needs to stay
     // visible, otherwise nobody can tell a healthy sweep from a prompt
     // regression that started spraying script names into every draft.
-    detail: demotedSpans.length
-      ? `${finalGate.cmd} (demoted ${demotedSpans.length} non-command span(s) to prose: ${demotedSpans.slice(0, 3).join(', ').slice(0, 120)})`
+    detail: allDemotedSpans.length
+      ? `${finalGate.cmd} (demoted ${allDemotedSpans.length} non-command span(s) to prose: ${allDemotedSpans.slice(0, 3).join(', ').slice(0, 120)})`
       : finalGate.cmd,
-    demotedSpans,
+    demotedSpans: allDemotedSpans,
     newPaths: pathCheck.newPaths || [],
   };
 }

--- a/scripts/enrich-card-acceptance.js
+++ b/scripts/enrich-card-acceptance.js
@@ -64,15 +64,14 @@ const path = require('path');
 const https = require('https');
 const { execFileSync } = require('child_process');
 const { hasHelpFlag } = require('./lib/cli-help.js');
-const { evaluateVerifiability, isSafeCheckCommand, candidatesFrom, SECTION_RE, VERIFY_LINE_RE } = (() => {
+const { evaluateVerifiability, isSafeCheckCommand, candidatesFrom, SECTION_RE } = (() => {
   const gate = require('./lib/verify-gate.js');
-  const { SECTION_RE, VERIFY_LINE_RE } = require('./lib/autonomous-verify-cmd.js');
+  const { SECTION_RE } = require('./lib/autonomous-verify-cmd.js');
   return {
     evaluateVerifiability: gate.evaluateVerifiability,
     isSafeCheckCommand: gate.isSafeCheckCommand,
     candidatesFrom: gate.candidatesFrom,
     SECTION_RE,
-    VERIFY_LINE_RE,
   };
 })();
 const { isCardEligible } = require('./lib/autonomous-eligibility.js');
@@ -371,32 +370,46 @@ function unsanctionedRenderedSpans(section, finalCommand) {
 // the surface a dispatcher can read a command out of, and it rode through
 // every write path unexamined.
 //
-// Narrowly scoped on purpose (task description option 3): only lines
-// matching VERIFY_LINE_RE are touched. Ordinary owner-authored prose
-// elsewhere in the card — including a backticked word that happens to sit
-// outside a VERIFY: line — is never rewritten. VERIFY_LINE_RE's capture
-// group is intentionally single-line (`(.+)$` under 'm', not 's'), matching
-// extractVerifyCmd's own candidatesFrom() scan, which also never reads
-// across a newline — so this can't miss a candidate extractVerifyCmd itself
-// would have missed too.
+// Scoped to the whole VERIFY "paragraph" — through the next blank line, next
+// heading, or end of text — NOT a single line matched by autonomous-verify-
+// cmd.js's line-anchored VERIFY_LINE_RE. Ship-check finding: a first version
+// scoped to VERIFY_LINE_RE's single line missed the same class of hole
+// guardrail 3 was hardened against for the drafted section (commits
+// a9b0c8d355b, bc9059c9b31) — CommonMark inline code can straddle a line
+// ending WITHIN one paragraph, so `VERIFY: \`rm -rf\n/tmp\`` renders as one
+// intact "VERIFY: `rm -rf /tmp`" code span to a human/Notion/Linear reader
+// even though extractVerifyCmd's own single-line regex would never treat it
+// as an executable candidate. Bounding at the next blank line/heading is
+// where CommonMark itself stops letting a code span continue, so this can't
+// be tricked into swallowing an unrelated later paragraph — and it lets the
+// SAME newline-tolerant demoteUnsafeSpans/unsanctionedRenderedSpans
+// guardrail 3 already proved safe under backtick re-pairing attacks run here
+// unchanged, rather than a second, drifting implementation.
+// (?![\s\S]) rather than a bare $ — under the 'm' flag $ matches before EVERY
+// line terminator, not just true end-of-string, which would silently collapse
+// this back to single-line matching (caught by direct regex testing before
+// this shipped: the lookahead's own `$` was satisfying at the first line
+// break, well short of the closing backtick).
+const VERIFY_BLOCK_RE = /^\s*(?:[-*]\s*)?(?:\*\*)?VERIFY(?:\*\*)?:[\s\S]*?(?=\n[ \t]*\n|\n#|(?![\s\S]))/gim;
+
 function demoteUnsafeVerifyLines(text) {
   const demoted = [];
-  const rewritten = String(text).replace(VERIFY_LINE_RE, (whole, captured) => {
-    const { section: rewrittenCaptured, demoted: lineDemoted } = demoteUnsafeSpans(captured, undefined);
-    if (!lineDemoted.length) return whole;
-    demoted.push(...lineDemoted);
-    return whole.slice(0, whole.length - captured.length) + rewrittenCaptured;
+  const rewritten = String(text).replace(VERIFY_BLOCK_RE, (whole) => {
+    const { section: rewrittenBlock, demoted: blockDemoted } = demoteUnsafeSpans(whole, undefined);
+    if (!blockDemoted.length) return whole;
+    demoted.push(...blockDemoted);
+    return rewrittenBlock;
   });
   return { text: rewritten, demoted };
 }
 
-// Structural assertion mirroring unsanctionedRenderedSpans, scoped to VERIFY:
-// lines only — the re-check that makes demoteUnsafeVerifyLines a proof
+// Structural assertion mirroring unsanctionedRenderedSpans, scoped to VERIFY
+// blocks only — the re-check that makes demoteUnsafeVerifyLines a proof
 // rather than a hope.
 function unsanctionedVerifyLineSpans(text) {
   const out = [];
-  for (const m of String(text).matchAll(VERIFY_LINE_RE)) {
-    out.push(...unsanctionedRenderedSpans(m[1], undefined));
+  for (const m of String(text).matchAll(VERIFY_BLOCK_RE)) {
+    out.push(...unsanctionedRenderedSpans(m[0], undefined));
   }
   return out;
 }

--- a/scripts/enrich-card-acceptance.test.mjs
+++ b/scripts/enrich-card-acceptance.test.mjs
@@ -449,6 +449,35 @@ test('BRO-2232: the owner-judgment write path also strips a pre-existing unsanct
   assert.ok(!/`rm -rf \/`/.test(written), 'rm -rf / must not remain backticked');
 });
 
+// A first version of this fix scoped demotion to VERIFY_LINE_RE's single
+// line and missed exactly the class of hole guardrail 3 was hardened
+// against for the drafted section: CommonMark inline code can straddle a
+// line ending within one paragraph, so a backtick opened on the VERIFY:
+// line and closed on the NEXT line still renders as one intact command to a
+// human/Notion/Linear reader. This must be caught the same as a same-line
+// span.
+test('BRO-2232: a pre-existing unsafe VERIFY line whose backtick span straddles a newline is still demoted', async () => {
+  const calls = [];
+  const card = {
+    id: 'bro2232-e', name: 'Fix scoring bug', category: 'Product', tags: [],
+    notes: '## Problem\nx.\nVERIFY: `rm -rf\n/tmp`',
+  };
+  const r = await enrichOneCard(card, {
+    callLLM: async () => JSON.stringify({
+      command: 'npx tsc --noEmit',
+      acceptanceCriteria: '## Acceptance criteria\n`npx tsc --noEmit` passes',
+    }),
+    notionBrain: fakeNotionBrain(calls),
+    logPath: SCRATCH_LOG_PATH,
+  });
+  assert.equal(r.action, 'llm-enriched');
+  assert.equal(calls.length, 1);
+  const written = writtenNotes(calls);
+  const unsafeRendered = renderedCodeSpans(written).filter(c => !isSafeCheckCommand(c));
+  assert.deepEqual(unsafeRendered, [], `card renders an unsanctioned command as code: ${unsafeRendered.join(', ')}`);
+  assert.ok(r.demotedSpans.some(s => /rm -rf/.test(s)), 'the multiline span should be reported as demoted');
+});
+
 // Note: a card whose pre-existing notes already carry a SAFE VERIFY line
 // can't reach either write path at all — evaluateVerifiability() sees that
 // safe candidate and arms the card, so it's skipped before any write, same

--- a/scripts/enrich-card-acceptance.test.mjs
+++ b/scripts/enrich-card-acceptance.test.mjs
@@ -400,6 +400,84 @@ test('guardrail 3: an ADDITIONAL safe command keeps its backticks (no gratuitous
   assert.deepEqual(r.demotedSpans, [], 'nothing should be demoted when every span is safe');
 });
 
+// BRO-2232: spliceNotes() only ever rewrites the "## Acceptance criteria"
+// section it finds, and the owner-judgment path only ever APPENDS — neither
+// examines a VERIFY: line living anywhere else in the card's OWN
+// pre-existing notes. But extractVerifyCmd() scopes its command search to
+// exactly that section AND every VERIFY: line in the whole text, so a
+// pre-existing unsanctioned VERIFY line rode through every write path
+// unexamined. This is the exact repro from the Linear issue.
+test('BRO-2232: a pre-existing unsanctioned VERIFY line in the card\'s own notes is never written back in command position', async () => {
+  const calls = [];
+  const card = {
+    id: 'bro2232-a', name: 'Fix scoring bug', category: 'Product', tags: [],
+    notes: '## Problem\nx.\nVERIFY: `rm -rf /`',
+  };
+  const r = await enrichOneCard(card, {
+    callLLM: async () => JSON.stringify({
+      command: 'npx tsc --noEmit',
+      acceptanceCriteria: '## Acceptance criteria\n`npx tsc --noEmit` passes',
+    }),
+    notionBrain: fakeNotionBrain(calls),
+    logPath: SCRATCH_LOG_PATH,
+  });
+  assert.equal(r.action, 'llm-enriched');
+  assert.equal(calls.length, 1);
+  const written = writtenNotes(calls);
+  const unsafeWritten = backtickedSpans(written).filter(c => !isSafeCheckCommand(c));
+  assert.deepEqual(unsafeWritten, [], `unsanctioned command written as a command: ${unsafeWritten.join(', ')}`);
+  assert.ok(!/`rm -rf \/`/.test(written), 'rm -rf / must not remain backticked');
+  assert.ok(r.demotedSpans.includes('rm -rf /'), 'the pre-existing unsafe VERIFY line should be reported as demoted');
+});
+
+test('BRO-2232: the owner-judgment write path also strips a pre-existing unsanctioned VERIFY line', async () => {
+  const calls = [];
+  const card = {
+    id: 'bro2232-b', name: 'Pitch kit for industry intros', category: 'Marketing', tags: [],
+    notes: '## Problem\nNeed a forwardable blurb.\nVERIFY: `rm -rf /`',
+  };
+  const r = await enrichOneCard(card, {
+    callLLM: async () => { throw new Error('must not be called — human-territory cards skip the LLM'); },
+    notionBrain: fakeNotionBrain(calls),
+    logPath: SCRATCH_LOG_PATH,
+  });
+  assert.equal(r.action, 'owner-judgment');
+  assert.equal(calls.length, 1);
+  const written = writtenNotes(calls);
+  const unsafeWritten = backtickedSpans(written).filter(c => !isSafeCheckCommand(c));
+  assert.deepEqual(unsafeWritten, [], `unsanctioned command written as a command: ${unsafeWritten.join(', ')}`);
+  assert.ok(!/`rm -rf \/`/.test(written), 'rm -rf / must not remain backticked');
+});
+
+// Note: a card whose pre-existing notes already carry a SAFE VERIFY line
+// can't reach either write path at all — evaluateVerifiability() sees that
+// safe candidate and arms the card, so it's skipped before any write, same
+// as before this change. Nothing to assert there.
+
+// Option 3's scope is deliberately narrow: only VERIFY: lines, not arbitrary
+// backticked prose elsewhere in the card. An unsafe-looking backtick span
+// OUTSIDE a VERIFY: line is not part of extractVerifyCmd's scan surface at
+// all, so it is left untouched rather than rewriting owner-authored text
+// that was never going to be read as a command.
+test('BRO-2232: a backticked span outside any VERIFY line is left untouched (narrow scope)', async () => {
+  const calls = [];
+  const card = {
+    id: 'bro2232-d', name: 'Fix scoring bug', category: 'Product', tags: [],
+    notes: '## Problem\nFor context, someone once ran `rm -rf /` here.',
+  };
+  const r = await enrichOneCard(card, {
+    callLLM: async () => JSON.stringify({
+      command: 'npx tsc --noEmit',
+      acceptanceCriteria: '## Acceptance criteria\n`npx tsc --noEmit` passes',
+    }),
+    notionBrain: fakeNotionBrain(calls),
+    logPath: SCRATCH_LOG_PATH,
+  });
+  assert.equal(r.action, 'llm-enriched');
+  const written = writtenNotes(calls);
+  assert.match(written, /`rm -rf \/`/, 'prose outside a VERIFY line is not part of the executable surface and must be preserved verbatim');
+});
+
 test('eligible card: LLM call throws — failed, zero writes', async () => {
   const calls = [];
   const card = { id: 'c4', name: 'Fix scoring bug', category: 'Product', tags: [], notes: '## Problem\nBug.' };

--- a/scripts/lib/autonomous-verify-cmd.js
+++ b/scripts/lib/autonomous-verify-cmd.js
@@ -75,4 +75,4 @@ function extractVerifyCmd(notes, isSafeCheckCommand) {
   };
 }
 
-module.exports = { extractVerifyCmd, candidatesFrom, SECTION_RE, VERIFY_LINE_RE };
+module.exports = { extractVerifyCmd, candidatesFrom, SECTION_RE };

--- a/scripts/lib/autonomous-verify-cmd.js
+++ b/scripts/lib/autonomous-verify-cmd.js
@@ -75,4 +75,4 @@ function extractVerifyCmd(notes, isSafeCheckCommand) {
   };
 }
 
-module.exports = { extractVerifyCmd, candidatesFrom, SECTION_RE };
+module.exports = { extractVerifyCmd, candidatesFrom, SECTION_RE, VERIFY_LINE_RE };


### PR DESCRIPTION
## Summary
- `enrich-card-acceptance.js` only validated the "## Acceptance criteria" section it drafted — a backticked command already present in a card's own pre-existing `VERIFY:` line (outside that section) rode through `spliceNotes()`/the owner-judgment append untouched and got written back verbatim.
- Adds guardrail 4: `demoteUnsafeVerifyLines()`/`unsanctionedVerifyLineSpans()`, scoped to the whole VERIFY "paragraph" (through the next blank line/heading/end-of-text, matching CommonMark's own code-span boundary) — reuses the existing newline-tolerant `demoteUnsafeSpans()`/`unsanctionedRenderedSpans()` primitives guardrail 3 already proved safe under backtick re-pairing attacks, rather than a second implementation.
- Fixes a `$`-under-multiline-flag regex bug found during ship-check (a Claude codebase-review subagent caught it): `$` matches before every line terminator when `m` is set, not just true end-of-string — replaced with the flag-independent `(?![\s\S])`.

## Review
- `/ship-check` run: Claude codebase-aware review (caught the multiline escape above — fixed), gpt-5.4-mini independent security review (findings verified — the "outside VERIFY line" scope concern confirmed correct-by-design via `extractVerifyCmd`'s own scan surface), Codex adversarial review (its "High" finding — non-`-`/`*` list markers bypass the guard — verified false: the real dispatcher's `VERIFY_LINE_RE` doesn't recognize those forms as VERIFY lines either, so they're already unreachable; its other findings fail in the safe/over-refuse direction and match pre-existing codebase regex conventions).
- `node scripts/lib/review-gate.mjs --query=record --reviewer=ship-check --result=pass` recorded.

## Test plan
- [x] `node --test scripts/enrich-card-acceptance.test.mjs` — 49/49 pass, including the issue's exact repro and the multiline-escape regression
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)