### PR TITLE
fix: prefer in-body byline over WP house-account mapping in scrape-wp-theater-blogs.js (BRO-112)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -533,6 +533,12 @@ on:
       # scripts/lib/** glob above.
       - 'scripts/scrape-broadway-com-audience.js'
       - 'scripts/scrape-broadway-com-audience.test.mjs'
+      # BRO-112: top-level scripts/ file (no scripts/** glob) with a colocated
+      # test registered explicitly in tests/unit-test-manifest.txt (root-level
+      # scripts/*.test.mjs files are NOT globbed) — both need their own entry
+      # so a solo edit to either triggers CI.
+      - 'scripts/scrape-wp-theater-blogs.js'
+      - 'scripts/scrape-wp-theater-blogs.test.mjs'
       # Canonical Broadway-only scope + designation criteria for the commercial-
       # research pipeline (2026-07-14 market-vs-category leak). Colocated test
       # runs in the lib-test glob; path-listed so a solo edit triggers CI.

--- a/scripts/scrape-wp-theater-blogs.js
+++ b/scripts/scrape-wp-theater-blogs.js
@@ -20,7 +20,7 @@ const path = require('path');
 const https = require('https');
 const cheerio = require('cheerio');
 const { matchTitleToShow, loadShows } = require('./lib/show-matching');
-const { classifyContentTier } = require('./lib/content-quality');
+const { classifyContentTier, extractTheaterLifeByline } = require('./lib/content-quality');
 const { cleanText } = require('./lib/text-cleaning');
 const { setExtractedScore } = require('./lib/score-routing');
 const { createOrMergeReviewFile } = require('./lib/review-file-writer');
@@ -77,6 +77,10 @@ const SITES = [
     minContentLength: 500,
     extractStarRating: true,  // "Show Name *** 1/2" in titles
     usersEndpointPublic: true,
+    // WP author id 2 ("Barry Gordin") is the site's shared publishing/admin
+    // account, not the critic — every post's WP author resolves to it. The
+    // real byline is in-body ("By: <Name>"). See BRO-112 / Notion 39b637c5.
+    authorMappingIsHouseAccount: true,
   },
 ];
 
