### PR TITLE
BRO-93: Triage stale 'announced' shows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -809,6 +809,15 @@ on:
       # Check 2e). Solo edits must run its unit test (dolly incident 2026-07-14).
       - 'tests/unit/announced-promotion.test.mjs'
       - 'scripts/update-show-status.js'
+      # Stale 'announced' show detector (BRO-93) — flags announced shows whose
+      # run has demonstrably started/finished (stale previewsStartDate or
+      # collected review-texts). Root-level scripts/*.test.mjs is not globbed
+      # (registered in tests/unit-test-manifest.txt), so a solo edit needs its
+      # own entry. scripts/lib/stale-announced-audit.js (the decision logic +
+      # ack mechanism) is intentionally NOT listed here — already covered by
+      # the scripts/lib/** glob above.
+      - 'scripts/audit-stale-announced-shows.js'
+      - 'scripts/audit-stale-announced-shows.test.mjs'
       # Scraping cost v3 S2 — Bright Data daily breaker + per-run budget, and
       # the failed-fetch policy that keeps a budget_capped miss from retiring a
       # live review URL. Both have colocated *.test.mjs that run in the

--- a/scripts/audit-stale-announced-shows.js
+++ b/scripts/audit-stale-announced-shows.js
@@ -33,6 +33,7 @@
  *   node scripts/audit-stale-announced-shows.js --stale-days=30
  *   node scripts/audit-stale-announced-shows.js --fail-on-gap
  *   node scripts/audit-stale-announced-shows.js --ack=<show-id> --ack-note="..."
+ *   node scripts/audit-stale-announced-shows.js --unack=<show-id>
  *
  * Output: data/audit/stale-announced-shows.json
  */
@@ -59,6 +60,7 @@ const FAIL_ON_GAP = argv.includes('--fail-on-gap');
 const DRY_RUN = argv.includes('--dry-run');
 const ACK_ID = (argv.find(a => a.startsWith('--ack=')) || '').replace('--ack=', '') || null;
 const ACK_NOTE = (argv.find(a => a.startsWith('--ack-note=')) || '').replace('--ack-note=', '') || '';
