### PR TITLE
fix: Rate-limit-aware retry for opening-night private-repo checkouts (BRO-66)

### DIFF
--- a/.github/actions/checkout-core-data/action.yml
+++ b/.github/actions/checkout-core-data/action.yml
@@ -22,16 +22,26 @@ runs:
       env:
         CORE_DATA_TOKEN: ${{ inputs.token }}
       run: |
-        MAX_RETRIES=2
+        # BRO-66: REVIEW_TEXTS_TOKEN is a classic PAT (5000 req/hr across ALL
+        # API calls from that token, shared by every workflow that checks out
+        # core-data or review-texts). An opening-night burst of orchestrator
+        # dispatches can exhaust that quota mid-run; a rate-limited clone gets
+        # its own detection + 30s-base exponential backoff here (via
+        # scripts/lib/github-rate-limit-retry.js, unit-tested in
+        # tests/unit/checkout-rate-limit-retry.test.mjs) instead of the flat
+        # 10s sleep this used to give every failure regardless of cause.
+        MAX_RETRIES=3
+        STDERR_FILE=$(mktemp)
         for ATTEMPT in $(seq 1 $MAX_RETRIES); do
           START=$(date +%s)
           SUCCESS=false
+          : > "$STDERR_FILE"
 
           if [ -d "/tmp/core-data-checkout/.git" ]; then
             # Cache restored — fast update via fetch
             cd /tmp/core-data-checkout
             git remote set-url origin "https://x-access-token:${CORE_DATA_TOKEN}@github.com/thomaspryor/broadway-scorecard-data.git"
-            if git fetch origin main --depth 1 2>/dev/null && git reset --hard origin/main 2>/dev/null; then
+            if git fetch origin main --depth 1 2>>"$STDERR_FILE" && git reset --hard origin/main 2>>"$STDERR_FILE"; then
               ELAPSED=$(($(date +%s) - START))
               echo "Core data updated from cache in ${ELAPSED}s (git fetch)"
               SUCCESS=true
@@ -40,7 +50,7 @@ runs:
               echo "::warning::Cache update failed — falling back to full clone"
               cd /tmp
               rm -rf /tmp/core-data-checkout
-              if git clone --depth 1 "https://x-access-token:${CORE_DATA_TOKEN}@github.com/thomaspryor/broadway-scorecard-data.git" /tmp/core-data-checkout; then
+              if git clone --depth 1 "https://x-access-token:${CORE_DATA_TOKEN}@github.com/thomaspryor/broadway-scorecard-data.git" /tmp/core-data-checkout 2>>"$STDERR_FILE"; then
                 ELAPSED=$(($(date +%s) - START))
                 echo "Core data cloned fresh in ${ELAPSED}s (fallback)"
                 SUCCESS=true
@@ -49,7 +59,7 @@ runs:
           else
             # No cache — full clone
             rm -rf /tmp/core-data-checkout
-            if git clone --depth 1 "https://x-access-token:${CORE_DATA_TOKEN}@github.com/thomaspryor/broadway-scorecard-data.git" /tmp/core-data-checkout; then
+            if git clone --depth 1 "https://x-access-token:${CORE_DATA_TOKEN}@github.com/thomaspryor/broadway-scorecard-data.git" /tmp/core-data-checkout 2>>"$STDERR_FILE"; then
               ELAPSED=$(($(date +%s) - START))
               echo "Core data cloned fresh in ${ELAPSED}s"
               SUCCESS=true
@@ -58,14 +68,42 @@ runs:
 
           if [ "$SUCCESS" = "true" ]; then
             break
-          elif [ "$ATTEMPT" -lt "$MAX_RETRIES" ]; then
-            echo "::warning::Core data checkout failed (attempt $ATTEMPT/$MAX_RETRIES) — retrying in 10s"
-            sleep 10
-            rm -rf /tmp/core-data-checkout
-          else
-            echo "::error::Core data checkout failed after $MAX_RETRIES attempts"
-            exit 1
           fi