@@ -232,6 +236,20 @@ async function fetchAuthorMapping(site) {
 // ---------------------------------------------------------------------------
 // Author extraction fallback
 // ---------------------------------------------------------------------------
+
+// Resolve author: knownAuthors map (hand-verified) → in-body byline (when the
+// WP author mapping is a shared house account rather than the critic, e.g.
+// theaterlife.com's every post resolving to site owner "Barry Gordin" —
+// BRO-112) → WP users mapping → regex fallback.
+function resolveAuthorName(site, authorId, authorMapping, plainText, post) {
+  if (site.knownAuthors && site.knownAuthors[authorId]) {
+    return site.knownAuthors[authorId];
+  }
+  if (site.authorMappingIsHouseAccount) {
+    return extractTheaterLifeByline(plainText) || authorMapping[authorId] || extractAuthorFromContent(post) || 'Unknown';
+  }
+  return authorMapping[authorId] || extractAuthorFromContent(post) || 'Unknown';
+}
 
 function extractAuthorFromContent(post) {
   // Non-greedy name regex: 2-4 words starting with uppercase (handles McCall, O'Brien, Porter II)
@@ -503,8 +521,7 @@ async function scrapeSite(site, shows) {
       continue;
     }
 
-    // Resolve author: knownAuthors map → WP users mapping → regex fallback
-    let authorName = (site.knownAuthors && site.knownAuthors[authorId]) || authorMapping[authorId] || extractAuthorFromContent(post) || 'Unknown';
+    const authorName = resolveAuthorName(site, authorId, authorMapping, plainText, post);
 
     // Build review data
     const reviewData = {
@@ -623,7 +640,11 @@ async function main() {
   }
 }
 
-main().catch(err => {
-  console.error('Fatal error:', err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(err => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = { SITES, resolveAuthorName, extractAuthorFromContent };

--- a/scripts/scrape-wp-theater-blogs.test.mjs
+++ b/scripts/scrape-wp-theater-blogs.test.mjs
@@ -1,0 +1,102 @@
+// Regression test for BRO-112: scrape-wp-theater-blogs.js re-created the
+// phantom "Barry Gordin" byline class at scale (207 files, 8 live
+// double-counted reviews) because its authorName resolution checked the WP
+// author mapping BEFORE the in-body byline. theaterlife.com's WP author id 2
+// is the site's shared house/admin account "Barry Gordin" — never the actual
+// critic — so authorMapping[authorId] always resolved truthy and the real
+// in-body "By: <name>" byline (which extractTheaterLifeByline already parses
+// correctly, see tests/unit/theaterlife-byline.test.mjs and Notion 39b637c5)
+// was never even consulted.
+//
+// Requires the REAL exported resolveAuthorName per CLAUDE.md rule 15 — no
+// logic copies. Registered explicitly in tests/unit-test-manifest.txt
+// (top-level scripts/*.test.mjs is not globbed).
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { SITES, resolveAuthorName } = require('./scrape-wp-theater-blogs.js');
+
+const theaterLife = SITES.find((s) => s.id === 'theater-life');
+const frontRowCenter = SITES.find((s) => s.id === 'front-row-center');
+
+// Real corpus shape (a-dolls-house-2023/theater-life--barry-gordin.json):
+// criticName was stamped "Barry Gordin" even though the post literally opens
+// with a different critic's byline.
+const REAL_BYLINE_TEXT = 'By: Samuel L. Leiter\n\nMarch 17, 2023: Jessica Chastain’s compelling performance of Nora';
+const NO_BYLINE_TEXT = 'A review with no recognizable byline anywhere in the text.';
+
+describe('resolveAuthorName', () => {
+  const cases = [
+    {
+      name: 'house-account site: in-body byline wins over the WP author mapping',
+      site: theaterLife,
+      authorId: 2,
+      authorMapping: { 2: 'Barry Gordin' },
+      plainText: REAL_BYLINE_TEXT,
+      post: {},
+      expected: 'Samuel L. Leiter',
+    },
+    {
+      name: 'house-account site: falls back to WP author mapping when no in-body byline parses',
+      site: theaterLife,
+      authorId: 2,
+      authorMapping: { 2: 'Barry Gordin' },
+      plainText: NO_BYLINE_TEXT,
+      post: {},
+      expected: 'Barry Gordin',
+    },
+    {
+      name: 'house-account site: falls back to Unknown when nothing resolves',
+      site: theaterLife,
+      authorId: 999,
+      authorMapping: {},
+      plainText: NO_BYLINE_TEXT,
+      post: {},
+      expected: 'Unknown',
+    },
+    {
+      name: 'non-house-account site: WP author mapping still wins over content extraction (unchanged behavior)',
+      site: { id: 'other-site', usersEndpointPublic: true },
+      authorId: 5,
+      authorMapping: { 5: 'Some Real Author' },
+      plainText: REAL_BYLINE_TEXT,
+      post: {},
+      expected: 'Some Real Author',
+    },
+    {
+      name: 'knownAuthors map wins unconditionally, even ahead of authorMapping',
+      site: frontRowCenter,
+      authorId: 2,
+      authorMapping: { 2: 'Wrong Name From WP' },
+      plainText: REAL_BYLINE_TEXT,
+      post: {},
+      expected: frontRowCenter.knownAuthors[2],
+    },
+    {
+      name: 'knownAuthors map wins even when authorMappingIsHouseAccount is also set',
+      site: { ...theaterLife, knownAuthors: { 2: 'Hand-Verified Critic' } },
+      authorId: 2,
+      authorMapping: { 2: 'Barry Gordin' },
+      plainText: REAL_BYLINE_TEXT,
+      post: {},
+      expected: 'Hand-Verified Critic',
+    },
+  ];
+
+  for (const c of cases) {
+    test(c.name, () => {
+      assert.strictEqual(
+        resolveAuthorName(c.site, c.authorId, c.authorMapping, c.plainText, c.post),
+        c.expected
+      );
+    });
+  }
+});
+
+describe('theater-life site config', () => {
+  test('is flagged as a WP house account so the priority override applies', () => {
+    assert.strictEqual(theaterLife.authorMappingIsHouseAccount, true);
+  });
+});

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -74,6 +74,7 @@ scripts/produce-coverage-digest-snapshot.test.mjs
 scripts/reconcile-dead-completions.test.mjs
 scripts/scoring-delta-autoclear-coverage.test.mjs
 scripts/scrape-broadway-com-audience.test.mjs
+scripts/scrape-wp-theater-blogs.test.mjs
 scripts/send-opening-night-broadcast.test.mjs
 scripts/telegraph-reviews-index.test.mjs
 scripts/tests/agent-auth-preflight.test.mjs


### PR DESCRIPTION
## Summary
- theaterlife.com's WP author id 2 ("Barry Gordin") is the site's shared publishing/admin account, not the critic. `scrape-wp-theater-blogs.js`'s authorName priority checked the WP author mapping before the in-body byline, so every scraped post landed as `theater-life--barry-gordin.json` — 207 phantom files in the corpus, 8 live double-counted reviews (confirmed by direct inspection: files stamped `criticName: "Barry Gordin"` whose `fullText` opens with `By: Samuel L. Leiter` etc).
- Extracted a pure `resolveAuthorName(site, authorId, authorMapping, plainText, post)` and wired in the already-hardened `extractTheaterLifeByline()` (`scripts/lib/content-quality.js`, previously fixed the same class for a different scraper path — Notion 39b637c5) ahead of the WP mapping for sites flagged `authorMappingIsHouseAccount: true`.
- Added a `require.main === module` guard + exports so the fix is unit-testable without triggering a live scrape.

## Test plan
- [x] `node --test scripts/scrape-wp-theater-blogs.test.mjs` — 7/7 pass (per BRO-112 acceptance criteria)
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint --file scripts/scrape-wp-theater-blogs.js` — clean
- [x] Verified `front-row-center` (knownAuthors map) is unaffected — `resolveAuthorName` short-circuits on `knownAuthors` before the house-account branch
- [x] Verified `require()`-ing the module no longer triggers the live scrape
- [x] `/second-opinion` plan review (CI wiring) + adversarial `/ship-check` review — both passed, no blockers
- [ ] Not in scope: backfilling the 207 existing phantom files in the private review-texts repo — tracked separately (Notion card for BRO-112 predecessor, closed as duplicate with Linear as system of record); this PR only stops new phantom attributions going forward (weekly cron `scrape-wp-blogs.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)