### PR TITLE
feat: Add stage-latency.jsonl rotation cron (BRO-54)

### DIFF
--- a/.cron-health-exempt.txt
+++ b/.cron-health-exempt.txt
@@ -190,3 +190,12 @@ outlet-registry-baseline-maintenance.yml
 # the other weekly audit-*.yml entries above.
 audit-stale-wrong-production.yml
 clear-stale-suspected-misattribution-flags.yml
+
+# BRO-54: daily safety-net rotation for data/audit/stage-latency.jsonl.
+# emitStage() already self-rotates the log inline on every pipeline write;
+# this cron only matters if no pipeline writes for a while. A stale/missed
+# run just means the file grows a bit longer before the next rotation —
+# it's already on the ALLOW_LARGE allowlist + 90MiB hard cap in
+# check-file-sizes/action.yml, so there's no user-facing staleness or gate
+# risk to page on. Failures alert via notify-failure (warning severity).
+stage-latency-rotation.yml

--- a/.github/workflows/stage-latency-rotation.yml
+++ b/.github/workflows/stage-latency-rotation.yml
@@ -1,0 +1,57 @@
+# Belt-and-suspenders rotation for data/audit/stage-latency.jsonl.
+#
+# emitStage() (scripts/lib/stage-latency.js) already self-rotates the log at
+# 40MB on every pipeline write, so this cron is a safety net for the case
+# where no pipeline writes for a while and the file sits oversized. It's
+# already on the ALLOW_LARGE allowlist in check-file-sizes/action.yml, so
+# the 5MB gate isn't at risk — this exists to stay well clear of GitHub's
+# 100MiB hard push limit (hit once at 100.15MB on 2026-07-05, blocked every
+# data-committing workflow for a day). BRO-54.
+name: Stage Latency Log Rotation
+
+on:
+  schedule:
+    # Daily at 3 AM UTC. Rotation only fires roughly once every ~20 days
+    # (log grows ~1MB/day, rotates at 40MB) — every other run is a cheap
+    # no-op exit.
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: stage-latency-rotation
+  cancel-in-progress: false
+
+jobs:
+  rotate:
+    name: Rotate stage-latency.jsonl if oversized
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/setup-node
+        with:
+          configure-git: 'true'
+
+      # scripts/stage-latency-rotation.sh is self-contained: it no-ops below
+      # the 40MB threshold, and when it rotates it commits + pushes itself
+      # via push-with-retry.sh. Rotation always shrinks the file, so a
+      # separate check-file-sizes step on this workflow's own commit would
+      # be structurally moot — intentionally not run here.
+      - name: Rotate stage-latency.jsonl
+        run: bash scripts/stage-latency-rotation.sh
+
+      - name: Notify on failure
+        if: failure()
+        uses: ./.github/actions/notify-failure
+        with:
+          title: 'Stage Latency Log Rotation Failed'
+          severity: 'warning'