+
+          cat "$STDERR_FILE" >&2
+
+          DECISION=$(STDERR_FILE="$STDERR_FILE" ATTEMPT="$ATTEMPT" MAX_RETRIES="$MAX_RETRIES" node -e "
+            const fs = require('fs');
+            const { shouldRetry, retryDelayMs } = require('${GITHUB_WORKSPACE}/scripts/lib/github-rate-limit-retry.js');
+            const stderr = fs.readFileSync(process.env.STDERR_FILE, 'utf8');
+            const attempt = Number(process.env.ATTEMPT);
+            const r = shouldRetry({ attempt, exitCode: 1, stderr, maxAttempts: Number(process.env.MAX_RETRIES) });
+            console.log(r.retry ? ('retry:' + retryDelayMs(attempt)) : ('stop:' + r.reason));
+          ")
+
+          rm -rf /tmp/core-data-checkout
+
+          case "$DECISION" in
+            retry:*)
+              DELAY_MS="${DECISION#retry:}"
+              DELAY_S=$(( (DELAY_MS + 999) / 1000 ))
+              echo "::warning::Core data checkout hit a GitHub API rate limit (attempt $ATTEMPT/$MAX_RETRIES) — backing off ${DELAY_S}s before retry"
+              sleep "$DELAY_S"
+              ;;
+            stop:max-attempts-reached)
+              echo "::error::Core data checkout still rate-limited after $MAX_RETRIES attempts — giving up"
+              exit 1
+              ;;
+            stop:not-rate-limit|*)
+              if [ "$ATTEMPT" -lt "$MAX_RETRIES" ]; then
+                echo "::warning::Core data checkout failed (attempt $ATTEMPT/$MAX_RETRIES, non-rate-limit) — retrying in 10s"
+                sleep 10
+              else
+                echo "::error::Core data checkout failed after $MAX_RETRIES attempts"
+                exit 1
+              fi
+              ;;
+          esac
         done
 
     - name: Copy core data to data/

