### PR TITLE
BRO-102: harden IBDB creative-team scrape path against hallucinations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,6 +147,10 @@ on:
       # lib itself needs explicit listing per this repo's convention.
       - 'scripts/audit-creative-team-serp.js'
       - 'scripts/auto-fix-show-data.js'
+      # BRO-102 colocated test (root-level scripts/*.test.mjs is NOT globbed,
+      # registered in tests/unit-test-manifest.txt) — path-listed so a solo
+      # edit to either triggers CI.
+      - 'scripts/auto-fix-show-data.test.mjs'
       # BWW Review Roundup byline parser: a photo credit's photographer surname
       # ("Photo credit: Mark Senior") was absorbed as the next critic's first
       # name, minting a phantom URL-less duplicate that same-URL dedup could not

--- a/scripts/auto-fix-show-data.js
+++ b/scripts/auto-fix-show-data.js
@@ -410,13 +410,31 @@ Return ONLY the JSON array, no other text. Example:
 
   if (!proposed || proposed.length === 0) return null;
 
-  // Step 2: SERP-verify each proposed member.
-  // 2026-05-26: previously non-director roles were accepted without verification.
-  // Result: LLM hallucinated "Martyna Majok (Book Writer)" for Liberation (correct:
-  // Bess Wohl, Playwright) and reached production. Now ALL roles require SERP
-  // confirmation; unrecognized roles are rejected rather than silently accepted.
-  // Decision logic lives in lib/creative-team-verify.js (shared with
-  // audit-creative-team-serp.js, which retro-verifies pre-guard entries).
+  // Step 2: SERP-verify each proposed member. Shared with the IBDB scrape
+  // path (see verifyCreativeTeamViaSerp below) — BRO-102.
+  const verified = await verifyCreativeTeamViaSerp(show, proposed, year, 'serp-verified-llm');
+
+  return verified.length > 0 ? verified : null;
+}
+
+// Shared SERP-verification gate for creative-team writes.
+//
+// 2026-05-26: previously non-director roles proposed by the LLM were accepted
+// without verification. Result: LLM hallucinated "Martyna Majok (Book Writer)"
+// for Liberation (correct: Bess Wohl, Playwright) and reached production. Now
+// ALL roles require SERP confirmation; unrecognized roles (design/tech
+// credits with no reliable "<verb> <name>" attribution phrase — Scenic
+// Design, Orchestrations, etc.) are rejected rather than trusted verbatim.
+//
+// BRO-102: the IBDB scrape path (Step 2 in fixCreativeTeam) previously took
+// ibdb.creativeTeam verbatim — a wrong table cell or stale IBDB entry would
+// repeat the same wrong-attribution pattern for any Broadway show with an
+// ibdbUrl. It now routes through this same gate before writing.
+//
+// Decision logic (roleVerb/ROLE_CANON/serpTextConfirms) lives in
+// lib/creative-team-verify.js, shared with audit-creative-team-serp.js,
+// which retro-verifies pre-guard entries.
+async function verifyCreativeTeamViaSerp(show, proposed, year, sourceTag) {
   const verified = [];
   for (const member of proposed) {
     const role = String(member.role || '').toLowerCase();
@@ -425,7 +443,7 @@ Return ONLY the JSON array, no other text. Example:
       console.log(`    ❌ Unrecognized role "${member.role}" for ${member.name} — rejecting (cannot SERP-verify)`);
       continue;
     }
-    const canonRole = ROLE_CANON[role];
+    const canonRole = ROLE_CANON[role] || member.role;
 
     const query = `"${show.title}" ${year} "${verb} ${member.name}"`;
     console.log(`    🔍 Verifying: ${member.name} (${member.role}) via SERP...`);
@@ -439,7 +457,7 @@ Return ONLY the JSON array, no other text. Example:
         const confirmed = serpTextConfirms(serpResults, [verb], member.name, { title: show.title });
         if (confirmed) {
           console.log(`    ✅ SERP confirmed: ${member.name} (${member.role})`);
-          verified.push({ ...member, role: canonRole, _source: 'serp-verified-llm' });
+          verified.push({ ...member, role: canonRole, _source: sourceTag });
         } else {
           console.log(`    ❌ SERP did not confirm: ${member.name} (${member.role}) — rejecting`);
         }
@@ -451,7 +469,7 @@ Return ONLY the JSON array, no other text. Example:
     }
   }
 
