### PR TITLE
fix: sync opening-night tracker to origin on draft creation (BRO-60)

### DIFF
--- a/scripts/send-opening-night-broadcast.js
+++ b/scripts/send-opening-night-broadcast.js
@@ -258,6 +258,33 @@ function syncTrackerToOrigin(localData) {
 }
 
 /**
+ * Marks a draft (or preview) as complete in the in-memory tracker, persists it
+ * locally, and syncs it to origin/main. BRO-60: previously only the SEND_TO
+ * (preview) path called syncTrackerToOrigin — a real Resend draft creation saved
+ * locally via saveSentData() but never synced, so a CLI-created draft's
+ * completed:true state was invisible to origin until the next scheduled CI
+ * commit, same class of divergence as the 2026-04-11 preview incident this
+ * function's sibling comment describes. Exported for unit testing.
+ */
+function recordDraftCompletion(sentData, broadcastKey, showsForEmail, draftInfo) {
+  const completionData = {
+    draftCreatedAt: new Date().toISOString(),
+    ...draftInfo,
+    completed: true,
+    draftStatus: 'draft',
+    sentAt: null,
+    recipientCount: null,
+  };
+  sentData.shows[broadcastKey] = completionData;
+  for (const s of showsForEmail) {
+    sentData.shows[s.showId] = { ...completionData, broadcastKey };
+  }
+  saveSentData(sentData);
+  syncTrackerToOrigin(sentData);
+  return completionData;
+}
+
+/**
  * Find shows that opened within the last N days.
  */
 function findRecentlyOpenedShows(shows, lookbackDays) {
@@ -821,22 +848,12 @@ async function main() {
       // NEW 2026-04-22: also track draftStatus so reconcile-broadcast-state.js can
       // round-trip the Resend API and detect cancelled/deleted drafts. completed:true
       // stays for backwards-compat; shouldRequeueShow() gates the re-entry path.
-      const completionData = {
-        draftCreatedAt: new Date().toISOString(),
+      recordDraftCompletion(sentData, broadcastKey, showsForEmail, {
         draftId,
         draftUrl,
         method: 'resend-draft',
         reviewCount: showsForEmail.reduce((sum, s) => sum + s.reviewCount, 0),
-        completed: true,
-        draftStatus: 'draft',
-        sentAt: null,
-        recipientCount: null,
-      };
-      sentData.shows[broadcastKey] = completionData;
-      for (const s of showsForEmail) {
-        sentData.shows[s.showId] = { ...completionData, broadcastKey };
-      }
-      saveSentData(sentData);
+      });
 
       console.log(`\nDraft ready — log into Resend to send: ${draftUrl}`);
 
@@ -890,7 +907,7 @@ async function main() {
 }
 
 // Exported for unit testing. Only run main() when invoked as a CLI.
-module.exports = { syncTrackerToOrigin, mergeTrackerEntries, findRecentlyOpenedShows, buildBroadcastName, RESEND_NAME_MAX, SYNC_REPO, SYNC_REMOTE_PATH };
+module.exports = { syncTrackerToOrigin, mergeTrackerEntries, findRecentlyOpenedShows, buildBroadcastName, RESEND_NAME_MAX, SYNC_REPO, SYNC_REMOTE_PATH, recordDraftCompletion, SENT_PATH };
 
 if (require.main === module) {
   main().catch(err => {

--- a/scripts/send-opening-night-broadcast.test.mjs
+++ b/scripts/send-opening-night-broadcast.test.mjs
@@ -1,0 +1,166 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const mod = require('./send-opening-night-broadcast.js');
+const { recordDraftCompletion, SYNC_REPO, SYNC_REMOTE_PATH, SENT_PATH } = mod;
+
+// BRO-60: real Resend draft creation called saveSentData() (local disk only) but
+// never syncTrackerToOrigin() — only the --send-to preview path synced. A
+// CLI-created draft's completed:true state was invisible to origin/main until
+// the next scheduled CI commit, the same class of divergence that caused the
+// 2026-04-11 duplicate-preview incident on the preview path.
+//
+// This spins up a fake `gh` binary on PATH that stands in for origin/main:
+// `gh api repos/OWNER/REPO/contents/PATH?ref=main` reads a local "remote" file,
+// `gh api --method PUT ... --input FILE` writes it back. That lets the test
+// assert real origin state after recordDraftCompletion() runs, without any
+// network access or touching the real gh CLI / real repo.
+
+function makeFakeGh(remoteFile) {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fake-gh-bin-'));
+  const ghPath = path.join(binDir, 'gh');
+  const script = `#!/usr/bin/env node
+const fs = require('fs');
+const args = process.argv.slice(2);
+const remoteFile = ${JSON.stringify(remoteFile)};
+
+if (args[0] === 'auth' && args[1] === 'status') {
+  process.exit(0);
+}
+
+if (args[0] === 'api') {
+  const rest = args.slice(1);
+  const methodIdx = rest.indexOf('--method');
+  if (methodIdx !== -1 && rest[methodIdx + 1] === 'PUT') {
+    const inputIdx = rest.indexOf('--input');
+    const inputFile = rest[inputIdx + 1];
+    const payload = JSON.parse(fs.readFileSync(inputFile, 'utf8'));
+    const content = Buffer.from(payload.content, 'base64').toString('utf8');
+    fs.writeFileSync(remoteFile, content);
+    fs.writeFileSync(remoteFile + '.sha', 'sha-' + Date.now());
+    process.stdout.write(JSON.stringify({ content: { sha: 'sha-' + Date.now() } }));
+    process.exit(0);
+  }
+  // GET repos/OWNER/REPO/contents/PATH?ref=main
+  let existing = '{"shows":{}}';
+  let sha = 'initial-sha';
+  if (fs.existsSync(remoteFile)) existing = fs.readFileSync(remoteFile, 'utf8');
+  if (fs.existsSync(remoteFile + '.sha')) sha = fs.readFileSync(remoteFile + '.sha', 'utf8');
+  process.stdout.write(JSON.stringify({ sha, content: Buffer.from(existing, 'utf8').toString('base64') }));
+  process.exit(0);
+}
+process.exit(1);
+`;
+  fs.writeFileSync(ghPath, script);
+  fs.chmodSync(ghPath, 0o755);
+  return binDir;
+}
+
+function withFakeOrigin(fn) {
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ons-origin-'));
+  const remoteFile = path.join(workDir, 'origin-opening-night-sent.json');
+  const binDir = makeFakeGh(remoteFile);
+
+  const savedPath = process.env.PATH;
+  const savedGithubActions = process.env.GITHUB_ACTIONS;
+  process.env.PATH = `${binDir}${path.delimiter}${savedPath}`;
+  delete process.env.GITHUB_ACTIONS;
+
+  // Prevent recordDraftCompletion's saveSentData() from clobbering the real
+  // data/opening-night-sent.json tracker file — divert only that exact path.
+  const realWriteFileSync = fs.writeFileSync;
+  const localWrites = [];
+  fs.writeFileSync = (filePath, data, ...rest) => {
+    if (filePath === SENT_PATH) {
+      localWrites.push(data);
+      return undefined;
+    }
+    return realWriteFileSync.call(fs, filePath, data, ...rest);
+  };
+
+  try {
+    return fn({ remoteFile, localWrites });
+  } finally {
+    fs.writeFileSync = realWriteFileSync;
+    process.env.PATH = savedPath;
+    if (savedGithubActions === undefined) delete process.env.GITHUB_ACTIONS;
+    else process.env.GITHUB_ACTIONS = savedGithubActions;
+    fs.rmSync(workDir, { recursive: true, force: true });
+    fs.rmSync(binDir, { recursive: true, force: true });
+  }
+}
+
+test('recordDraftCompletion: syncs completed:true to origin on draft creation, not just preview', () => {
+  withFakeOrigin(({ remoteFile }) => {
+    const sentData = { shows: {} };
+    const showsForEmail = [{ showId: 'giant-2026', reviewCount: 12 }];
+
+    recordDraftCompletion(sentData, 'broadway:giant-2026', showsForEmail, {
+      draftId: 'draft_abc123',
+      draftUrl: 'https://resend.com/broadcasts/draft_abc123',
+      method: 'resend-draft',
+      reviewCount: 12,
+    });
+
+    assert.ok(fs.existsSync(remoteFile), 'expected recordDraftCompletion to push a file to origin/main');
+    const origin = JSON.parse(fs.readFileSync(remoteFile, 'utf8'));
+
+    const byBroadcastKey = origin.shows['broadway:giant-2026'];
+    assert.ok(byBroadcastKey, 'origin state missing the broadcastKey entry');
+    assert.equal(byBroadcastKey.completed, true);
+    assert.equal(byBroadcastKey.draftId, 'draft_abc123');
+    assert.equal(byBroadcastKey.draftStatus, 'draft');
+
+    const byShowId = origin.shows['giant-2026'];
+    assert.ok(byShowId, 'origin state missing the per-show entry');
+    assert.equal(byShowId.completed, true);
+    assert.equal(byShowId.broadcastKey, 'broadway:giant-2026');
+  });
+});
+
+test('recordDraftCompletion: merges with pre-existing origin state instead of overwriting it', () => {
+  withFakeOrigin(({ remoteFile }) => {
+    fs.writeFileSync(remoteFile, JSON.stringify({
+      shows: { 'broadway:other-show-2026': { completed: true, draftId: 'draft_other' } },
+    }));
+    fs.writeFileSync(remoteFile + '.sha', 'preexisting-sha');
+
+    const sentData = { shows: {} };
+    recordDraftCompletion(sentData, 'broadway:giant-2026', [{ showId: 'giant-2026', reviewCount: 5 }], {
+      draftId: 'draft_new',
+      draftUrl: 'https://resend.com/broadcasts/draft_new',
+      method: 'resend-draft',
+      reviewCount: 5,
+    });
+
+    const origin = JSON.parse(fs.readFileSync(remoteFile, 'utf8'));
+    assert.ok(origin.shows['broadway:other-show-2026'], 'pre-existing origin entry was dropped, not merged');
+    assert.ok(origin.shows['broadway:giant-2026'], 'new draft entry missing from merged origin state');
+  });
+});
+
+test('recordDraftCompletion: still saves locally (SENT_PATH) in addition to syncing', () => {
+  withFakeOrigin(({ localWrites }) => {
+    const sentData = { shows: {} };
+    recordDraftCompletion(sentData, 'broadway:giant-2026', [{ showId: 'giant-2026', reviewCount: 5 }], {
+      draftId: 'draft_local',
+      draftUrl: 'https://resend.com/broadcasts/draft_local',
+      method: 'resend-draft',
+      reviewCount: 5,
+    });
+
+    assert.equal(localWrites.length, 1, 'expected exactly one local saveSentData() write');
+    const saved = JSON.parse(localWrites[0]);
+    assert.equal(saved.shows['broadway:giant-2026'].draftId, 'draft_local');
+  });
+});
+
+test('SYNC_REPO / SYNC_REMOTE_PATH point at the private data repo root (sanity check for the fake-gh harness)', () => {
+  assert.equal(SYNC_REPO, 'thomaspryor/broadway-scorecard-data');
+  assert.equal(SYNC_REMOTE_PATH, 'opening-night-sent.json');
+});

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -73,6 +73,7 @@ scripts/produce-coverage-digest-snapshot.test.mjs
 scripts/reconcile-dead-completions.test.mjs
 scripts/scoring-delta-autoclear-coverage.test.mjs
 scripts/scrape-broadway-com-audience.test.mjs
+scripts/send-opening-night-broadcast.test.mjs
 scripts/telegraph-reviews-index.test.mjs
 scripts/tests/agent-auth-preflight.test.mjs
 scripts/tests/audit-card-relevance.test.mjs


### PR DESCRIPTION
## Summary
- `send-opening-night-broadcast.js` only synced `opening-night-sent.json` to origin/main on the `--send-to` (transactional preview) path. A real Resend draft creation saved `completed:true` locally via `saveSentData()` but never pushed to origin — CI's checkout stayed blind to CLI-created drafts until the next scheduled commit (same failure class as the 2026-04-11 preview duplicate-send incident).
- Extracted the draft-completion bookkeeping into `recordDraftCompletion()`, which now calls the existing `syncTrackerToOrigin()` on the draft path too.
- Added `scripts/send-opening-night-broadcast.test.mjs` (fake `gh` binary standing in for origin/main) asserting origin state reflects `completed:true` after a draft creation, registered in `tests/unit-test-manifest.txt`.

## Test plan
- [x] `node --test scripts/send-opening-night-broadcast.test.mjs` — 4/4 pass
- [x] `node --test scripts/reconcile-dead-completions.test.mjs tests/unit/broadcast-state.test.mjs tests/unit/resend-we-audience-routing.test.mjs` — 46/46 pass, no interference
- [x] `npx tsc --noEmit`, `npx next lint`, `node scripts/lint-resend-calls.js` — clean
- [x] Adversarial subagent review — confirmed behavior-preserving refactor, no lock/ordering hazard; found one pre-existing narrower gap in `--recreate-draft`'s clear path, carded separately (Notion 3c2637c5) since it needs a deletion-propagation design change, not a 1-liner

Linear: BRO-60

🤖 Generated with [Claude Code](https://claude.com/claude-code)