--- a/.github/actions/checkout-review-texts/action.yml
+++ b/.github/actions/checkout-review-texts/action.yml
@@ -13,10 +13,76 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v5
-      with:
-        repository: thomaspryor/broadway-review-texts
-        token: ${{ inputs.token }}
-        path: data/review-texts
-        fetch-depth: ${{ inputs.fetch-depth }}
-        ref: main
+    # BRO-66: this is the exact step named in the incident — "Checkout
+    # review-texts (private repo)" failed with "API rate limit exceeded for
+    # user ID 3475675" during an opening-night burst of orchestrator
+    # dispatches. REVIEW_TEXTS_TOKEN is a classic PAT (5000 req/hr across ALL
+    # API calls from that token, shared by every workflow using this action),
+    # and actions/checkout@v5 has no retry of its own. Manual clone (same
+    # pattern as checkout-core-data/action.yml) gives this composite action
+    # control over retry timing: a rate-limited clone gets 30s-base
+    # exponential backoff (scripts/lib/github-rate-limit-retry.js, unit-tested
+    # in tests/unit/checkout-rate-limit-retry.test.mjs) instead of failing the
+    # whole job outright.
+    - name: Clone review-texts repo
+      shell: bash
+      env:
+        REVIEW_TEXTS_TOKEN: ${{ inputs.token }}
+        FETCH_DEPTH: ${{ inputs.fetch-depth }}
+      run: |
+        DEPTH_ARGS=""
+        if [ -n "${FETCH_DEPTH}" ] && [ "${FETCH_DEPTH}" != "0" ]; then
+          DEPTH_ARGS="--depth ${FETCH_DEPTH}"
+        fi
+
+        rm -rf data/review-texts
+        MAX_RETRIES=3
+        STDERR_FILE=$(mktemp)
+        for ATTEMPT in $(seq 1 $MAX_RETRIES); do
+          : > "$STDERR_FILE"
+          START=$(date +%s)
+          if git clone $DEPTH_ARGS --branch main "https://x-access-token:${REVIEW_TEXTS_TOKEN}@github.com/thomaspryor/broadway-review-texts.git" data/review-texts 2>>"$STDERR_FILE"; then
+            ELAPSED=$(($(date +%s) - START))
+            echo "review-texts cloned in ${ELAPSED}s"
+            break
+          fi
+
+          cat "$STDERR_FILE" >&2
+          rm -rf data/review-texts
+
+          DECISION=$(STDERR_FILE="$STDERR_FILE" ATTEMPT="$ATTEMPT" MAX_RETRIES="$MAX_RETRIES" node -e "
+            const fs = require('fs');
+            const { shouldRetry, retryDelayMs } = require('${GITHUB_WORKSPACE}/scripts/lib/github-rate-limit-retry.js');
+            const stderr = fs.readFileSync(process.env.STDERR_FILE, 'utf8');
+            const attempt = Number(process.env.ATTEMPT);
+            const r = shouldRetry({ attempt, exitCode: 1, stderr, maxAttempts: Number(process.env.MAX_RETRIES) });
+            console.log(r.retry ? ('retry:' + retryDelayMs(attempt)) : ('stop:' + r.reason));
+          ")
+
+          case "$DECISION" in
+            retry:*)
+              DELAY_MS="${DECISION#retry:}"
+              DELAY_S=$(( (DELAY_MS + 999) / 1000 ))
+              echo "::warning::review-texts checkout hit a GitHub API rate limit (attempt $ATTEMPT/$MAX_RETRIES) — backing off ${DELAY_S}s before retry"
+              sleep "$DELAY_S"
+              ;;
+            stop:max-attempts-reached)
+              echo "::error::review-texts checkout still rate-limited after $MAX_RETRIES attempts — giving up"
+              exit 1
+              ;;
+            *)
+              if [ "$ATTEMPT" -lt "$MAX_RETRIES" ]; then
+                echo "::warning::review-texts checkout failed (attempt $ATTEMPT/$MAX_RETRIES, non-rate-limit) — retrying in 10s"
+                sleep 10
+              else
+                echo "::error::review-texts checkout failed after $MAX_RETRIES attempts"
+                exit 1
+              fi
+              ;;
+          esac
+        done
+
+        if [ ! -d data/review-texts/.git ]; then
+          echo "::error::review-texts checkout FAILED — data/review-texts/.git missing"
+          exit 1
+        fi

--- a/.github/workflows/opening-night-orchestrator.yml
+++ b/.github/workflows/opening-night-orchestrator.yml
@@ -456,7 +456,16 @@ jobs:
           # unchanged. Early-exit on broadcast-complete still applies. Manual dispatches
           # can override with -f max_iterations=16.
           MAX_ITERATIONS=${{ inputs.max_iterations || 10 }}
-          POLL_INTERVAL=${{ inputs.poll_interval_minutes || 10 }}
+          # BRO-66: scheduled (cron) runs never populate `inputs.*`, so this
+          # fallback — not the workflow_dispatch default of 15 above — is the
+          # cadence every opening night actually runs at. It used to fall back
+          # to 10min (rate-limit UNsafe per the input's own description),
+          # which is the "aggressive 10-min cadence" this card is named after:
+          # more iterations/hour → proportionally more REVIEW_TEXTS_TOKEN API
+          # calls from checkout-core-data + checkout-review-texts per poller
+          # dispatch, and that PAT has a flat 5000 req/hr ceiling shared by
+          # every workflow using it. 15min matches the documented safe default.
+          POLL_INTERVAL=${{ inputs.poll_interval_minutes || 15 }}
           SHOWS="${{ steps.find.outputs.shows }}"
           MARKET="${{ steps.market.outputs.market }}"
 
@@ -546,12 +555,13 @@ jobs:
           #      report and the checklist + SLA dispatch tail steps never fired.
           # Exiting cleanly under the cap restores both.
           # 240min, not 300: the deadline is only checked at the TOP of each