-  return verified.length > 0 ? verified : null;
+  return verified;
 }
 
 // Fix creative team - fetch from TodayTix, IBDB (Broadway), or SERP-verified LLM (OB/WE)
@@ -485,15 +503,27 @@ async function fixCreativeTeam(show, todayTixIds) {
       const openingYear = show.openingDate ? parseInt(show.openingDate.slice(0, 4)) : undefined;
       const ibdb = await lookupIBDBDates(show.title, { ibdbUrl: show.ibdbUrl, openingYear });
       if (ibdb.creativeTeam && ibdb.creativeTeam.length >= 1) {
-        // Defensive: never overwrite an existing non-empty creativeTeam from IBDB
-        // without a louder signal. The guard at line 413 already returns early if
-        // show.creativeTeam.length >= 2, so we only reach here when it's empty
-        // or has 1 entry — log the latter so regressions are auditable.
-        if (show.creativeTeam && show.creativeTeam.length > 0) {
-          console.log(`    ⚠️  IBDB replacing existing creativeTeam[${show.creativeTeam.length}] on ${show.id}`);
+        // BRO-102: IBDB regex extraction can grab the wrong table cell or
+        // carry stale data — route through the same SERP-verification gate
+        // as the LLM path (verifyCreativeTeamViaSerp) rather than trusting
+        // ibdb.creativeTeam verbatim. Design/tech-credit roles with no
+        // verifiable attribution phrase (Scenic Design, Orchestrations, etc.)
+        // are dropped, same as the LLM path.
+        const year = openingYear || show.openingDate?.slice(0, 4) || 'upcoming';
+        console.log(`    Verifying ${ibdb.creativeTeam.length} IBDB creative-team member(s) via SERP...`);
+        const verified = await verifyCreativeTeamViaSerp(show, ibdb.creativeTeam, year, 'serp-verified-ibdb');
+        if (verified.length > 0) {
+          // Defensive: never overwrite an existing non-empty creativeTeam from IBDB
+          // without a louder signal. The guard at line 413 already returns early if
+          // show.creativeTeam.length >= 2, so we only reach here when it's empty
+          // or has 1 entry — log the latter so regressions are auditable.
+          if (show.creativeTeam && show.creativeTeam.length > 0) {
+            console.log(`    ⚠️  IBDB replacing existing creativeTeam[${show.creativeTeam.length}] on ${show.id}`);
+          }
+          show.creativeTeam = verified;
+          return `Fetched creative team from IBDB for ${show.title} (${verified.length} member(s), SERP-verified)`;
         }
-        show.creativeTeam = ibdb.creativeTeam;
-        return `Fetched creative team from IBDB for ${show.title} (${ibdb.creativeTeam.length} members)`;
+        console.log(`    ⚠️  No IBDB creative-team members passed SERP verification — leaving unset`);
       }
     } catch (e) {
       console.log(`    ⚠️  IBDB fetch failed: ${e.message}`);
@@ -713,14 +743,26 @@ async function main() {
   return results;
 }
 
-main()
-  .catch(err => {
-    console.error('Fatal error:', err);
-    process.exitCode = 1;
-  })
-  .finally(() => {
-    // fetchUrl()'s Playwright fallback leaves Chromium open on success —
-    // cleanup() closes it with a timeout guard. Without this, any run that
-    // touches even one Playwright-fetched URL hangs forever (#438/#914 class).
-    cleanupScraper().catch(() => {}).finally(() => process.exit(process.exitCode || 0));
-  });
+if (require.main === module) {
+  main()
+    .catch(err => {
+      console.error('Fatal error:', err);
+      process.exitCode = 1;
+    })
+    .finally(() => {
+      // fetchUrl()'s Playwright fallback leaves Chromium open on success —
+      // cleanup() closes it with a timeout guard. Without this, any run that
+      // touches even one Playwright-fetched URL hangs forever (#438/#914 class).
+      cleanupScraper().catch(() => {}).finally(() => process.exit(process.exitCode || 0));
+    });
+}
+
+// Exports for unit tests (BRO-102) — the IBDB and LLM creative-team write
+// paths both route through verifyCreativeTeamViaSerp before touching
+// show.creativeTeam; tests exercise that gate directly against a fake
+// serpQuery rather than re-implementing its decision logic.
+module.exports = {
+  fixCreativeTeam,
+  verifyCreativeTeamViaSerp,
+  generateCreativeTeamWithSerpVerification,
+};

--- a/scripts/auto-fix-show-data.js
+++ b/scripts/auto-fix-show-data.js
@@ -434,19 +434,50 @@ Return ONLY the JSON array, no other text. Example:
 // Decision logic (roleVerb/ROLE_CANON/serpTextConfirms) lives in
 // lib/creative-team-verify.js, shared with audit-creative-team-serp.js,
 // which retro-verifies pre-guard entries.
+//
+// Cost: this adds up to ~7 SERP calls (one per verifiable role) where the
+// IBDB path previously made zero. Bounded by check-show-freshness.yml's
+// open/previews-only scope for the daily cron; a large --backfill-historical
+// or targeted --show= batch run is the case to watch if SB SERP credit burn
+// spikes.
+//
+// Scope note: this SERP check confirms "<verb> <name>" for the show's TITLE,
+// not its specific production year — it can't tell a 2026 revival's director
+// from a same-titled 1990s production's director if both are attributable
+// online. For the IBDB caller that's covered upstream: lookupIBDBDates()'s
+// production-year gate (lib/ibdb-dates.js) already rejects ibdb.creativeTeam
+// entirely when the IBDB page's year doesn't match the show's openingYear, so
+// only same-production entries ever reach this function. Callers without an
+// equivalent upstream year gate should not assume this function verifies
+// production identity, only name+role attribution.
 async function verifyCreativeTeamViaSerp(show, proposed, year, sourceTag) {
   const verified = [];
+  const seen = new Set(); // name+role dedup — a shared gate can't assume every caller pre-dedupes
   for (const member of proposed) {
+    const name = String(member.name || '').trim();
+    if (!name) {
+      console.log(`    ❌ Blank/missing name for role "${member.role}" — rejecting`);
+      continue;
+    }
     const role = String(member.role || '').toLowerCase();
+    const dedupeKey = `${role}::${name.toLowerCase()}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
     const verb = roleVerb(role);
     if (!verb) {
-      console.log(`    ❌ Unrecognized role "${member.role}" for ${member.name} — rejecting (cannot SERP-verify)`);
+      console.log(`    ❌ Unrecognized role "${member.role}" for ${name} — rejecting (cannot SERP-verify)`);
       continue;
     }
     const canonRole = ROLE_CANON[role] || member.role;
+    // "Music & Lyrics" is published inconsistently ("music and lyrics by" vs
+    // "music & lyrics by") — accept either spelling for this one role rather
+    // than widening every role to roleVerbVariants (which would weaken the
+    // single-verb hallucination signal the other roles rely on).
+    const phrases = role === 'music & lyrics' ? [verb, 'music & lyrics by'] : [verb];
 
-    const query = `"${show.title}" ${year} "${verb} ${member.name}"`;
-    console.log(`    🔍 Verifying: ${member.name} (${member.role}) via SERP...`);
+    const query = `"${show.title}" ${year} "${verb} ${name}"`;
+    console.log(`    🔍 Verifying: ${name} (${member.role}) via SERP...`);
     try {
       await sleep(500);
       const serpResults = await serpQuery(query);
@@ -454,10 +485,10 @@ async function verifyCreativeTeamViaSerp(show, proposed, year, sourceTag) {
         // Require the full phrase "directed by [name]" in a snippet — not just
         // the name — anchored to a segment naming this show (see
         // lib/creative-team-verify.js for the snippet-stitching failure mode).
-        const confirmed = serpTextConfirms(serpResults, [verb], member.name, { title: show.title });
+        const confirmed = serpTextConfirms(serpResults, phrases, name, { title: show.title });
         if (confirmed) {
-          console.log(`    ✅ SERP confirmed: ${member.name} (${member.role})`);
-          verified.push({ ...member, role: canonRole, _source: sourceTag });
+          console.log(`    ✅ SERP confirmed: ${name} (${member.role})`);
+          verified.push({ ...member, name, role: canonRole, _source: sourceTag });
         } else {
           console.log(`    ❌ SERP did not confirm: ${member.name} (${member.role}) — rejecting`);
         }

--- a/scripts/auto-fix-show-data.test.mjs
+++ b/scripts/auto-fix-show-data.test.mjs
@@ -1,0 +1,170 @@
+// BRO-102: the IBDB creative-team scrape path (fixCreativeTeam Step 2) used
+// to take ibdb.creativeTeam verbatim — a wrong table cell or stale IBDB entry
+// would ship a hallucinated attribution the same way the LLM path did before
+// the 2026-05-26 Liberation fix (generateCreativeTeamWithSerpVerification).
+// Both paths now route through the same verifyCreativeTeamViaSerp() gate.
+//
+// serpQuery and lookupIBDBDates are network calls, so this file mocks them
+// via require.cache injection (pre-seed the module cache for their owning
+// libs before requiring auto-fix-show-data.js fresh) rather than re-implementing
+// their decision logic — see CLAUDE.md rule 15 ("require() the real function").
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+process.env.SCRAPINGBEE_API_KEY = process.env.SCRAPINGBEE_API_KEY || 'test-key';
+
+const targetPath = require.resolve('./auto-fix-show-data.js');
+const urlDiscoveryPath = require.resolve('./lib/url-discovery.js');
+const ibdbDatesPath = require.resolve('./lib/ibdb-dates.js');
+
+// Load auto-fix-show-data.js with serpQuery and lookupIBDBDates swapped out.
+// Restores the real modules afterward so other tests in the same process
+// (or a later require in this file) aren't left with mocks installed.
+function loadWithMocks({ serpQueryImpl, ibdbCreativeTeam }) {
+  const realUrlDiscovery = require(urlDiscoveryPath);
+  const realIbdbDates = require(ibdbDatesPath);
+
+  delete require.cache[urlDiscoveryPath];
+  delete require.cache[ibdbDatesPath];
+  delete require.cache[targetPath];
+
+  require.cache[urlDiscoveryPath] = {
+    id: urlDiscoveryPath, filename: urlDiscoveryPath, loaded: true,
+    exports: { ...realUrlDiscovery, serpQuery: serpQueryImpl },
+  };
+  require.cache[ibdbDatesPath] = {
+    id: ibdbDatesPath, filename: ibdbDatesPath, loaded: true,
+    exports: {
+      ...realIbdbDates,
+      lookupIBDBDates: async () => ({
+        previewsStartDate: '2026-01-01',
+        openingDate: '2026-01-15',
+        closingDate: null,
+        creativeTeam: ibdbCreativeTeam,
+        showType: null,
+        ibdbUrl: 'https://www.ibdb.com/broadway-production/example-123456',
+        found: true,
+      }),
+    },
+  };
+
+  const mod = require(targetPath);
+
+  // Restore the real modules for anything requiring them after this point.
+  delete require.cache[urlDiscoveryPath];
+  delete require.cache[ibdbDatesPath];
+  delete require.cache[targetPath];
+  require.cache[urlDiscoveryPath] = { id: urlDiscoveryPath, filename: urlDiscoveryPath, loaded: true, exports: realUrlDiscovery };
+  require.cache[ibdbDatesPath] = { id: ibdbDatesPath, filename: ibdbDatesPath, loaded: true, exports: realIbdbDates };
+
+  return mod;
+}
+
+function fakeShow(overrides = {}) {
+  return {
+    id: 'example-2026',
+    title: 'Example',
+    openingDate: '2026-01-15',
+    ibdbUrl: 'https://www.ibdb.com/broadway-production/example-123456',
+    ...overrides,
+  };
+}
+
+test('verifyCreativeTeamViaSerp: unrecognized (design/tech-credit) roles are rejected without a network call', async () => {
+  let calls = 0;
+  const { verifyCreativeTeamViaSerp } = loadWithMocks({
+    serpQueryImpl: async () => { calls++; return []; },
+    ibdbCreativeTeam: [],
+  });
+
+  const proposed = [{ name: 'Arnulfo Maldonado', role: 'Scenic Design' }];
+  const verified = await verifyCreativeTeamViaSerp(fakeShow(), proposed, '2026', 'serp-verified-ibdb');
+
+  assert.deepEqual(verified, []);
+  assert.equal(calls, 0, 'unverifiable roles must never reach serpQuery');
+});
+
+test('verifyCreativeTeamViaSerp: a member confirmed by SERP is accepted and tagged with the source', async () => {
+  const { verifyCreativeTeamViaSerp } = loadWithMocks({
+    serpQueryImpl: async () => [
+      { title: 'Example opens', snippet: 'Example, directed by Mary Zimmerman, begins previews.' },
+    ],
+    ibdbCreativeTeam: [],
+  });
+
+  const proposed = [{ name: 'Mary Zimmerman', role: 'Director' }];
+  const verified = await verifyCreativeTeamViaSerp(fakeShow(), proposed, '2026', 'serp-verified-ibdb');
+
+  assert.equal(verified.length, 1);
+  assert.equal(verified[0].name, 'Mary Zimmerman');
+  assert.equal(verified[0].role, 'Director');
+  assert.equal(verified[0]._source, 'serp-verified-ibdb');
+});
+
+test('verifyCreativeTeamViaSerp: a member SERP does not confirm is rejected (the wrong-table-cell / hallucination case)', async () => {
+  const { verifyCreativeTeamViaSerp } = loadWithMocks({
+    // No result mentions "written by Reginald Rose" for this show — simulates
+    // IBDB regex grabbing the wrong playwright (the romantic-comedy-1979 bug).
+    serpQueryImpl: async () => [
+      { title: 'Unrelated', snippet: 'Some other show entirely, opening next month.' },
+    ],
+    ibdbCreativeTeam: [],
+  });
+
+  const proposed = [{ name: 'Reginald Rose', role: 'Playwright' }];
+  const verified = await verifyCreativeTeamViaSerp(fakeShow({ title: 'Romantic Comedy' }), proposed, '2026', 'serp-verified-ibdb');
+
+  assert.deepEqual(verified, []);
+});
+
+test('fixCreativeTeam: IBDB step drops an unconfirmed member but keeps a confirmed one, and writes only the verified set', async () => {
+  const { fixCreativeTeam } = loadWithMocks({
+    serpQueryImpl: async (query) => {
+      if (query.includes('directed by')) {
+        return [{ title: 'Example opens', snippet: 'Example, directed by Mary Zimmerman, begins previews.' }];
+      }
+      // "written by Reginald Rose" (or any other query) finds nothing.
+      return [];
+    },
+    ibdbCreativeTeam: [
+      { name: 'Mary Zimmerman', role: 'Director' },
+      { name: 'Reginald Rose', role: 'Playwright' }, // wrong table cell — unconfirmed
+    ],
+  });
+
+  const show = fakeShow();
+  const result = await fixCreativeTeam(show, { shows: {} });
+
+  assert.match(result, /SERP-verified/);
+  assert.equal(show.creativeTeam.length, 1);
+  assert.equal(show.creativeTeam[0].name, 'Mary Zimmerman');
+  assert.ok(!show.creativeTeam.some(m => m.name === 'Reginald Rose'), 'the unconfirmed member must not be written');
+});
+
+test('fixCreativeTeam: IBDB step writes nothing when no member passes SERP verification', async () => {
+  const { fixCreativeTeam } = loadWithMocks({
+    serpQueryImpl: async () => [],
+    ibdbCreativeTeam: [{ name: 'Someone Wrong', role: 'Director' }],
+  });
+
+  const show = fakeShow();
+  const result = await fixCreativeTeam(show, { shows: {} });
+
+  assert.equal(result, null);
+  assert.equal(show.creativeTeam, undefined, 'no creative team data may be introduced without verification');
+});
+
+test('fixCreativeTeam: IBDB step never overwrites an existing creativeTeam[1] with an unverified replacement', async () => {
+  const { fixCreativeTeam } = loadWithMocks({
+    serpQueryImpl: async () => [],
+    ibdbCreativeTeam: [{ name: 'Someone Wrong', role: 'Director' }],
+  });
+
+  const show = fakeShow({ creativeTeam: [{ name: 'Existing Person', role: 'Director' }] });
+  await fixCreativeTeam(show, { shows: {} });
+
+  assert.deepEqual(show.creativeTeam, [{ name: 'Existing Person', role: 'Director' }]);
+});

--- a/scripts/auto-fix-show-data.test.mjs
+++ b/scripts/auto-fix-show-data.test.mjs
@@ -51,16 +51,19 @@ function loadWithMocks({ serpQueryImpl, ibdbCreativeTeam }) {
     },
   };
 
-  const mod = require(targetPath);
-
-  // Restore the real modules for anything requiring them after this point.
-  delete require.cache[urlDiscoveryPath];
-  delete require.cache[ibdbDatesPath];
-  delete require.cache[targetPath];
-  require.cache[urlDiscoveryPath] = { id: urlDiscoveryPath, filename: urlDiscoveryPath, loaded: true, exports: realUrlDiscovery };
-  require.cache[ibdbDatesPath] = { id: ibdbDatesPath, filename: ibdbDatesPath, loaded: true, exports: realIbdbDates };
-
-  return mod;
+  try {
+    return require(targetPath);
+  } finally {
+    // Restore the real modules for anything requiring them after this point,
+    // even if requiring targetPath threw — a leaked mock in require.cache
+    // would otherwise silently poison every later test in this process that
+    // does a plain require('./lib/ibdb-dates') / require('./lib/url-discovery').
+    delete require.cache[urlDiscoveryPath];
+    delete require.cache[ibdbDatesPath];
+    delete require.cache[targetPath];
+    require.cache[urlDiscoveryPath] = { id: urlDiscoveryPath, filename: urlDiscoveryPath, loaded: true, exports: realUrlDiscovery };
+    require.cache[ibdbDatesPath] = { id: ibdbDatesPath, filename: ibdbDatesPath, loaded: true, exports: realIbdbDates };
+  }
 }
 
 function fakeShow(overrides = {}) {
@@ -155,6 +158,56 @@ test('fixCreativeTeam: IBDB step writes nothing when no member passes SERP verif
 
   assert.equal(result, null);
   assert.equal(show.creativeTeam, undefined, 'no creative team data may be introduced without verification');
+});
+
+test('verifyCreativeTeamViaSerp: dedupes duplicate name+role entries (one SERP call, one output entry)', async () => {
+  let calls = 0;
+  const { verifyCreativeTeamViaSerp } = loadWithMocks({
+    serpQueryImpl: async () => {
+      calls++;
+      return [{ title: 'Example opens', snippet: 'Example, directed by Mary Zimmerman, begins previews.' }];
+    },
+    ibdbCreativeTeam: [],
+  });
+
+  const proposed = [
+    { name: 'Mary Zimmerman', role: 'Director' },
+    { name: 'Mary Zimmerman', role: 'Director' },
+    { name: 'mary zimmerman', role: 'director' }, // case-insensitive duplicate
+  ];
+  const verified = await verifyCreativeTeamViaSerp(fakeShow(), proposed, '2026', 'serp-verified-ibdb');
+
+  assert.equal(calls, 1, 'duplicate members must only be SERP-queried once');
+  assert.equal(verified.length, 1, 'duplicate members must only appear once in the output');
+});
+
+test('verifyCreativeTeamViaSerp: a blank/missing name is rejected without a network call (would otherwise wildcard-match any "<verb> <anyone>" snippet)', async () => {
+  let calls = 0;
+  const { verifyCreativeTeamViaSerp } = loadWithMocks({
+    serpQueryImpl: async () => { calls++; return [{ title: 'Example opens', snippet: 'Example, directed by Someone Else, begins previews.' }]; },
+    ibdbCreativeTeam: [],
+  });
+
+  const proposed = [{ name: '', role: 'Director' }, { name: '   ', role: 'Director' }];
+  const verified = await verifyCreativeTeamViaSerp(fakeShow(), proposed, '2026', 'serp-verified-ibdb');
+
+  assert.deepEqual(verified, []);
+  assert.equal(calls, 0, 'a blank name must never reach serpQuery');
+});
+
+test('verifyCreativeTeamViaSerp: "Music & Lyrics" confirms on either "music and lyrics by" or "music & lyrics by"', async () => {
+  const { verifyCreativeTeamViaSerp } = loadWithMocks({
+    serpQueryImpl: async () => [
+      { title: 'Example opens', snippet: 'Example, music & lyrics by Jason Robert Brown, begins previews.' },
+    ],
+    ibdbCreativeTeam: [],
+  });
+
+  const proposed = [{ name: 'Jason Robert Brown', role: 'Music & Lyrics' }];
+  const verified = await verifyCreativeTeamViaSerp(fakeShow(), proposed, '2026', 'serp-verified-ibdb');
+
+  assert.equal(verified.length, 1);
+  assert.equal(verified[0].name, 'Jason Robert Brown');
 });
 
 test('fixCreativeTeam: IBDB step never overwrites an existing creativeTeam[1] with an unverified replacement', async () => {

--- a/scripts/lib/creative-team-verify.js
+++ b/scripts/lib/creative-team-verify.js
@@ -20,6 +20,10 @@ const ROLE_CANON = {
   director: 'Director', playwright: 'Playwright', choreographer: 'Choreographer',
   'book writer': 'Book Writer', book: 'Book',
   composer: 'Composer', lyricist: 'Lyricist',
+  // IBDB's extractCreativeTeamFromText() (lib/ibdb-dates.js) emits these
+  // exact labels — added for BRO-102 so the IBDB scrape path can route
+  // through the same SERP-verification gate as the LLM path.
+  music: 'Music', lyrics: 'Lyrics', 'music & lyrics': 'Music & Lyrics',
 };
 
 /**
@@ -33,8 +37,9 @@ function roleVerb(role) {
          r === 'playwright' ? 'written by' :
          r === 'choreographer' ? 'choreographed by' :
          (r === 'book writer' || r === 'book') ? 'book by' :
-         r === 'composer' ? 'music by' :
-         r === 'lyricist' ? 'lyrics by' : null;
+         (r === 'composer' || r === 'music') ? 'music by' :
+         (r === 'lyricist' || r === 'lyrics') ? 'lyrics by' :
+         r === 'music & lyrics' ? 'music and lyrics by' : null;
 }
 
 /**

--- a/scripts/lib/creative-team-verify.test.mjs
+++ b/scripts/lib/creative-team-verify.test.mjs
@@ -51,6 +51,25 @@ test('ROLE_CANON preserves exact-case labels for data-creative.ts routing', () =
   assert.equal(ROLE_CANON['playwright'], 'Playwright');
 });
 
+// BRO-102: IBDB's extractCreativeTeamFromText() (lib/ibdb-dates.js) emits
+// "Music"/"Lyrics"/"Music & Lyrics" (not "composer"/"lyricist") — roleVerb
+// must recognize both so the IBDB scrape path can route composer/lyricist
+// credits through the same SERP-verification gate as the LLM path.
+test('roleVerb recognizes IBDB label variants alongside the LLM-facing labels', () => {
+  assert.equal(roleVerb('music'), 'music by');
+  assert.equal(roleVerb('Music'), 'music by');
+  assert.equal(roleVerb('lyrics'), 'lyrics by');
+  assert.equal(roleVerb('Lyrics'), 'lyrics by');
+  assert.equal(roleVerb('music & lyrics'), 'music and lyrics by');
+  assert.equal(roleVerb('Music & Lyrics'), 'music and lyrics by');
+});
+
+test('ROLE_CANON maps IBDB label variants to their own exact-case labels', () => {
+  assert.equal(ROLE_CANON['music'], 'Music');
+  assert.equal(ROLE_CANON['lyrics'], 'Lyrics');
+  assert.equal(ROLE_CANON['music & lyrics'], 'Music & Lyrics');
+});
+
 test('roleVerbVariants covers audit-only roles and rejects design roles', () => {
   assert.ok(roleVerbVariants('Music & Lyrics').includes('music and lyrics by'));
   assert.ok(roleVerbVariants('composer').includes('composed by'));

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -14,6 +14,7 @@ scripts/audit-show-review-gap.test.mjs
 scripts/audit-standing-coverage.test.mjs
 scripts/audit-test-yml-lib-deps.test.mjs
 scripts/audit-venue-complex-slugs.test.mjs
+scripts/auto-fix-show-data.test.mjs
 scripts/autonomous-acceptance-recheck.test.mjs
 scripts/autonomous-merge-core-data-guard.test.mjs
 scripts/autonomous-merge-parity.test.mjs


### PR DESCRIPTION
## Summary
- The IBDB step in `fixCreativeTeam()` (scripts/auto-fix-show-data.js) took `ibdb.creativeTeam` verbatim — a wrong regex-extracted table cell or stale IBDB entry could ship a hallucinated attribution, the same failure class the LLM proposal path was hardened against on 2026-05-26.
- Extracted that path's per-member SERP-verification loop into a shared `verifyCreativeTeamViaSerp()` and routed both the LLM path and the IBDB path through it. Unverifiable design/tech-credit roles (Scenic Design, Orchestrations, ...) are rejected rather than trusted verbatim, matching the LLM path's existing "omit if uncertain" policy.
- Extended `roleVerb`/`ROLE_CANON` in `scripts/lib/creative-team-verify.js` to recognize IBDB's own role labels (`Music`, `Lyrics`, `Music & Lyrics`) so composer/lyricist credits scraped from IBDB can be verified too.
- Follow-up hardening from an independent ship-check review: reject blank/malformed names, dedupe proposed members, accept "music & lyrics by" alongside "music and lyrics by", and a try/finally around the test mock cleanup.
- New colocated test `scripts/auto-fix-show-data.test.mjs` (registered in `tests/unit-test-manifest.txt` + `.github/workflows/test.yml` path filter, since root-level `scripts/*.test.mjs` isn't globbed).

Linear: BRO-102

## Test plan
- [x] `node --test scripts/auto-fix-show-data.test.mjs` (the exact acceptance-criteria command) — 9/9 pass
- [x] `node --test scripts/lib/creative-team-verify.test.mjs` — 11/11 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint` — no new warnings
- [x] `/second-opinion` plan review recorded before the test.yml CI-workflow edit (rule 18)
- [x] `/ship-check` — codebase-aware + Codex adversarial review, findings fixed, verdict recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)