--- a/scripts/stage-latency-rotation.sh
+++ b/scripts/stage-latency-rotation.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Cron-driven rotation of data/audit/stage-latency.jsonl.
+#
+# emitStage() (scripts/lib/stage-latency.js) already self-rotates the log at
+# MAX_LOG_BYTES (40MB) on every write, but that only fires from inside a
+# pipeline run that happens to append a line. If no pipeline writes for a
+# while — or a burst of writes lands the file just over the threshold right
+# before the last emitStage() call of a run — the oversized file can sit
+# committed until the next append. This script is the independent safety
+# net: run on a schedule, rotate unconditionally if oversized, commit and
+# push. Belt-and-suspenders for the incident that blocked
+# llm-ensemble-score.yml for ~30min on 2026-04-29 (BRO-54).
+#
+# Usage: bash scripts/stage-latency-rotation.sh
+# Exits 0 whether or not rotation was needed. Exits 1 only on an actual
+# rotation/commit/push failure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+LOG_FILE="data/audit/stage-latency.jsonl"
+
+if [ ! -f "$LOG_FILE" ]; then
+  echo "[stage-latency-rotation] $LOG_FILE does not exist yet — nothing to rotate"
+  exit 0
+fi
+
+SIZE_BEFORE=$(stat --format=%s "$LOG_FILE" 2>/dev/null || stat -f%z "$LOG_FILE" 2>/dev/null)
+echo "[stage-latency-rotation] $LOG_FILE is ${SIZE_BEFORE} bytes"
+
+ROTATE_STATUS=0
+node -e "
+  const { rotateIfNeeded } = require('./scripts/lib/stage-latency.js');
+  const rotated = rotateIfNeeded('$LOG_FILE');
+  process.exit(rotated ? 0 : 3);
+" || ROTATE_STATUS=$?
+
+if [ "$ROTATE_STATUS" -eq 3 ]; then
+  echo "[stage-latency-rotation] below rotation threshold — no changes"
+  exit 0
+elif [ "$ROTATE_STATUS" -ne 0 ]; then
+  echo "[stage-latency-rotation] rotateIfNeeded failed (exit $ROTATE_STATUS)" >&2
+  exit 1
+fi
+
+if git diff --quiet -- "$LOG_FILE"; then
+  echo "[stage-latency-rotation] rotation ran but produced no diff — nothing to commit"
+  exit 0
+fi
+
+SIZE_AFTER=$(stat --format=%s "$LOG_FILE" 2>/dev/null || stat -f%z "$LOG_FILE" 2>/dev/null)
+echo "[stage-latency-rotation] rotated: ${SIZE_BEFORE} -> ${SIZE_AFTER} bytes"
+
+git add "$LOG_FILE"
+git commit -m "chore: Rotate stage-latency.jsonl (${SIZE_BEFORE} -> ${SIZE_AFTER} bytes) [skip ci]"
+
+bash scripts/lib/push-with-retry.sh


### PR DESCRIPTION
## Summary
- Adds `scripts/stage-latency-rotation.sh` + `.github/workflows/stage-latency-rotation.yml`: a daily cron safety net that rotates `data/audit/stage-latency.jsonl` if it's grown past 40MB (calls the existing tested `rotateIfNeeded()` from `scripts/lib/stage-latency.js`), commits, and pushes via `push-with-retry.sh`.
- `emitStage()` already self-rotates the log inline on every pipeline write; this cron only matters if no pipeline writes for a while and the file sits oversized.
- Confirmed `stage-latency.jsonl` is already on the `ALLOW_LARGE` allowlist in `check-file-sizes/action.yml` (added 2026-05-16) with a 90MiB hard-cap check (added 2026-07-05) — the acute gate-blocking incident (BRO-54's origin, 2026-04-29) is already mitigated there. This cron is defense-in-depth against the file creeping toward GitHub's 100MiB hard push limit between pipeline runs.
- Exempted the new cron from `check-cron-health.yml` real-time paging via `.cron-health-exempt.txt` (digest-only — a missed run just delays rotation, no user-facing staleness).

## Test plan
- [x] `node --test tests/unit/stage-latency.test.mjs` — 15/15 pass (existing `rotateIfNeeded` coverage)
- [x] `node --test tests/smoke/stage-latency-wiring.test.mjs` — 4/4 pass
- [x] Ran `scripts/stage-latency-rotation.sh` against real data: below-threshold no-op, missing-file no-op, and an artificially-oversized copy (rotation + local commit verified, then reverted — never pushed)
- [x] `npx actionlint .github/workflows/stage-latency-rotation.yml` — clean
- [x] `shellcheck scripts/stage-latency-rotation.sh` — clean
- [x] `node scripts/audit-workflow-hygiene.js` — passes (231 workflows)
- [x] `node scripts/audit-cron-health-coverage.js` — 0 uncovered scheduled workflows
- [x] `npx tsc --noEmit` — clean
- [x] `/second-opinion` plan review — pass, recorded via `review-gate.mjs --query=record-plan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)