-          # iteration, and one iteration can then run ~75min (poller's own 60min
-          # job timeout + POLL_INTERVAL sleep + dispatch/verify overhead). So the
-          # true worst case is DEADLINE + ~75min, and 240+75=315 stays under the
-          # 360 cap with a real reserve for the always() tail steps. It also has
-          # to absorb the steps that run BEFORE this one (checkout, npm ci,
-          # budget pre-flight), which are not covered by this clock.
+          # iteration, and one iteration can then run ~80min (poller's own 60min
+          # job timeout + POLL_INTERVAL sleep [15min default for scheduled runs
+          # since BRO-66, was 10] + dispatch/verify overhead). So the true worst
+          # case is DEADLINE + ~80min, and 240+80=320 stays under the 360 cap
+          # with a real reserve for the always() tail steps. It also has to
+          # absorb the steps that run BEFORE this one (checkout, npm ci, budget
+          # pre-flight), which are not covered by this clock.
           DEADLINE=$(( $(date +%s) + 240*60 ))
           COMPLETED_ITERATIONS=0
           DEADLINE_EXIT=false

--- a/.github/workflows/opening-night-poller.yml
+++ b/.github/workflows/opening-night-poller.yml
@@ -106,6 +106,21 @@ jobs:
           # merge-base resolvable so every commit stays properly parented.
           fetch-depth: 0
 
+      # BRO-66: REVIEW_TEXTS_TOKEN is a classic PAT — 5000 req/hr across ALL
+      # API calls from that token, shared by every workflow that checks out
+      # or pushes core-data/review-texts. Logging remaining/reset at job start
+      # and end (see the matching step near the bottom of this job) makes a
+      # near-exhausted quota visible in the run log BEFORE it causes a hard
+      # failure, instead of the only signal being the checkout step's error.
+      - name: Log REVIEW_TEXTS_TOKEN rate-limit status (start)
+        timeout-minutes: 1
+        env:
+          GH_TOKEN: ${{ secrets.REVIEW_TEXTS_TOKEN }}
+        run: |
+          gh api rate_limit --jq '.rate | "REVIEW_TEXTS_TOKEN rate limit: \(.remaining)/\(.limit) remaining, resets \(.reset | todate)"' \
+            || echo "::warning::Could not fetch REVIEW_TEXTS_TOKEN rate-limit status"
+        continue-on-error: true
+
       - name: Checkout core data
         uses: ./.github/actions/checkout-core-data
         with:
@@ -693,6 +708,16 @@ jobs:
               fi
             fi
           done
+
+      - name: Log REVIEW_TEXTS_TOKEN rate-limit status (end)
+        if: always()
+        timeout-minutes: 1
+        env:
+          GH_TOKEN: ${{ secrets.REVIEW_TEXTS_TOKEN }}
+        run: |
+          gh api rate_limit --jq '.rate | "REVIEW_TEXTS_TOKEN rate limit: \(.remaining)/\(.limit) remaining, resets \(.reset | todate)"' \
+            || echo "::warning::Could not fetch REVIEW_TEXTS_TOKEN rate-limit status"
+        continue-on-error: true
 
       - name: Notify on failure
         id: notify

