### PR TITLE
fix: add timeout protection to https.get() calls in discover-new-shows.js (BRO-108)

### DIFF
--- a/scripts/discover-new-shows.js
+++ b/scripts/discover-new-shows.js
@@ -277,7 +277,7 @@ function bwayFallbackFlags(show) {
 function fetchTodayTixPage(offset = 0, limit = 100) {
   return new Promise((resolve, reject) => {
     const url = `https://api.todaytix.com/api/v2/shows?location=1&limit=${limit}&offset=${offset}`;
-    https.get(url, (response) => {
+    const req = https.get(url, { timeout: 15000 }, (response) => {
       if (response.statusCode !== 200) {
         reject(new Error(`TodayTix API HTTP ${response.statusCode}`));
         return;
@@ -290,6 +290,7 @@ function fetchTodayTixPage(offset = 0, limit = 100) {
       });
       response.on('error', reject);
     }).on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('TodayTix API request timed out')); });
   });
 }
 
@@ -555,7 +556,7 @@ async function fetchShowsFromPlaybillBroadway() {
 function fetchTodayTixLondonPage(offset = 0, limit = 100) {
   return new Promise((resolve, reject) => {
     const url = `https://api.todaytix.com/api/v2/shows?location=2&limit=${limit}&offset=${offset}`;
-    https.get(url, (response) => {
+    const req = https.get(url, { timeout: 15000 }, (response) => {
       if (response.statusCode !== 200) {
         reject(new Error(`TodayTix London API HTTP ${response.statusCode}`));
         return;
@@ -568,6 +569,7 @@ function fetchTodayTixLondonPage(offset = 0, limit = 100) {
       });
       response.on('error', reject);
     }).on('error', reject);
+    req.on('timeout', () => { req.destroy(); reject(new Error('TodayTix London API request timed out')); });
   });
 }
 
@@ -1300,7 +1302,7 @@ function searchTodayTixByTitle(title, location = 1) {
   const query = encodeURIComponent(cleanSearchTitle(title));
   const url = `https://api.todaytix.com/api/v2/shows?query=${query}&location=${location}`;
   return new Promise((resolve, reject) => {
-    https.get(url, (response) => {
+    const req = https.get(url, { timeout: 15000 }, (response) => {
       if (response.statusCode !== 200) {
         resolve(null);
         return;
@@ -1372,6 +1374,7 @@ function searchTodayTixByTitle(title, location = 1) {
       });
       response.on('error', () => resolve(null));
     }).on('error', () => resolve(null));
+    req.on('timeout', () => { req.destroy(); resolve(null); });
   });
 }
 

--- a/scripts/discover-new-shows.js
+++ b/scripts/discover-new-shows.js
@@ -280,6 +280,7 @@ function fetchTodayTixPage(offset = 0, limit = 100) {
     const req = https.get(url, { timeout: 15000 }, (response) => {
       if (response.statusCode !== 200) {
         reject(new Error(`TodayTix API HTTP ${response.statusCode}`));
+        response.resume();
         return;
       }
       let data = '';
@@ -559,6 +560,7 @@ function fetchTodayTixLondonPage(offset = 0, limit = 100) {
     const req = https.get(url, { timeout: 15000 }, (response) => {
       if (response.statusCode !== 200) {
         reject(new Error(`TodayTix London API HTTP ${response.statusCode}`));
+        response.resume();
         return;
       }
       let data = '';
@@ -768,7 +770,7 @@ async function fetchShowsFromOfficialLondonTheatre() {
     }, (res) => {
       // Follow one redirect (301/302/307/308)
       if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-        https.get(res.headers.location, {
+        const redirectReq = https.get(res.headers.location, {
           headers: { 'User-Agent': 'Mozilla/5.0', 'Accept': 'text/html' },
           timeout: 20000,
         }, (res2) => {
@@ -777,6 +779,7 @@ async function fetchShowsFromOfficialLondonTheatre() {
           res2.on('data', chunk => d += chunk);
           res2.on('end', () => resolve(d));
         }).on('error', reject);
+        redirectReq.on('timeout', () => { redirectReq.destroy(); reject(new Error('Timeout after redirect')); });
         res.resume();
         return;
       }
@@ -883,7 +886,7 @@ async function fetchShowsFromLondonTheatre() {
     }, (res) => {
       // Follow one redirect (301/302/307/308)
       if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-        https.get(res.headers.location, {
+        const redirectReq = https.get(res.headers.location, {
           headers: { 'User-Agent': 'Mozilla/5.0', 'Accept': 'text/html' },
           timeout: 20000,
         }, (res2) => {
@@ -892,6 +895,7 @@ async function fetchShowsFromLondonTheatre() {
           res2.on('data', chunk => d += chunk);
           res2.on('end', () => resolve(d));
         }).on('error', reject);
+        redirectReq.on('timeout', () => { redirectReq.destroy(); reject(new Error('Timeout after redirect')); });
         res.resume();
         return;
       }
@@ -1305,6 +1309,7 @@ function searchTodayTixByTitle(title, location = 1) {
     const req = https.get(url, { timeout: 15000 }, (response) => {
       if (response.statusCode !== 200) {
         resolve(null);
+        response.resume();
         return;
       }
       let data = '';

--- a/scripts/discover-new-shows.test.mjs
+++ b/scripts/discover-new-shows.test.mjs
@@ -11,9 +11,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 const require = createRequire(import.meta.url);
 const { shouldExcludeVenueShow, VENUE_LISTING_PAGES } = require('./discover-new-shows.js');
+const SOURCE_PATH = fileURLToPath(new URL('./discover-new-shows.js', import.meta.url));
 
 test('two-word protagonist-style titles are NOT excluded (Space Dogs class)', () => {
   const realShows = [
@@ -114,5 +117,44 @@ test('Orange Tree + Park Theatre linkPatterns admit shows, reject utility/pagina
     assert.ok(venue, `${name} must be in VENUE_LISTING_PAGES`);
     for (const href of admit) assert.ok(venue.linkPattern.test(href), `${name} should admit: ${href}`);
     for (const href of reject) assert.ok(!venue.linkPattern.test(href), `${name} should reject: ${href}`);
+  }
+});
+
+// BRO-108: fetchShowsFromTheatremonkey() was the only fetch() call in this file
+// with no timeout/AbortSignal, and could hang a scraper indefinitely regardless
+// of any --time-budget-min wall-clock guard (budget checks only run between
+// discovery sources, not inside a single hung network call). Static-scans every
+// network call site in the file so a future fetch()/https.get() addition without
+// timeout protection fails CI instead of shipping a silent hang risk.
+test('every fetch()/https.get() call site in discover-new-shows.js has timeout protection', () => {
+  const source = readFileSync(SOURCE_PATH, 'utf8');
+  const WINDOW = 800;
+  const isCommentLine = (index) => {
+    const lineStart = source.lastIndexOf('\n', index) + 1;
+    return source.slice(lineStart, index).trimStart().startsWith('//');
+  };
+
+  // Bare fetch( calls — excludes fetchPage(/fetchShowsFrom...( by requiring no
+  // preceding word char or dot immediately before "fetch(", and skips mentions
+  // inside // comments.
+  const fetchSites = [...source.matchAll(/(?<![.\w])fetch\(/g)].filter(m => !isCommentLine(m.index));
+  assert.ok(fetchSites.length >= 2, 'expected at least the known fetch() call sites — did they move or get removed?');
+  for (const match of fetchSites) {
+    const window = source.slice(match.index, match.index + WINDOW);
+    const line = source.slice(0, match.index).split('\n').length;
+    assert.match(window, /AbortSignal\.timeout\(\d+\)/,
+      `fetch() at line ${line} must pass an AbortSignal.timeout(...) signal`);
+  }
+
+  // https.get(/http.get( calls — Node's http(s) module doesn't support
+  // AbortSignal directly; timeout protection here is the { timeout: N } option
+  // plus a req.on('timeout', ...) handler that destroys the request.
+  const httpGetSites = [...source.matchAll(/\bhttps?\.get\(/g)].filter(m => !isCommentLine(m.index));
+  assert.ok(httpGetSites.length >= 2, 'expected at least the known https.get() call sites — did they move or get removed?');
+  for (const match of httpGetSites) {
+    const window = source.slice(match.index, match.index + WINDOW);
+    const line = source.slice(0, match.index).split('\n').length;
+    assert.match(window, /timeout\s*:\s*\d+/,
+      `https.get()/http.get() at line ${line} must pass a { timeout: N } option`);
   }
 });

--- a/scripts/discover-new-shows.test.mjs
+++ b/scripts/discover-new-shows.test.mjs
@@ -128,10 +128,19 @@ test('Orange Tree + Park Theatre linkPatterns admit shows, reject utility/pagina
 // timeout protection fails CI instead of shipping a silent hang risk.
 test('every fetch()/https.get() call site in discover-new-shows.js has timeout protection', () => {
   const source = readFileSync(SOURCE_PATH, 'utf8');
-  const WINDOW = 800;
   const isCommentLine = (index) => {
     const lineStart = source.lastIndexOf('\n', index) + 1;
     return source.slice(lineStart, index).trimStart().startsWith('//');
+  };
+  // Top-level function boundaries, sorted — used to scope each call site's
+  // search to "rest of its enclosing function" instead of a fixed character
+  // window. A fixed window either misses handlers in long functions or, if
+  // widened enough to cover them, can bleed into an unrelated later call's
+  // handler and mask a real gap. Scoping to the enclosing function is exact.
+  const fnBoundaries = [...source.matchAll(/^(?:async )?function \w+\(/gm)].map(m => m.index);
+  const restOfEnclosingFunction = (index) => {
+    const next = fnBoundaries.find(b => b > index);
+    return source.slice(index, next === undefined ? source.length : next);
   };
 
   // Bare fetch( calls — excludes fetchPage(/fetchShowsFrom...( by requiring no
@@ -140,21 +149,28 @@ test('every fetch()/https.get() call site in discover-new-shows.js has timeout p
   const fetchSites = [...source.matchAll(/(?<![.\w])fetch\(/g)].filter(m => !isCommentLine(m.index));
   assert.ok(fetchSites.length >= 2, 'expected at least the known fetch() call sites — did they move or get removed?');
   for (const match of fetchSites) {
-    const window = source.slice(match.index, match.index + WINDOW);
+    const scope = restOfEnclosingFunction(match.index);
     const line = source.slice(0, match.index).split('\n').length;
-    assert.match(window, /AbortSignal\.timeout\(\d+\)/,
+    assert.match(scope, /AbortSignal\.timeout\(\d+\)/,
       `fetch() at line ${line} must pass an AbortSignal.timeout(...) signal`);
   }
 
   // https.get(/http.get( calls — Node's http(s) module doesn't support
-  // AbortSignal directly; timeout protection here is the { timeout: N } option
-  // plus a req.on('timeout', ...) handler that destroys the request.
+  // AbortSignal directly. The { timeout: N } option alone is not enough: Node
+  // just emits a 'timeout' event and does nothing further, so the request
+  // hangs forever unless a listener destroys it (this was a real gap in the
+  // OLT/LT redirect-follow calls — the option was set but nothing destroyed
+  // the socket on fire). Require both the option AND a handler that calls
+  // .destroy() on it, within the same enclosing function (so an outer
+  // request's handler can't be mistaken for a nested redirect request's).
   const httpGetSites = [...source.matchAll(/\bhttps?\.get\(/g)].filter(m => !isCommentLine(m.index));
   assert.ok(httpGetSites.length >= 2, 'expected at least the known https.get() call sites — did they move or get removed?');
   for (const match of httpGetSites) {
-    const window = source.slice(match.index, match.index + WINDOW);
+    const scope = restOfEnclosingFunction(match.index);
     const line = source.slice(0, match.index).split('\n').length;
-    assert.match(window, /timeout\s*:\s*\d+/,
+    assert.match(scope, /timeout\s*:\s*\d+/,
       `https.get()/http.get() at line ${line} must pass a { timeout: N } option`);
+    assert.match(scope, /on\(\s*'timeout'\s*,[\s\S]*?\.destroy\(\)/,
+      `https.get()/http.get() at line ${line} must have a .on('timeout', ...) handler that calls .destroy()`);
   }
 });


### PR DESCRIPTION
## Summary
- BRO-108 audit of fetch()/https.get() calls in `scripts/discover-new-shows.js` for missing hang-prevention timeouts (follow-up to card #438, which fixed the fetch()-only gap)
- Both `fetch()` call sites already had `AbortSignal.timeout` from that prior fix
- Found and fixed 5 real gaps in `https.get()` calls: 3 with no timeout at all, and 2 more (OLT/LT redirect-follow) where a `{ timeout: N }` option was set but no `req.on('timeout', ...)` handler destroyed the socket on fire — caught by an adversarial Codex review pass
- Also fixed a `response.resume()` gap on non-200 TodayTix responses (socket leak on error path)
- Added a static-analysis regression test scoped to each call site's enclosing function (not a fixed char window) that requires both timeout protection and a destroy handler

## Test plan
- [x] `node --test scripts/discover-new-shows.test.mjs` — 5/5 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint --file scripts/discover-new-shows.js` — clean
- [x] Manually verified the regression test catches both a stripped `AbortSignal.timeout` and a stripped `.destroy()` handler, then restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)