### PR TITLE
BRO-75: wrongProduction exclusion-volume analysis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -928,6 +928,14 @@ on:
       - 'tests/unit/stage-latency.test.mjs'
       - 'tests/unit/opening-night-sla.test.mjs'
       - 'tests/unit/opening-night-latency-report.test.mjs'
+      # BRO-75: wrongProduction exclusion-volume analysis (distinguishes
+      # sticky-flag re-logging across rebuild passes from genuine new
+      # over-blocking). Colocated scripts/wrong-production-exclusion-
+      # analysis.test.mjs runs in the tests/unit-test-manifest.txt batch;
+      # these source entries make a solo edit trigger it.
+      - 'scripts/lib/wrong-production-exclusion-analysis.js'
+      - 'scripts/wrong-production-exclusion-analysis.js'
+      - 'scripts/wrong-production-exclusion-analysis.test.mjs'
       # Pull-quote guards decide the excerpt shown on every review card. The
       # 2026-08-01 owner report (listing chrome / tag cloud / mid-word
       # truncation / hedge-guard starvation) added hard + soft guards here and

--- a/.gitignore
+++ b/.gitignore
@@ -287,6 +287,9 @@ BroadwayScorecard/data/theatr-refresh-token.tmp
 # Structural #1 — daily exclusion logs (may contain URLs, not committed)
 /data/audit/exclusions-*.jsonl
 /data/audit/exclusion-summary-yesterday.json
+# BRO-75: cross-day seen-files ledger for wrong-production-exclusion-analysis.js
+# — local-only ad-hoc investigation state, same reasoning as exclusions-*.jsonl
+/data/audit/wrongproduction-seen-files.json
 /data/integrity-report.md
 /data/review-reports/
 

--- a/scripts/lib/wrong-production-exclusion-analysis.js
+++ b/scripts/lib/wrong-production-exclusion-analysis.js
@@ -1,0 +1,123 @@
+'use strict';
+
+/**
+ * BRO-75: analyzes exclusion-logger output for the `skippedWrongProduction`
+ * reason to distinguish genuine over-blocking from log noise.
+ *
+ * Root cause found investigating beetlejuice-2022's reported 261/day volume:
+ * rebuild-all-reviews.js re-logs `skippedWrongProduction` for every review
+ * file that still carries `wrongProduction: true` on EVERY rebuild pass (the
+ * flag is sticky — nothing clears it once set, see rebuild-all-reviews.js
+ * ~line 2805). beetlejuice-2022 has 94 files flagged wrongProduction, all
+ * touring/prior-run reviews correctly excluded (2019 NYT/Post/Vulture
+ * reviews of the original run, scraped into the 2022 return-engagement show
+ * ID; BWW national-tour city reviews). 94 files x ~3 rebuild runs/day ≈ 261
+ * log lines — the same known-bad files re-logged, not 261 new mistakes.
+ * moulin-rouge-the-musical-west-end-2021 (82/114 flagged) and
+ * pretty-woman-the-musical-2018 (75/129 flagged) show the identical pattern.
+ */
+
+/**
+ * Parse a raw exclusions-YYYY-MM-DD.jsonl file (or any JSONL text) into an
+ * array of exclusion-logger records. Skips blank lines and non-JSON lines.
+ */
+function parseExclusionLog(jsonlText) {
+  const records = [];
+  for (const line of String(jsonlText || '').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      records.push(JSON.parse(trimmed));
+    } catch {
+      // not a JSON line (e.g. a stray log header) — skip
+    }
+  }
+  return records;
+}
+
+/**
+ * Group wrongProduction exclusion records by show, tracking both the raw
+ * log-line count and the count of DISTINCT (showId, file) pairs.
+ *
+ * Why the distinction matters: a show with N already-flagged files and R
+ * rebuild runs in a day logs ~N*R lines even though zero NEW reviews were
+ * excluded that day. Raw volume alone can't tell "newly over-blocking this
+ * show" apart from "rebuild ran a few times and re-logged the same
+ * known-bad files."
+ */
+function summarizeByShow(records) {
+  const byShow = new Map();
+  for (const rec of records) {
+    if (!rec || rec.reason !== 'skippedWrongProduction') continue;
+    const showId = rec.showId || 'unknown';
+    if (!byShow.has(showId)) {
+      byShow.set(showId, { showId, totalLines: 0, files: new Set() });
+    }
+    const entry = byShow.get(showId);
+    entry.totalLines++;
+    entry.files.add(rec.file || '-');
+  }
+  return byShow;
+}
+
+const DEFAULT_REPEAT_THRESHOLD = 1.5;
+const DEFAULT_DISTINCT_FILE_THRESHOLD = 10;
+
+/**
+ * Categorize one show's exclusion volume.
+ *
+ * - REPEATED_LOGGING: the same small set of files re-logged across multiple
+ *   rebuild runs (high totalLines, low distinct-file-to-line ratio). Not
+ *   evidence of over-blocking — log noise from a sticky flag.
+ * - NEEDS_REVIEW: many DISTINCT files excluded, each close to once. A real
+ *   signal of newly-excluded content — warrants a content-level audit (see
+ *   scripts/audit-wrong-production.js).
+ * - NORMAL: low volume either way.
+ */
+function categorizeShow(entry, opts = {}) {
+  const repeatThreshold = opts.repeatThreshold ?? DEFAULT_REPEAT_THRESHOLD;
+  const distinctFileThreshold = opts.distinctFileThreshold ?? DEFAULT_DISTINCT_FILE_THRESHOLD;
+
+  const distinctFiles = entry.files.size;
+  const repeatMultiplier = distinctFiles > 0 ? entry.totalLines / distinctFiles : 0;
+
+  let category;
+  if (repeatMultiplier >= repeatThreshold) {
+    category = 'REPEATED_LOGGING';
+  } else if (distinctFiles >= distinctFileThreshold) {
+    category = 'NEEDS_REVIEW';
+  } else {
+    category = 'NORMAL';
+  }
+
+  return {
+    showId: entry.showId,
+    totalLines: entry.totalLines,
+    distinctFiles,
+    repeatMultiplier: Math.round(repeatMultiplier * 100) / 100,
+    category,
+  };
+}
+
+/**
+ * Full pipeline: JSONL text -> per-show categorized summaries, sorted by
+ * total log volume descending (matches how "top shows by exclusion count"
+ * gets read).
+ */
+function analyzeExclusionLog(jsonlText, opts) {
+  const records = parseExclusionLog(jsonlText);
+  const byShow = summarizeByShow(records);
+  const results = [];
+  for (const entry of byShow.values()) {
+    results.push(categorizeShow(entry, opts));
+  }
+  results.sort((a, b) => b.totalLines - a.totalLines);
+  return results;
+}
+
+module.exports = {
+  parseExclusionLog,
+  summarizeByShow,
+  categorizeShow,
+  analyzeExclusionLog,
+};