--- a/scripts/lib/github-rate-limit-retry.js
+++ b/scripts/lib/github-rate-limit-retry.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// scripts/lib/github-rate-limit-retry.js — pure retry decisions for private-repo
+// git checkouts authenticated with REVIEW_TEXTS_TOKEN (a classic PAT, 5000
+// req/hr across ALL API calls from that token — shared by every workflow that
+// checks out core-data or review-texts). No fetch, no fs, no timers, no
+// process: every function here is a pure input→output decision so the retry
+// timing is unit-testable without spinning up a real git clone.
+//
+// BRO-66: opening-night-poller.yml's "Checkout review-texts (private repo)"
+// step failed with "API rate limit exceeded for user ID 3475675" during a
+// 46-run/hour burst on an aggressive 10-min polling cadence. The composite
+// actions (checkout-core-data, checkout-review-texts) previously retried ANY
+// clone failure with a flat sleep — this gives the rate-limit case its own
+// detection + 30s-base exponential backoff, per the card's acceptance
+// criteria, instead of treating it the same as a generic network blip.
+//
+// CLAUDE.md rule 15 — tests require() these functions rather than restating
+// the logic; tests/unit/checkout-rate-limit-retry.test.mjs is the caller.
+
+'use strict';
+
+// GitHub's classic-PAT REST/git-over-HTTPS rate-limit error. Seen verbatim in
+// the BRO-66 incident: "API rate limit exceeded for user ID 3475675 (or one
+// of its API partners)." Secondary limits use different wording ("You have
+// exceeded a secondary rate limit") — matched too since the git clone path
+// can trip either one, and both call for the same backoff-and-retry response.
+const RATE_LIMIT_MESSAGE_RE = /api rate limit exceeded|secondary rate limit|rate limit exceeded/i;
+
+// Never sleep longer than this in one wait — a checkout retry loop is inside
+// a job with its own timeout-minutes; an unbounded wait just burns that
+// budget without giving the job a chance to fail visibly and get retried by
+// the next cron/orchestrator iteration.
+const MAX_DELAY_MS = 300_000; // 5 min
+// 30s base per the BRO-66 acceptance criteria ("30s backoff").
+const DEFAULT_BASE_MS = 30_000;
+// 3 attempts at a 30s base = 30 + 60 = 90s of sleeping worst case (last
+// attempt's failure doesn't sleep), well inside a 60s-scoped composite-action
+// step and small relative to the poller's 60-min job timeout.
+const DEFAULT_MAX_ATTEMPTS = 3;
+
+function isRateLimitError(text) {
+  return RATE_LIMIT_MESSAGE_RE.test(String(text || ''));
+}
+
+/**
+ * How long to wait before the next attempt. Full-jitter exponential from a
+ * 30s base: attempt 1 waits ~30s, attempt 2 waits ~60s, capped at MAX_DELAY_MS.
+ *
+ * @param {number} attempt 1-based attempt that just failed
+ * @param {{baseMs?: number, capMs?: number, random?: () => number}} opts
+ */
+function retryDelayMs(attempt, opts = {}) {
+  const baseMs = Number.isFinite(opts.baseMs) ? opts.baseMs : DEFAULT_BASE_MS;
+  const capMs = Number.isFinite(opts.capMs) ? opts.capMs : MAX_DELAY_MS;
+  const random = typeof opts.random === 'function' ? opts.random : Math.random;
+
+  const exp = baseMs * Math.pow(2, Math.max(0, attempt - 1));
+  // Half the spread (like linear-retry-policy.js's exponential branch) so a
+  // retry storm still spreads out but no single attempt collapses to ~0ms.
+  return Math.min(capMs, Math.round(exp * (0.5 + 0.5 * random())));
+}
+
+/**
+ * Decide whether a failed checkout attempt should retry.
+ *
+ * @param {{attempt: number, exitCode: number, stderr?: string, maxAttempts?: number}} input
+ * @returns {{retry: boolean, reason: string}}
+ */
+function shouldRetry({ attempt, exitCode, stderr = '', maxAttempts } = {}) {
+  const cap = Number.isFinite(maxAttempts) ? maxAttempts : DEFAULT_MAX_ATTEMPTS;
+  if (exitCode === 0) return { retry: false, reason: 'success' };
+  if (!isRateLimitError(stderr)) return { retry: false, reason: 'not-rate-limit' };
+  if (attempt >= cap) return { retry: false, reason: 'max-attempts-reached' };
+  return { retry: true, reason: 'rate-limited' };
+}
+
+module.exports = {
+  isRateLimitError,
+  retryDelayMs,
+  shouldRetry,
+  MAX_DELAY_MS,
+  DEFAULT_BASE_MS,
+  DEFAULT_MAX_ATTEMPTS,
+};

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -181,6 +181,7 @@ tests/unit/cast-tombstone.test.mjs
 tests/unit/census-ledger-outlet-ids.test.mjs
 tests/unit/check-claude-auth-health.test.mjs
 tests/unit/check-corpus-drift.test.mjs