+const UNACK_ID = (argv.find(a => a.startsWith('--unack=')) || '').replace('--unack=', '') || null;
 
 function loadJSON(file, fallback = null) {
   try {
@@ -78,10 +80,27 @@ function hasPopulatedReviewTextsDir(showId) {
 }
 
 function main() {
+  const showsData = loadJSON(SHOWS_FILE);
+  if (!showsData || !Array.isArray(showsData.shows)) {
+    console.error(`Could not load ${SHOWS_FILE}`);
+    process.exit(1);
+  }
+
   // --ack=<id>: record a triage decision and exit — doesn't run the audit.
+  // Requires the id to be a real, currently-'announced' show, so a typo or a
+  // not-yet-discovered id can't pre-silence a future real flag.
   if (ACK_ID) {
     if (!ACK_NOTE) {
       console.error('--ack requires --ack-note="<why this show is known-stale>"');
+      process.exit(1);
+    }
+    const show = showsData.shows.find(s => s.id === ACK_ID);
+    if (!show) {
+      console.error(`--ack=${ACK_ID}: no show with this id in ${SHOWS_FILE}`);
+      process.exit(1);
+    }
+    if (show.status !== 'announced') {
+      console.error(`--ack=${ACK_ID}: show status is '${show.status}', not 'announced' — nothing to ack`);
       process.exit(1);
     }
     const acks = addAck(loadAcks(), ACK_ID, ACK_NOTE, new Date().toISOString());
@@ -90,15 +109,26 @@ function main() {
     return;
   }
 
-  const showsData = loadJSON(SHOWS_FILE);
-  if (!showsData || !Array.isArray(showsData.shows)) {
-    console.error(`Could not load ${SHOWS_FILE}`);
-    process.exit(1);
+  // --unack=<id>: remove a previously-recorded ack and exit.
+  if (UNACK_ID) {
+    const acks = loadAcks();
+    const remaining = acks.filter(a => a.id !== UNACK_ID);
+    if (remaining.length === acks.length) {
+      console.error(`--unack=${UNACK_ID}: no ack found for this id`);
+      process.exit(1);
+    }
+    saveAcks(remaining);
+    console.log(`Unacked ${UNACK_ID}`);
+    return;
   }
 
   const now = new Date();
   const acks = loadAcks();
   const flagged = [];
+
+  if (!fs.existsSync(REVIEW_TEXTS_DIR)) {
+    console.log(`  ⚠️  ${REVIEW_TEXTS_DIR} not found — review-texts signal is disabled in this environment (private repo not checked out); only date-based signals will fire`);
+  }
 
   for (const show of showsData.shows) {
     if (show.status !== 'announced') continue;

--- a/scripts/audit-stale-announced-shows.js
+++ b/scripts/audit-stale-announced-shows.js
@@ -18,14 +18,21 @@
  *
  * This script does NOT auto-flip status (an 'announced' show can legitimately
  * be pre-sale/unconfirmed and previewsStartDate can slip) — it flags for
- * human/pipeline follow-up. Two independent signals, either fires:
- *   - previewsStartDate is set and > STALE_DAYS in the past
- *   - data/review-texts/{id}/ exists and contains at least one file
+ * human/pipeline follow-up. Decision logic lives in
+ * scripts/lib/stale-announced-audit.js (CLAUDE.md §15) so the test exercises
+ * the real predicate.
+ *
+ * Triage (BRO-93): once a flagged show has actually been looked at — its real
+ * previewsStartDate/openingDate corrected in shows.json, or confirmed to have
+ * no announced date yet — record that with --ack so it stops reappearing in
+ * the report every run. The ack does not change shows.json; it only silences
+ * the audit for a show a human has already triaged.
  *
  * Usage:
  *   node scripts/audit-stale-announced-shows.js
  *   node scripts/audit-stale-announced-shows.js --stale-days=30
  *   node scripts/audit-stale-announced-shows.js --fail-on-gap
+ *   node scripts/audit-stale-announced-shows.js --ack=<show-id> --ack-note="..."
  *
  * Output: data/audit/stale-announced-shows.json
  */
@@ -34,6 +41,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const {
+  loadAcks,
+  addAck,
+  saveAcks,
+  evaluateAnnouncedShow,
+} = require('./lib/stale-announced-audit');
 
 const DATA_DIR = path.join(__dirname, '..', 'data');
 const SHOWS_FILE = path.join(DATA_DIR, 'shows.json');
@@ -44,6 +57,8 @@ const argv = process.argv.slice(2);
 const STALE_DAYS = parseInt((argv.find(a => a.startsWith('--stale-days=')) || '').replace('--stale-days=', ''), 10) || 30;
 const FAIL_ON_GAP = argv.includes('--fail-on-gap');
 const DRY_RUN = argv.includes('--dry-run');
+const ACK_ID = (argv.find(a => a.startsWith('--ack=')) || '').replace('--ack=', '') || null;
+const ACK_NOTE = (argv.find(a => a.startsWith('--ack-note=')) || '').replace('--ack-note=', '') || '';
 
 function loadJSON(file, fallback = null) {
   try {
@@ -51,12 +66,6 @@ function loadJSON(file, fallback = null) {
   } catch {
     return fallback;
   }
-}
-
-function daysSince(dateStr, now) {
-  const d = new Date(dateStr);
-  if (isNaN(d.getTime())) return null;
-  return Math.floor((now.getTime() - d.getTime()) / (24 * 60 * 60 * 1000));
 }
 
 function hasPopulatedReviewTextsDir(showId) {
@@ -69,6 +78,18 @@ function hasPopulatedReviewTextsDir(showId) {
 }
 
 function main() {
+  // --ack=<id>: record a triage decision and exit — doesn't run the audit.
+  if (ACK_ID) {
+    if (!ACK_NOTE) {
+      console.error('--ack requires --ack-note="<why this show is known-stale>"');
+      process.exit(1);
+    }
+    const acks = addAck(loadAcks(), ACK_ID, ACK_NOTE, new Date().toISOString());
+    saveAcks(acks);
+    console.log(`Acked ${ACK_ID}: ${ACK_NOTE}`);
+    return;
+  }
+
   const showsData = loadJSON(SHOWS_FILE);
   if (!showsData || !Array.isArray(showsData.shows)) {
     console.error(`Could not load ${SHOWS_FILE}`);
@@ -76,22 +97,18 @@ function main() {
   }
 
   const now = new Date();
+  const acks = loadAcks();
   const flagged = [];
 
   for (const show of showsData.shows) {
     if (show.status !== 'announced') continue;
 
-    const reasons = [];
-
-    const pastDays = show.previewsStartDate ? daysSince(show.previewsStartDate, now) : null;
-    if (pastDays !== null && pastDays > STALE_DAYS) {
-      reasons.push(`previewsStartDate ${show.previewsStartDate} is ${pastDays}d in the past`);
-    }
-
-    const hasReviews = hasPopulatedReviewTextsDir(show.id);
-    if (hasReviews) {
-      reasons.push('data/review-texts/ has collected review file(s)');
-    }
+    const reasons = evaluateAnnouncedShow(show, {
+      now,
+      staleDays: STALE_DAYS,
+      hasReviews: hasPopulatedReviewTextsDir(show.id),
+      acks,
+    });
 
     if (reasons.length > 0) {
       flagged.push({

--- a/scripts/audit-stale-announced-shows.test.mjs
+++ b/scripts/audit-stale-announced-shows.test.mjs
@@ -44,10 +44,23 @@ test('announced with collected review-texts → flagged even with no previewsSta
   assert.deepEqual(reasons, ['data/review-texts/ has collected review file(s)']);
 });
 
-test('announced, both signals fire → both reasons reported', () => {
-  const show = { id: 'x', status: 'announced', previewsStartDate: '2026-06-01' };
+test('announced, openingDate 30+ days in the past, no previewsStartDate → flagged (straight-to-open transfer class)', () => {
+  const show = { id: 'x', status: 'announced', previewsStartDate: null, openingDate: '2026-06-01' };
+  const reasons = evaluateAnnouncedShow(show, { now: NOW, staleDays: STALE_DAYS, hasReviews: false, acks: [] });
+  assert.equal(reasons.length, 1);
+  assert.match(reasons[0], /openingDate 2026-06-01 is \d+d in the past/);
+});
+
+test('announced, openingDate within stale window → not flagged', () => {
+  const show = { id: 'x', status: 'announced', openingDate: '2026-08-01' };
+  const reasons = evaluateAnnouncedShow(show, { now: NOW, staleDays: STALE_DAYS, hasReviews: false, acks: [] });
+  assert.deepEqual(reasons, []);
+});
+
+test('announced, all three signals fire → three reasons reported', () => {
+  const show = { id: 'x', status: 'announced', previewsStartDate: '2026-06-01', openingDate: '2026-06-15' };
   const reasons = evaluateAnnouncedShow(show, { now: NOW, staleDays: STALE_DAYS, hasReviews: true, acks: [] });
-  assert.equal(reasons.length, 2);
+  assert.equal(reasons.length, 3);
 });
 
 test('acked show is never flagged, even when stale signals fire', () => {

--- a/scripts/audit-stale-announced-shows.test.mjs
+++ b/scripts/audit-stale-announced-shows.test.mjs
@@ -1,0 +1,128 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  evaluateAnnouncedShow,
+  isAcked,
+  addAck,
+} = require('./lib/stale-announced-audit.js');
+
+// Fixed clock so results don't drift: "today" is 2026-08-20.
+const NOW = new Date('2026-08-20T12:00:00');
+const STALE_DAYS = 30;
+
+test('non-announced show → never flagged', () => {
+  const show = { id: 'x', status: 'previews', previewsStartDate: '2020-01-01' };
+  const reasons = evaluateAnnouncedShow(show, { now: NOW, staleDays: STALE_DAYS, hasReviews: false, acks: [] });
+  assert.deepEqual(reasons, []);
+});
+
+test('announced, no previewsStartDate, no reviews → not flagged', () => {
+  const show = { id: 'x', status: 'announced', previewsStartDate: null };
+  const reasons = evaluateAnnouncedShow(show, { now: NOW, staleDays: STALE_DAYS, hasReviews: false, acks: [] });
+  assert.deepEqual(reasons, []);
+});
+
+test('announced, previewsStartDate within stale window → not flagged', () => {
+  const show = { id: 'x', status: 'announced', previewsStartDate: '2026-08-01' };
+  const reasons = evaluateAnnouncedShow(show, { now: NOW, staleDays: STALE_DAYS, hasReviews: false, acks: [] });
+  assert.deepEqual(reasons, []);
+});
+
+test('announced, previewsStartDate 30+ days in the past → flagged', () => {
+  const show = { id: 'x', status: 'announced', previewsStartDate: '2026-06-01' };
+  const reasons = evaluateAnnouncedShow(show, { now: NOW, staleDays: STALE_DAYS, hasReviews: false, acks: [] });
+  assert.equal(reasons.length, 1);
+  assert.match(reasons[0], /previewsStartDate 2026-06-01 is \d+d in the past/);
+});
+
+test('announced with collected review-texts → flagged even with no previewsStartDate', () => {
+  const show = { id: 'x', status: 'announced', previewsStartDate: null };
+  const reasons = evaluateAnnouncedShow(show, { now: NOW, staleDays: STALE_DAYS, hasReviews: true, acks: [] });
+  assert.deepEqual(reasons, ['data/review-texts/ has collected review file(s)']);
+});
+
+test('announced, both signals fire → both reasons reported', () => {
+  const show = { id: 'x', status: 'announced', previewsStartDate: '2026-06-01' };
+  const reasons = evaluateAnnouncedShow(show, { now: NOW, staleDays: STALE_DAYS, hasReviews: true, acks: [] });
+  assert.equal(reasons.length, 2);
+});
+
+test('acked show is never flagged, even when stale signals fire', () => {
+  const show = { id: 'sherlock-holmes-west-end-2026', status: 'announced', previewsStartDate: '2020-01-01' };
+  const acks = [{ id: 'sherlock-holmes-west-end-2026', ackedAt: NOW.toISOString(), note: 'triaged' }];
+  const reasons = evaluateAnnouncedShow(show, { now: NOW, staleDays: STALE_DAYS, hasReviews: true, acks });
+  assert.deepEqual(reasons, []);
+});
+
+test('ack only silences the matching show id, not others', () => {
+  const acks = [{ id: 'show-a', ackedAt: NOW.toISOString(), note: 'triaged' }];
+  const showB = { id: 'show-b', status: 'announced', previewsStartDate: '2026-06-01' };
+  const reasons = evaluateAnnouncedShow(showB, { now: NOW, staleDays: STALE_DAYS, hasReviews: false, acks });
+  assert.equal(reasons.length, 1);
+});
+
+test('isAcked matches by id', () => {
+  const acks = [{ id: 'a', ackedAt: 'x', note: 'n' }];
+  assert.equal(isAcked('a', acks), true);
+  assert.equal(isAcked('b', acks), false);
+});
+
+test('addAck appends and re-acking the same id refreshes (no duplicates)', () => {
+  let acks = addAck([], 'a', 'first note', '2026-01-01T00:00:00.000Z');
+  assert.equal(acks.length, 1);
+  acks = addAck(acks, 'a', 'updated note', '2026-01-02T00:00:00.000Z');
+  assert.equal(acks.length, 1);
+  assert.equal(acks[0].note, 'updated note');
+});
+
+// Regression guard for BRO-93: the current data/shows.json + data/audit ack
+// file must produce zero flagged 'announced' shows. This is what makes
+// `node --test scripts/audit-stale-announced-shows.test.mjs` the acceptance
+// check for "the audit script no longer reports any stale 'announced' shows".
+test('BRO-93 acceptance: current shows.json produces zero stale announced flags', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const { fileURLToPath } = require('url');
+  const { loadAcks } = require('./lib/stale-announced-audit.js');
+
+  const dirname = path.dirname(fileURLToPath(import.meta.url));
+  const root = path.join(dirname, '..');
+  const showsPath = path.join(root, 'data', 'shows.json');
+  const reviewTextsDir = path.join(root, 'data', 'review-texts');
+
+  let showsData;
+  try {
+    showsData = JSON.parse(fs.readFileSync(showsPath, 'utf8'));
+  } catch {
+    // No local data checkout (e.g. a bare CI shard without data/) — nothing to check.
+    return;
+  }
+
+  const hasPopulatedReviewTextsDir = (showId) => {
+    const dir = path.join(reviewTextsDir, showId);
+    try {
+      return fs.readdirSync(dir).some((f) => f.endsWith('.json'));
+    } catch {
+      return false;
+    }
+  };
+
+  const acks = loadAcks();
+  const now = new Date();
+  const flagged = [];
+  for (const show of showsData.shows || []) {
+    if (show.status !== 'announced') continue;
+    const reasons = evaluateAnnouncedShow(show, {
+      now,
+      staleDays: 30,
+      hasReviews: hasPopulatedReviewTextsDir(show.id),
+      acks,
+    });
+    if (reasons.length > 0) flagged.push({ id: show.id, reasons });
+  }
+
+  assert.deepEqual(flagged, [], `expected zero stale announced shows, got: ${JSON.stringify(flagged, null, 2)}`);
+});

--- a/scripts/lib/stale-announced-audit.js
+++ b/scripts/lib/stale-announced-audit.js
@@ -52,8 +52,13 @@ function daysSince(dateStr, now) {
 }
 
 /**
- * Is this 'announced' show stale? Two independent signals, either fires:
+ * Is this 'announced' show stale? Three independent signals, any fires:
  *  - previewsStartDate is set and > staleDays in the past
+ *  - openingDate is set and > staleDays in the past (mirrors the date-staleness
+ *    check announced-promotion.js's decideAnnouncedPromotion already does for
+ *    BOTH dates — a show can be announced with only an openingDate set and no
+ *    previewsStartDate, e.g. a straight-to-open transfer, and that case was
+ *    silently unflaggable before this)
  *  - the show has a populated data/review-texts/{id}/ directory (hasReviews, injected
  *    so this stays a pure function — the fs read is the caller's job)
  *
@@ -67,9 +72,13 @@ function evaluateAnnouncedShow(show, opts) {
   if (isAcked(show.id, acks)) return [];
 
   const reasons = [];
-  const pastDays = show.previewsStartDate ? daysSince(show.previewsStartDate, now) : null;
-  if (pastDays !== null && pastDays > staleDays) {
-    reasons.push(`previewsStartDate ${show.previewsStartDate} is ${pastDays}d in the past`);
+  const previewsPastDays = show.previewsStartDate ? daysSince(show.previewsStartDate, now) : null;
+  if (previewsPastDays !== null && previewsPastDays > staleDays) {
+    reasons.push(`previewsStartDate ${show.previewsStartDate} is ${previewsPastDays}d in the past`);
+  }
+  const openingPastDays = show.openingDate ? daysSince(show.openingDate, now) : null;
+  if (openingPastDays !== null && openingPastDays > staleDays) {
+    reasons.push(`openingDate ${show.openingDate} is ${openingPastDays}d in the past`);
   }
   if (hasReviews) {
     reasons.push('data/review-texts/ has collected review file(s)');

--- a/scripts/lib/stale-announced-audit.js
+++ b/scripts/lib/stale-announced-audit.js
@@ -1,0 +1,88 @@
+/**
+ * stale-announced-audit.js — decision logic for audit-stale-announced-shows.js
+ * (BRO-93). Extracted per CLAUDE.md §15 so scripts/audit-stale-announced-shows.test.mjs
+ * exercises the real predicate instead of a copy.
+ *
+ * Ack mechanism mirrors scripts/lib/t1-scoreboard.js's data/audit/t1-coverage-ack.json
+ * pattern: the audit script does NOT auto-flip status (previewsStartDate can
+ * legitimately slip and 'announced' can be pre-sale/unconfirmed), so a human who has
+ * actually looked at a flagged show records that triage as an ack — a reason the show
+ * is known-stale-for-a-good-reason — so the same show doesn't reappear in the report
+ * every run. An acked show is still 'announced' in shows.json; the ack only silences
+ * the audit, it does not change data.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const ACK_PATH = path.join(ROOT, 'data', 'audit', 'stale-announced-shows-ack.json');
+
+/** @returns {Array<{id, ackedAt, note}>} */
+function loadAcks() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(ACK_PATH, 'utf8'));
+    if (Array.isArray(parsed)) return parsed;
+  } catch { /* missing/corrupt — nothing acked */ }
+  return [];
+}
+
+function isAcked(showId, acks) {
+  return (acks || []).some((a) => a && a.id === showId);
+}
+
+/** Pure w.r.t. the input array — returns a new array (append, or refresh the note on re-ack). */
+function addAck(acks, id, note, nowIso) {
+  const kept = (acks || []).filter((a) => a && a.id !== id);
+  kept.push({ id, ackedAt: nowIso, note: note || '' });
+  return kept;
+}
+
+function saveAcks(acks) {
+  fs.mkdirSync(path.dirname(ACK_PATH), { recursive: true });
+  fs.writeFileSync(ACK_PATH, JSON.stringify(acks, null, 2) + '\n');
+}
+
+function daysSince(dateStr, now) {
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return null;
+  return Math.floor((now.getTime() - d.getTime()) / (24 * 60 * 60 * 1000));
+}
+
+/**
+ * Is this 'announced' show stale? Two independent signals, either fires:
+ *  - previewsStartDate is set and > staleDays in the past
+ *  - the show has a populated data/review-texts/{id}/ directory (hasReviews, injected
+ *    so this stays a pure function — the fs read is the caller's job)
+ *
+ * @param show shows.json entry
+ * @param opts { now: Date, staleDays: number, hasReviews: boolean, acks: array }
+ * @returns {string[]} reasons (empty = not flagged, including because it's acked)
+ */
+function evaluateAnnouncedShow(show, opts) {
+  const { now, staleDays, hasReviews, acks } = opts || {};
+  if (!show || show.status !== 'announced') return [];
+  if (isAcked(show.id, acks)) return [];
+
+  const reasons = [];
+  const pastDays = show.previewsStartDate ? daysSince(show.previewsStartDate, now) : null;
+  if (pastDays !== null && pastDays > staleDays) {
+    reasons.push(`previewsStartDate ${show.previewsStartDate} is ${pastDays}d in the past`);
+  }
+  if (hasReviews) {
+    reasons.push('data/review-texts/ has collected review file(s)');
+  }
+  return reasons;
+}
+
+module.exports = {
+  ACK_PATH,
+  loadAcks,
+  isAcked,
+  addAck,
+  saveAcks,
+  daysSince,
+  evaluateAnnouncedShow,
+};

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -11,6 +11,7 @@ scripts/audit-outlet-stub-rate.test.mjs
 scripts/audit-push-core-data-audit-gap.test.mjs
 scripts/audit-review-texts-test-yml-coverage.test.mjs
 scripts/audit-show-review-gap.test.mjs
+scripts/audit-stale-announced-shows.test.mjs
 scripts/audit-standing-coverage.test.mjs
 scripts/audit-test-yml-lib-deps.test.mjs
 scripts/audit-venue-complex-slugs.test.mjs


### PR DESCRIPTION
## Summary
- 4 of the original 51 shows flagged by `audit-stale-announced-shows.js` remained stale; the rest self-resolved via normal pipeline drift since the script was added.
- Researched each via multi-source web corroboration and fixed the underlying `shows.json` data (private data repo, separate commits): 3 shows had wrong/stale `previewsStartDate` placeholders cleared (no confirmed date exists yet); 1 (`10-things-i-hate-about-you-on-broadway-2024`) got its confirmed real preview date (2027-08-17).
- Extending the audit's `openingDate` staleness check (previously only checked `previewsStartDate`, a gap found by an adversarial Codex review) surfaced one more genuine case: `dear-england-new-wimbledon-theatre-west-end-2026`, a UK touring stop that ran and closed 2026-02-24/28 while still marked `announced` — fixed to `closed`.
- Extracted the decision logic to `scripts/lib/stale-announced-audit.js` (CLAUDE.md §15) and added an ack mechanism (`--ack`/`--unack`) modeled on `t1-scoreboard.js`'s pattern, so a human-triaged show doesn't reappear in the report every run without mutating `shows.json`.

## Test plan
- [x] `node --test scripts/audit-stale-announced-shows.test.mjs` — 13/13 pass, including a live-data regression guard (BRO-93 acceptance criteria)
- [x] `node --test scripts/audit-stale-announced-shows.test.mjs tests/unit/announced-promotion.test.mjs` — 25/25 pass
- [x] `node scripts/audit-stale-announced-shows.js --dry-run` — reports 0 stale shows
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint` — no new warnings
- [x] `node scripts/validate-data.js` — exit 0
- [x] `/second-opinion` review before editing `.github/workflows/test.yml` (CLAUDE.md §18)
- [x] Codex adversarial review — found the `openingDate` gap (fixed) and ack-safety issues (added `--unack` + id validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)