--- a/scripts/lib/wrong-production-exclusion-analysis.js
+++ b/scripts/lib/wrong-production-exclusion-analysis.js
@@ -62,27 +62,55 @@ function summarizeByShow(records) {
 
 const DEFAULT_REPEAT_THRESHOLD = 1.5;
 const DEFAULT_DISTINCT_FILE_THRESHOLD = 10;
+const DEFAULT_NEW_FILE_THRESHOLD = 1;
 
 /**
  * Categorize one show's exclusion volume.
  *
- * - REPEATED_LOGGING: the same small set of files re-logged across multiple
- *   rebuild runs (high totalLines, low distinct-file-to-line ratio). Not
- *   evidence of over-blocking — log noise from a sticky flag.
- * - NEEDS_REVIEW: many DISTINCT files excluded, each close to once. A real
- *   signal of newly-excluded content — warrants a content-level audit (see
- *   scripts/audit-wrong-production.js).
- * - NORMAL: low volume either way.
+ * `opts.knownFiles` (a Set of filenames already flagged as of a PRIOR day,
+ * loaded from the cross-day ledger — see loadSeenLedger/CLI wrapper) is what
+ * makes this actually distinguish new mistakes from stale re-logging.
+ * Without it, a same-day repeat count alone can't tell "flagged for the
+ * first time this morning, re-logged on the next 2 rebuild passes" (3 lines,
+ * 1 file, repeatMultiplier 3 — indistinguishable from a file that's been
+ * flagged for months) from genuine staleness. When `knownFiles` is provided:
+ *
+ * - NEEDS_REVIEW: at least one file in today's log is NOT in `knownFiles` —
+ *   a genuinely new exclusion, regardless of how noisy the rest of the
+ *   show's re-logging is. This is the case a pure repeat-ratio heuristic
+ *   masks (see analyzeExclusionLog's `newFiles` plumbing).
+ * - REPEATED_LOGGING: every file in today's log is already in `knownFiles`
+ *   and got re-logged across multiple rebuild passes. Log noise, not
+ *   over-blocking.
+ * - NORMAL: low volume, nothing new.
+ *
+ * Without `knownFiles` (single-day snapshot, e.g. a first run with no
+ * ledger yet), falls back to the same-day repeat-ratio heuristic: a high
+ * totalLines/distinctFiles ratio still doesn't prove staleness, but it's the
+ * best available signal until a ledger exists.
  */
 function categorizeShow(entry, opts = {}) {
   const repeatThreshold = opts.repeatThreshold ?? DEFAULT_REPEAT_THRESHOLD;
   const distinctFileThreshold = opts.distinctFileThreshold ?? DEFAULT_DISTINCT_FILE_THRESHOLD;
+  const newFileThreshold = opts.newFileThreshold ?? DEFAULT_NEW_FILE_THRESHOLD;
 
   const distinctFiles = entry.files.size;
   const repeatMultiplier = distinctFiles > 0 ? entry.totalLines / distinctFiles : 0;
 
+  let newFileCount = null;
+  if (opts.knownFiles instanceof Set) {
+    newFileCount = 0;
+    for (const file of entry.files) {
+      if (!opts.knownFiles.has(file)) newFileCount++;
+    }
+  }
+
   let category;
-  if (repeatMultiplier >= repeatThreshold) {
+  if (newFileCount !== null) {
+    // Ledger available: new-file evidence takes priority over repeat noise.
+    category = newFileCount >= newFileThreshold ? 'NEEDS_REVIEW' : 'REPEATED_LOGGING';
+    if (newFileCount === 0 && repeatMultiplier < repeatThreshold) category = 'NORMAL';
+  } else if (repeatMultiplier >= repeatThreshold) {
     category = 'REPEATED_LOGGING';
   } else if (distinctFiles >= distinctFileThreshold) {
     category = 'NEEDS_REVIEW';
@@ -95,6 +123,7 @@ function categorizeShow(entry, opts = {}) {
     totalLines: entry.totalLines,
     distinctFiles,
     repeatMultiplier: Math.round(repeatMultiplier * 100) / 100,
+    ...(newFileCount !== null ? { newFileCount } : {}),
     category,
   };
 }
@@ -103,16 +132,46 @@ function categorizeShow(entry, opts = {}) {
  * Full pipeline: JSONL text -> per-show categorized summaries, sorted by
  * total log volume descending (matches how "top shows by exclusion count"
  * gets read).
+ *
+ * `opts.knownFilesByShow` (Map<showId, Set<file>> | Record<showId, string[]>)
+ * is forwarded per-show as `knownFiles` to categorizeShow — pass the
+ * cross-day ledger here to get real new-vs-stale categorization.
  */
-function analyzeExclusionLog(jsonlText, opts) {
+function analyzeExclusionLog(jsonlText, opts = {}) {
   const records = parseExclusionLog(jsonlText);
   const byShow = summarizeByShow(records);
   const results = [];
   for (const entry of byShow.values()) {
-    results.push(categorizeShow(entry, opts));
+    const perShowOpts = { ...opts };
+    delete perShowOpts.knownFilesByShow;
+    if (opts.knownFilesByShow) {
+      const raw = opts.knownFilesByShow instanceof Map
+        ? opts.knownFilesByShow.get(entry.showId)
+        : opts.knownFilesByShow[entry.showId];
+      if (raw) perShowOpts.knownFiles = raw instanceof Set ? raw : new Set(raw);
+    }
+    results.push(categorizeShow(entry, perShowOpts));
   }
   results.sort((a, b) => b.totalLines - a.totalLines);
   return results;
+}
+
+/**
+ * Build the next cross-day ledger snapshot: union of everything previously
+ * known with everything seen in today's log, per show. The CLI wrapper
+ * persists this to disk so tomorrow's run can tell new files from old ones.
+ */
+function buildNextLedger(records, previousLedger = {}) {
+  const byShow = summarizeByShow(records);
+  const next = {};
+  const showIds = new Set([...Object.keys(previousLedger), ...byShow.keys()]);
+  for (const showId of showIds) {
+    const known = new Set(previousLedger[showId] || []);
+    const entry = byShow.get(showId);
+    if (entry) for (const file of entry.files) known.add(file);
+    next[showId] = [...known].sort();
+  }
+  return next;
 }
 
 module.exports = {
@@ -120,4 +179,5 @@ module.exports = {
   summarizeByShow,
   categorizeShow,
   analyzeExclusionLog,
+  buildNextLedger,
 };

--- a/scripts/wrong-production-exclusion-analysis.js
+++ b/scripts/wrong-production-exclusion-analysis.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * BRO-75: reports per-show `skippedWrongProduction` exclusion volume from
+ * data/audit/exclusions-YYYY-MM-DD.jsonl, categorized as REPEATED_LOGGING
+ * (same already-flagged files re-logged across rebuild runs — not
+ * over-blocking) vs NEEDS_REVIEW (many distinct newly-excluded files —
+ * worth a content audit) vs NORMAL.
+ *
+ * The exclusions-*.jsonl files are gitignored/ephemeral (written fresh by
+ * each CI run), so this reads whatever is present locally or via --file.
+ *
+ * Usage:
+ *   node scripts/wrong-production-exclusion-analysis.js [--date=YYYY-MM-DD] [--file=path]
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { analyzeExclusionLog } = require('./lib/wrong-production-exclusion-analysis');
+
+const argv = process.argv.slice(2);
+const dateArg = argv.find(a => a.startsWith('--date='))?.split('=')[1];
+const fileArg = argv.find(a => a.startsWith('--file='))?.split('=')[1];
+
+const auditDir = process.env.EXCLUSION_LOGGER_AUDIT_DIR || path.join(__dirname, '../data/audit');
+const targetFile = fileArg
+  ? path.resolve(fileArg)
+  : path.join(auditDir, `exclusions-${dateArg || new Date().toISOString().slice(0, 10)}.jsonl`);
+
+let jsonlText;
+try {
+  jsonlText = fs.readFileSync(targetFile, 'utf8');
+} catch (e) {
+  console.error(`Could not read ${targetFile}: ${e.message}`);
+  console.error('exclusions-*.jsonl is gitignored/ephemeral — pass --file=path to analyze an archived copy.');
+  process.exit(1);
+}
+
+const results = analyzeExclusionLog(jsonlText);
+
+if (results.length === 0) {
+  console.log(`No skippedWrongProduction exclusions found in ${targetFile}`);
+  process.exit(0);
+}
+
+console.log(`\n=== wrongProduction exclusion volume: ${path.basename(targetFile)} ===\n`);
+for (const r of results) {
+  const flag = r.category === 'NEEDS_REVIEW' ? '⚠️ ' : '';
+  console.log(`${flag}${r.showId}: ${r.totalLines} lines, ${r.distinctFiles} distinct files, ${r.repeatMultiplier}x repeat -> ${r.category}`);
+}
+
+const needsReview = results.filter(r => r.category === 'NEEDS_REVIEW');
+if (needsReview.length > 0) {
+  console.log(`\n${needsReview.length} show(s) flagged NEEDS_REVIEW — run scripts/audit-wrong-production.js --show=<id> for a content-level check.`);
+}

--- a/scripts/wrong-production-exclusion-analysis.js
+++ b/scripts/wrong-production-exclusion-analysis.js
@@ -2,29 +2,38 @@
 /**
  * BRO-75: reports per-show `skippedWrongProduction` exclusion volume from
  * data/audit/exclusions-YYYY-MM-DD.jsonl, categorized as REPEATED_LOGGING
- * (same already-flagged files re-logged across rebuild runs — not
- * over-blocking) vs NEEDS_REVIEW (many distinct newly-excluded files —
- * worth a content audit) vs NORMAL.
+ * (already-known files re-logged across rebuild runs — not over-blocking)
+ * vs NEEDS_REVIEW (genuinely new exclusions today — worth a content audit)
+ * vs NORMAL.
+ *
+ * Cross-day ledger (data/audit/wrongproduction-seen-files.json, gitignored
+ * like the rest of data/audit): each run diffs today's exclusion log against
+ * files already known from prior runs, so "new file excluded today" and
+ * "same file re-logged every rebuild pass" are told apart by actual history
+ * instead of guessed from a single day's repeat count. Without a ledger yet
+ * (first run), falls back to the same-day repeat-ratio heuristic.
  *
  * The exclusions-*.jsonl files are gitignored/ephemeral (written fresh by
  * each CI run), so this reads whatever is present locally or via --file.
  *
  * Usage:
- *   node scripts/wrong-production-exclusion-analysis.js [--date=YYYY-MM-DD] [--file=path]
+ *   node scripts/wrong-production-exclusion-analysis.js [--date=YYYY-MM-DD] [--file=path] [--no-ledger]
  */
 
 const fs = require('fs');
 const path = require('path');
-const { analyzeExclusionLog } = require('./lib/wrong-production-exclusion-analysis');
+const { parseExclusionLog, analyzeExclusionLog, buildNextLedger } = require('./lib/wrong-production-exclusion-analysis');
 
 const argv = process.argv.slice(2);
 const dateArg = argv.find(a => a.startsWith('--date='))?.split('=')[1];
 const fileArg = argv.find(a => a.startsWith('--file='))?.split('=')[1];
+const useLedger = !argv.includes('--no-ledger');
 
 const auditDir = process.env.EXCLUSION_LOGGER_AUDIT_DIR || path.join(__dirname, '../data/audit');
 const targetFile = fileArg
   ? path.resolve(fileArg)
   : path.join(auditDir, `exclusions-${dateArg || new Date().toISOString().slice(0, 10)}.jsonl`);
+const ledgerFile = path.join(auditDir, 'wrongproduction-seen-files.json');
 
 let jsonlText;
 try {
@@ -35,7 +44,17 @@ try {
   process.exit(1);
 }
 
-const results = analyzeExclusionLog(jsonlText);
+let previousLedger = {};
+if (useLedger) {
+  try {
+    previousLedger = JSON.parse(fs.readFileSync(ledgerFile, 'utf8'));
+  } catch {
+    // no ledger yet — first run falls back to the same-day heuristic
+  }
+}
+
+const knownFilesByShow = useLedger && Object.keys(previousLedger).length > 0 ? previousLedger : undefined;
+const results = analyzeExclusionLog(jsonlText, { knownFilesByShow });
 
 if (results.length === 0) {
   console.log(`No skippedWrongProduction exclusions found in ${targetFile}`);
@@ -43,12 +62,23 @@ if (results.length === 0) {
 }
 
 console.log(`\n=== wrongProduction exclusion volume: ${path.basename(targetFile)} ===\n`);
+if (!knownFilesByShow) {
+  console.log('(no cross-day ledger yet — using same-day repeat-ratio heuristic; a ledger will be written for next time)\n');
+}
 for (const r of results) {
   const flag = r.category === 'NEEDS_REVIEW' ? '⚠️ ' : '';
-  console.log(`${flag}${r.showId}: ${r.totalLines} lines, ${r.distinctFiles} distinct files, ${r.repeatMultiplier}x repeat -> ${r.category}`);
+  const newFilePart = r.newFileCount !== undefined ? `, ${r.newFileCount} new` : '';
+  console.log(`${flag}${r.showId}: ${r.totalLines} lines, ${r.distinctFiles} distinct files${newFilePart}, ${r.repeatMultiplier}x repeat -> ${r.category}`);
 }
 
 const needsReview = results.filter(r => r.category === 'NEEDS_REVIEW');
 if (needsReview.length > 0) {
   console.log(`\n${needsReview.length} show(s) flagged NEEDS_REVIEW — run scripts/audit-wrong-production.js --show=<id> for a content-level check.`);
+}
+
+if (useLedger) {
+  const records = parseExclusionLog(jsonlText);
+  const nextLedger = buildNextLedger(records, previousLedger);
+  fs.mkdirSync(path.dirname(ledgerFile), { recursive: true });
+  fs.writeFileSync(ledgerFile, JSON.stringify(nextLedger, null, 2));
 }

--- a/scripts/wrong-production-exclusion-analysis.test.mjs
+++ b/scripts/wrong-production-exclusion-analysis.test.mjs
@@ -19,6 +19,7 @@ const {
   summarizeByShow,
   categorizeShow,
   analyzeExclusionLog,
+  buildNextLedger,
 } = require('./lib/wrong-production-exclusion-analysis');
 
 function exclusionLine({ showId, file, ts, url }) {
@@ -133,6 +134,37 @@ describe('categorizeShow — REPEATED_LOGGING vs NEEDS_REVIEW (BRO-75 core quest
     assert.equal(result.repeatMultiplier, 0);
     assert.equal(result.category, 'NORMAL');
   });
+
+  it('with a knownFiles ledger, surfaces a genuinely new file even when it is buried among heavily re-logged stale files', () => {
+    // The gap a same-day-only repeat ratio can't see: 20 stale files each
+    // re-logged 3x (60 lines, repeatMultiplier 3 -> would read as pure
+    // REPEATED_LOGGING) PLUS 1 brand-new file logged once. Total volume
+    // (61 lines / 21 files) still looks noise-dominated by ratio alone, but
+    // the ledger diff must still catch the 1 new file.
+    const staleFiles = Array.from({ length: 20 }, (_, i) => `stale-${i}.json`);
+    const files = new Set([...staleFiles, 'brand-new-review.json']);
+    const entry = { showId: 'mixed-show', totalLines: 61, files };
+    const knownFiles = new Set(staleFiles); // everything except the new one was already known
+    const result = categorizeShow(entry, { knownFiles });
+    assert.equal(result.category, 'NEEDS_REVIEW');
+    assert.equal(result.newFileCount, 1);
+  });
+
+  it('with a knownFiles ledger, categorizes an all-known show as REPEATED_LOGGING regardless of ratio', () => {
+    const files = new Set(['a.json', 'b.json']);
+    const entry = { showId: 'all-known', totalLines: 6, files };
+    const result = categorizeShow(entry, { knownFiles: new Set(['a.json', 'b.json']) });
+    assert.equal(result.category, 'REPEATED_LOGGING');
+    assert.equal(result.newFileCount, 0);
+  });
+
+  it('with a knownFiles ledger, categorizes a single known file logged once as NORMAL', () => {
+    const files = new Set(['a.json']);
+    const entry = { showId: 'quiet', totalLines: 1, files };
+    const result = categorizeShow(entry, { knownFiles: new Set(['a.json']) });
+    assert.equal(result.category, 'NORMAL');
+    assert.equal(result.newFileCount, 0);
+  });
 });
 
 describe('analyzeExclusionLog — end to end', () => {
@@ -170,5 +202,71 @@ describe('analyzeExclusionLog — end to end', () => {
   it('returns [] for a log with no wrongProduction exclusions', () => {
     const lines = [JSON.stringify({ showId: 'a', file: 'x.json', reason: 'skippedDuplicateOf' })];
     assert.deepEqual(analyzeExclusionLog(lines.join('\n')), []);
+  });
+
+  it('with knownFilesByShow, distinguishes a new-file spike from stale re-logging on the SAME day — the case a repeat-ratio-only heuristic masks', () => {
+    // beetlejuice-2022: 94 files re-logged 3x today (282 lines) — all
+    // already in the ledger from prior days. Without a ledger this reads
+    // REPEATED_LOGGING purely from the ratio, same as with one; the real
+    // test is the show below.
+    const knownBeetlejuiceFiles = Array.from({ length: 94 }, (_, i) => `outlet-${i}.json`);
+    const lines = [];
+    for (let run = 0; run < 3; run++) {
+      for (const file of knownBeetlejuiceFiles) {
+        lines.push(exclusionLine({ showId: 'beetlejuice-2022', file, ts: `2026-04-17T0${run}:00:00.000Z` }));
+      }
+    }
+    // some-show-2026: 30 stale known files re-logged 3x (90 lines) PLUS 2
+    // brand-new files logged once each. Same-day repeat ratio for the whole
+    // show (92/32 ≈ 2.9x) reads as pure REPEATED_LOGGING and would hide the
+    // 2 new mistakes — the ledger diff must not.
+    const knownOtherFiles = Array.from({ length: 30 }, (_, i) => `known-${i}.json`);
+    for (let run = 0; run < 3; run++) {
+      for (const file of knownOtherFiles) {
+        lines.push(exclusionLine({ showId: 'some-show-2026', file, ts: `2026-04-17T0${run}:00:00.000Z` }));
+      }
+    }
+    lines.push(exclusionLine({ showId: 'some-show-2026', file: 'genuinely-new-1.json' }));
+    lines.push(exclusionLine({ showId: 'some-show-2026', file: 'genuinely-new-2.json' }));
+
+    const knownFilesByShow = {
+      'beetlejuice-2022': knownBeetlejuiceFiles,
+      'some-show-2026': knownOtherFiles,
+    };
+
+    const results = analyzeExclusionLog(lines.join('\n'), { knownFilesByShow });
+    const byShowId = Object.fromEntries(results.map(r => [r.showId, r]));
+
+    assert.equal(byShowId['beetlejuice-2022'].category, 'REPEATED_LOGGING');
+    assert.equal(byShowId['beetlejuice-2022'].newFileCount, 0);
+
+    assert.equal(byShowId['some-show-2026'].category, 'NEEDS_REVIEW');
+    assert.equal(byShowId['some-show-2026'].newFileCount, 2);
+  });
+});
+
+describe('buildNextLedger', () => {
+  it('unions previously-known files with files seen in today\'s log, per show', () => {
+    const records = [
+      JSON.parse(exclusionLine({ showId: 'a', file: 'new.json' })),
+      JSON.parse(exclusionLine({ showId: 'a', file: 'already-known.json' })),
+    ];
+    const previous = { a: ['already-known.json'], b: ['untouched-today.json'] };
+    const next = buildNextLedger(records, previous);
+    assert.deepEqual(next.a.sort(), ['already-known.json', 'new.json']);
+    // shows with no exclusions today keep their prior entries
+    assert.deepEqual(next.b, ['untouched-today.json']);
+  });
+
+  it('starts from an empty ledger on first run', () => {
+    const records = [JSON.parse(exclusionLine({ showId: 'a', file: 'x.json' }))];
+    const next = buildNextLedger(records, {});
+    assert.deepEqual(next, { a: ['x.json'] });
+  });
+
+  it('ignores exclusion reasons other than skippedWrongProduction', () => {
+    const records = [{ showId: 'a', file: 'x.json', reason: 'skippedDuplicateOf' }];
+    const next = buildNextLedger(records, {});
+    assert.deepEqual(next, {});
   });
 });

--- a/scripts/wrong-production-exclusion-analysis.test.mjs
+++ b/scripts/wrong-production-exclusion-analysis.test.mjs
@@ -1,0 +1,174 @@
+/**
+ * wrong-production-exclusion-analysis.test.mjs — BRO-75 acceptance suite.
+ *
+ * Confirms the analysis correctly distinguishes REPEATED_LOGGING (the same
+ * already-flagged review files re-logged across multiple rebuild passes —
+ * log noise, not over-blocking) from NEEDS_REVIEW (many distinct newly
+ * excluded files — a real signal worth a content audit). The real function
+ * is require()d (CLAUDE.md rule 15) — change the thresholds in production
+ * code and these tests fail.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  parseExclusionLog,
+  summarizeByShow,
+  categorizeShow,
+  analyzeExclusionLog,
+} = require('./lib/wrong-production-exclusion-analysis');
+
+function exclusionLine({ showId, file, ts, url }) {
+  return JSON.stringify({
+    ts: ts || '2026-04-17T00:00:00.000Z',
+    script: 'rebuild-all-reviews',
+    showId,
+    file,
+    reason: 'skippedWrongProduction',
+    details: { url, outletId: 'broadwayworld', criticName: 'unknown', publishDate: undefined },
+  });
+}
+
+describe('parseExclusionLog', () => {
+  it('parses one JSON object per line', () => {
+    const text = [
+      exclusionLine({ showId: 'a', file: 'x.json' }),
+      exclusionLine({ showId: 'b', file: 'y.json' }),
+    ].join('\n');
+    const records = parseExclusionLog(text);
+    assert.equal(records.length, 2);
+    assert.equal(records[0].showId, 'a');
+    assert.equal(records[1].showId, 'b');
+  });
+
+  it('skips blank lines and non-JSON garbage without throwing', () => {
+    const text = [
+      '',
+      '   ',
+      'not json at all',
+      exclusionLine({ showId: 'a', file: 'x.json' }),
+      '',
+    ].join('\n');
+    const records = parseExclusionLog(text);
+    assert.equal(records.length, 1);
+    assert.equal(records[0].showId, 'a');
+  });
+
+  it('returns [] for empty input', () => {
+    assert.deepEqual(parseExclusionLog(''), []);
+    assert.deepEqual(parseExclusionLog(undefined), []);
+  });
+});
+
+describe('summarizeByShow', () => {
+  it('ignores exclusion reasons other than skippedWrongProduction', () => {
+    const records = [
+      JSON.parse(exclusionLine({ showId: 'a', file: 'x.json' })),
+      { showId: 'a', file: 'x.json', reason: 'skippedDuplicateOf' },
+      { showId: 'a', file: 'y.json', reason: 'skippedNotReview' },
+    ];
+    const byShow = summarizeByShow(records);
+    assert.equal(byShow.size, 1);
+    assert.equal(byShow.get('a').totalLines, 1);
+  });
+
+  it('tracks distinct files separately from total log lines', () => {
+    const records = [
+      JSON.parse(exclusionLine({ showId: 'a', file: 'x.json' })),
+      JSON.parse(exclusionLine({ showId: 'a', file: 'x.json' })),
+      JSON.parse(exclusionLine({ showId: 'a', file: 'y.json' })),
+    ];
+    const byShow = summarizeByShow(records);
+    const entry = byShow.get('a');
+    assert.equal(entry.totalLines, 3);
+    assert.equal(entry.files.size, 2);
+  });
+});
+
+describe('categorizeShow — REPEATED_LOGGING vs NEEDS_REVIEW (BRO-75 core question)', () => {
+  it('categorizes the beetlejuice-2022 shape as REPEATED_LOGGING, not over-blocking', () => {
+    // Real-world shape from investigation: 94 distinct files (2019
+    // original-run reviews + national-tour BWW reviews scraped into the
+    // 2022 show ID), each re-logged on 3 same-day rebuild runs — the
+    // reported 261/day volume (94 * ~2.78 rebuild passes).
+    const files = new Set(Array.from({ length: 94 }, (_, i) => `outlet-${i}.json`));
+    const entry = { showId: 'beetlejuice-2022', totalLines: 261, files };
+    const result = categorizeShow(entry);
+    assert.equal(result.category, 'REPEATED_LOGGING');
+    assert.equal(result.distinctFiles, 94);
+    assert.ok(result.repeatMultiplier > 2.5 && result.repeatMultiplier < 3,
+      `expected ~2.78x repeat, got ${result.repeatMultiplier}`);
+  });
+
+  it('categorizes many distinct single-occurrence exclusions as NEEDS_REVIEW', () => {
+    // Contrast case: 20 DISTINCT files, each excluded exactly once — a
+    // genuine new-exclusion spike, not stale re-logging.
+    const files = new Set(Array.from({ length: 20 }, (_, i) => `new-review-${i}.json`));
+    const entry = { showId: 'some-new-show-2026', totalLines: 20, files };
+    const result = categorizeShow(entry);
+    assert.equal(result.category, 'NEEDS_REVIEW');
+    assert.equal(result.repeatMultiplier, 1);
+  });
+
+  it('categorizes low volume as NORMAL', () => {
+    const files = new Set(['x.json', 'y.json']);
+    const entry = { showId: 'quiet-show', totalLines: 2, files };
+    const result = categorizeShow(entry);
+    assert.equal(result.category, 'NORMAL');
+  });
+
+  it('respects custom thresholds', () => {
+    const files = new Set(['x.json', 'y.json']);
+    const entry = { showId: 'show', totalLines: 3, files }; // 1.5x repeat
+    assert.equal(categorizeShow(entry, { repeatThreshold: 2 }).category, 'NORMAL');
+    assert.equal(categorizeShow(entry, { repeatThreshold: 1.5 }).category, 'REPEATED_LOGGING');
+  });
+
+  it('handles a show with zero tracked files without dividing by zero', () => {
+    const entry = { showId: 'empty', totalLines: 0, files: new Set() };
+    const result = categorizeShow(entry);
+    assert.equal(result.repeatMultiplier, 0);
+    assert.equal(result.category, 'NORMAL');
+  });
+});
+
+describe('analyzeExclusionLog — end to end', () => {
+  it('distinguishes REPEATED_LOGGING from NEEDS_REVIEW across multiple shows in one log, sorted by volume', () => {
+    const lines = [];
+    // beetlejuice-2022: 5 known-bad files, logged 3x (3 rebuild runs) = 15 lines.
+    for (let run = 0; run < 3; run++) {
+      for (let i = 0; i < 5; i++) {
+        lines.push(exclusionLine({ showId: 'beetlejuice-2022', file: `outlet-${i}.json`, ts: `2026-04-17T0${run}:00:00.000Z` }));
+      }
+    }
+    // a show with 12 genuinely distinct new exclusions, logged once each.
+    for (let i = 0; i < 12; i++) {
+      lines.push(exclusionLine({ showId: 'genuinely-over-blocked-show', file: `review-${i}.json` }));
+    }
+    // an unrelated reason on the same show — must not be counted.
+    lines.push(JSON.stringify({ showId: 'beetlejuice-2022', file: 'ignored.json', reason: 'skippedDuplicateOf' }));
+
+    const results = analyzeExclusionLog(lines.join('\n'));
+    assert.equal(results.length, 2);
+
+    const byShowId = Object.fromEntries(results.map(r => [r.showId, r]));
+    assert.equal(byShowId['beetlejuice-2022'].category, 'REPEATED_LOGGING');
+    assert.equal(byShowId['beetlejuice-2022'].totalLines, 15);
+    assert.equal(byShowId['beetlejuice-2022'].distinctFiles, 5);
+
+    assert.equal(byShowId['genuinely-over-blocked-show'].category, 'NEEDS_REVIEW');
+    assert.equal(byShowId['genuinely-over-blocked-show'].totalLines, 12);
+    assert.equal(byShowId['genuinely-over-blocked-show'].distinctFiles, 12);
+
+    // sorted by total volume descending
+    assert.equal(results[0].showId, 'beetlejuice-2022');
+  });
+
+  it('returns [] for a log with no wrongProduction exclusions', () => {
+    const lines = [JSON.stringify({ showId: 'a', file: 'x.json', reason: 'skippedDuplicateOf' })];
+    assert.deepEqual(analyzeExclusionLog(lines.join('\n')), []);
+  });
+});

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -111,6 +111,7 @@ scripts/tests/tracked-and-ignored-guard.test.mjs
 scripts/tests/trunk-status.test.mjs
 scripts/tests/verify-edits-heredoc.test.mjs
 scripts/verify-contamination-gate.test.mjs
+scripts/wrong-production-exclusion-analysis.test.mjs
 tests/unit/1minutecritic-extractor.test.mjs
 tests/unit/aggregator-url-latent.test.mjs
 tests/unit/alert-email-policy.test.mjs


### PR DESCRIPTION
## Summary
- Investigated BRO-75's reported 261/day beetlejuice-2022 wrongProduction exclusion volume against the real private review-texts corpus — confirmed it's NOT over-blocking. 94/96 flagged files are genuine cross-production catches (2019 original-run NYT/Post/Vulture reviews scraped into the 2022 return-engagement show ID, plus BWW national-tour city reviews). Same pattern in moulin-rouge-the-musical-west-end-2021 (82/114) and pretty-woman-the-musical-2018 (75/129).
- Root cause of the *volume* metric: `rebuild-all-reviews.js` re-logs `skippedWrongProduction` for every file that still carries `wrongProduction: true` on **every** rebuild pass (the flag is sticky) — so already-known-bad files get re-counted each time rebuild runs that day, not newly excluded.
- Adds `scripts/lib/wrong-production-exclusion-analysis.js` + CLI wrapper + test suite that categorizes exclusion-log volume as REPEATED_LOGGING (stale re-logging, not a problem) vs NEEDS_REVIEW (genuinely new distinct exclusions, worth a content audit) vs NORMAL, using a persisted cross-day seen-files ledger so same-day new-vs-stale is actually distinguishable (not just guessed from a same-day repeat ratio).

## Test plan
- [x] `node --test scripts/wrong-production-exclusion-analysis.test.mjs` — 19/19 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint` — no new warnings (pre-existing warnings unrelated to this change)
- [x] CLI verified end-to-end against synthetic 2-day exclusion logs — ledger correctly flags a new file on day 2 even amid re-logged stale files
- [x] `/second-opinion` review of the test.yml CI-wiring change — no blockers
- [x] `/ship-check` adversarial review — found and fixed a real P1 (same-day-only heuristic couldn't distinguish new-today from stale-forever); added cross-day ledger + 7 tests to close the gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)