+tests/unit/checkout-rate-limit-retry.test.mjs
 tests/unit/ci-cancellation-logic.test.mjs
 tests/unit/ci-config-hygiene.test.mjs
 tests/unit/ci-red-claims.test.mjs

--- a/tests/unit/checkout-rate-limit-retry.test.mjs
+++ b/tests/unit/checkout-rate-limit-retry.test.mjs
@@ -1,0 +1,101 @@
+// tests/unit/checkout-rate-limit-retry.test.mjs — BRO-66 acceptance test.
+// Verifies scripts/lib/github-rate-limit-retry.js's backoff timing and
+// retry/give-up decisions against mocked 403 rate-limit responses, per the
+// card's "unit-tested with mock 403 responses to verify backoff timing and
+// success after retry" criterion.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  isRateLimitError,
+  retryDelayMs,
+  shouldRetry,
+  MAX_DELAY_MS,
+  DEFAULT_BASE_MS,
+  DEFAULT_MAX_ATTEMPTS,
+} from '../../scripts/lib/github-rate-limit-retry.js';
+
+const RATE_LIMIT_403 =
+  "fatal: unable to access 'https://github.com/thomaspryor/broadway-review-texts.git/': " +
+  'The requested URL returned error: 403\n' +
+  'API rate limit exceeded for user ID 3475675 (or one of its API partners).';
+
+test('isRateLimitError matches the exact BRO-66 incident message', () => {
+  assert.equal(isRateLimitError(RATE_LIMIT_403), true);
+});
+
+test('isRateLimitError matches secondary rate limit wording', () => {
+  assert.equal(isRateLimitError('You have exceeded a secondary rate limit'), true);
+});
+
+test('isRateLimitError is false for unrelated git failures', () => {
+  assert.equal(isRateLimitError('fatal: could not read Username for https://github.com'), false);
+  assert.equal(isRateLimitError(''), false);
+  assert.equal(isRateLimitError(undefined), false);
+});
+
+test('shouldRetry retries a rate-limited attempt under the max', () => {
+  const result = shouldRetry({ attempt: 1, exitCode: 128, stderr: RATE_LIMIT_403 });
+  assert.equal(result.retry, true);
+  assert.equal(result.reason, 'rate-limited');
+});
+
+test('shouldRetry gives up once max attempts is reached (success after retry stops there)', () => {
+  const result = shouldRetry({
+    attempt: DEFAULT_MAX_ATTEMPTS,
+    exitCode: 128,
+    stderr: RATE_LIMIT_403,
+  });
+  assert.equal(result.retry, false);
+  assert.equal(result.reason, 'max-attempts-reached');
+});
+
+test('shouldRetry never retries a non-rate-limit failure', () => {
+  const result = shouldRetry({ attempt: 1, exitCode: 128, stderr: 'fatal: repository not found' });
+  assert.equal(result.retry, false);
+  assert.equal(result.reason, 'not-rate-limit');
+});
+
+test('shouldRetry treats exitCode 0 as success regardless of stderr', () => {
+  const result = shouldRetry({ attempt: 1, exitCode: 0, stderr: RATE_LIMIT_403 });
+  assert.equal(result.retry, false);
+  assert.equal(result.reason, 'success');
+});
+
+test('shouldRetry honors a caller-supplied maxAttempts', () => {
+  const result = shouldRetry({ attempt: 1, exitCode: 128, stderr: RATE_LIMIT_403, maxAttempts: 1 });
+  assert.equal(result.retry, false);
+  assert.equal(result.reason, 'max-attempts-reached');
+});
+
+test('retryDelayMs backs off exponentially from the 30s base', () => {
+  // random=0 → lower bound of the jitter window (0.5x of the exponential term)
+  const attempt1Low = retryDelayMs(1, { random: () => 0 });
+  const attempt1High = retryDelayMs(1, { random: () => 1 });
+  assert.equal(attempt1Low, Math.round(DEFAULT_BASE_MS * 0.5));
+  assert.equal(attempt1High, DEFAULT_BASE_MS);
+
+  const attempt2Low = retryDelayMs(2, { random: () => 0 });
+  const attempt2High = retryDelayMs(2, { random: () => 1 });
+  assert.equal(attempt2Low, Math.round(DEFAULT_BASE_MS * 2 * 0.5));
+  assert.equal(attempt2High, DEFAULT_BASE_MS * 2);
+});
+
+test('retryDelayMs is monotonically non-decreasing with attempt number', () => {
+  const d1 = retryDelayMs(1, { random: () => 1 });
+  const d2 = retryDelayMs(2, { random: () => 1 });
+  const d3 = retryDelayMs(3, { random: () => 1 });
+  assert.ok(d2 >= d1);
+  assert.ok(d3 >= d2);
+});
+
+test('retryDelayMs never exceeds the cap even at high attempt numbers', () => {
+  const delay = retryDelayMs(10, { random: () => 1 });
+  assert.ok(delay <= MAX_DELAY_MS);
+  assert.equal(delay, MAX_DELAY_MS);
+});
+
+test('retryDelayMs respects a caller-supplied baseMs/capMs', () => {
+  const delay = retryDelayMs(1, { baseMs: 1000, capMs: 500, random: () => 1 });
+  assert.equal(delay, 500);
+});


### PR DESCRIPTION
## Summary
- REVIEW_TEXTS_TOKEN is a classic PAT (5000 req/hr across all API calls from that token, shared by every workflow). opening-night-poller.yml's "Checkout review-texts (private repo)" step hard-failed with "API rate limit exceeded for user ID 3475675" during an opening-night burst — root cause was `opening-night-orchestrator.yml` dispatching the poller every ~10 minutes for hours (a fallback default bug: scheduled cron runs never populate `inputs.*`, so `${{ inputs.poll_interval_minutes || 10 }}` fell back to 10min instead of the documented rate-limit-safe 15min default).
- `checkout-core-data` and `checkout-review-texts` composite actions now detect a rate-limit-shaped git failure and back off with 30s-base exponential backoff (capped at 5 min) instead of a flat 10s sleep on any failure. `checkout-review-texts` moved from `actions/checkout@v5` (opaque, no retry control) to a manual clone matching `checkout-core-data`'s existing pattern — verified none of its 79 callers pass `fetch-depth: 0` (all use the default/explicit `'1'`).
- `opening-night-orchestrator.yml`: fixed the scheduled-run `POLL_INTERVAL` fallback from 10min to 15min, matching the documented safe default.
- `opening-night-poller.yml`: logs `REVIEW_TEXTS_TOKEN`'s remaining quota + reset time at job start and end (1-min timeout each) for visibility into future incidents.
- Retry/backoff decisions extracted to `scripts/lib/github-rate-limit-retry.js` (pure functions), unit-tested in `tests/unit/checkout-rate-limit-retry.test.mjs` (12 tests, registered in the manifest).

Linear: BRO-66 · Notion: 345637c5-416f-8102-834b-e3b53a8701bd

## Test plan
- [x] `node --test tests/unit/checkout-rate-limit-retry.test.mjs` — 12/12 pass
- [x] `node --test tests/unit/checkout-rate-limit-retry.test.mjs scripts/lib/*.test.mjs` — 4600/4604 pass (4 pre-existing skips), no regressions
- [x] `npx eslint scripts/lib/github-rate-limit-retry.js tests/unit/checkout-rate-limit-retry.test.mjs` — clean
- [x] `npx tsc --noEmit` — no errors
- [x] `actionlint -shellcheck=` on both edited workflow files — clean
- [x] `node scripts/audit-workflow-hygiene.js` — 230/230 workflows pass
- [x] Independent second-opinion review (agent) — "Ready to ship"; 2 warnings addressed (stale deadline-math comment, added `timeout-minutes: 1` to the new logging steps)
- [ ] Live opening-night rate-limit scenario (can't be exercised outside a real 403 burst — the unit tests cover the retry/backoff logic against a mocked 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)