### PR TITLE
Route remaining IBDB creativeTeam consumers through SERP verification (#1863, BRO-102 follow-up)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1372,6 +1372,14 @@ on:
       # lib-test step, but only if this job fires — these paths trigger it on push).
       - 'scripts/enrich-ibdb-dates.js'
       - 'scripts/discover-new-shows.js'
+      # task #1863 (BRO-102 follow-up): IBDB creativeTeam consumers now route
+      # through verifyCreativeTeamViaSerp(). Colocated *.test.mjs files
+      # (root-level scripts/*.test.mjs is NOT globbed, registered in
+      # tests/unit-test-manifest.txt) — path-listed so a solo edit to either
+      # side triggers CI.
+      - 'scripts/enrich-ibdb-dates.test.mjs'
+      - 'scripts/backfill-playwright-credits.js'
+      - 'scripts/backfill-playwright-credits.test.mjs'
       # Task #649 set-diff gate: shared by update-show-status.yml's discovery
       # commit gate and enrich-ibdb-dates.js's date-enrichment gate. Test
       # lives in tests/unit/ (node --test batch, not globbed) — path-listed

--- a/scripts/auto-fix-show-data.js
+++ b/scripts/auto-fix-show-data.js
@@ -19,8 +19,7 @@ const { isValidSynopsis, classifyBadSynopsis } = require('./lib/synopsis-validat
 const { imageOnDisk } = require('./lib/show-images');
 const { verifyProductionMatch } = require('./lib/synopsis-production-match');
 const { isValidCreativeTeamName, lookupIBDBDates } = require('./lib/ibdb-dates');
-const { serpQuery } = require('./lib/url-discovery');
-const { ROLE_CANON, roleVerb, serpTextConfirms } = require('./lib/creative-team-verify');
+const { verifyCreativeTeamViaSerp } = require('./lib/creative-team-verify');
 const { CLAUDE_HAIKU, CLAUDE_OPUS } = require('./lib/models');
 const showsWriteGuard = require('./lib/shows-write-guard');
 const { cleanup: cleanupScraper } = require('./lib/scraper');
@@ -417,91 +416,12 @@ Return ONLY the JSON array, no other text. Example:
   return verified.length > 0 ? verified : null;
 }
 
-// Shared SERP-verification gate for creative-team writes.
-//
-// 2026-05-26: previously non-director roles proposed by the LLM were accepted
-// without verification. Result: LLM hallucinated "Martyna Majok (Book Writer)"
-// for Liberation (correct: Bess Wohl, Playwright) and reached production. Now
-// ALL roles require SERP confirmation; unrecognized roles (design/tech
-// credits with no reliable "<verb> <name>" attribution phrase — Scenic
-// Design, Orchestrations, etc.) are rejected rather than trusted verbatim.
-//
-// BRO-102: the IBDB scrape path (Step 2 in fixCreativeTeam) previously took
-// ibdb.creativeTeam verbatim — a wrong table cell or stale IBDB entry would
-// repeat the same wrong-attribution pattern for any Broadway show with an
-// ibdbUrl. It now routes through this same gate before writing.
-//
-// Decision logic (roleVerb/ROLE_CANON/serpTextConfirms) lives in
-// lib/creative-team-verify.js, shared with audit-creative-team-serp.js,
-// which retro-verifies pre-guard entries.
-//
-// Cost: this adds up to ~7 SERP calls (one per verifiable role) where the
-// IBDB path previously made zero. Bounded by check-show-freshness.yml's
-// open/previews-only scope for the daily cron; a large --backfill-historical
-// or targeted --show= batch run is the case to watch if SB SERP credit burn
-// spikes.
-//
-// Scope note: this SERP check confirms "<verb> <name>" for the show's TITLE,
-// not its specific production year — it can't tell a 2026 revival's director
-// from a same-titled 1990s production's director if both are attributable
-// online. For the IBDB caller that's covered upstream: lookupIBDBDates()'s
-// production-year gate (lib/ibdb-dates.js) already rejects ibdb.creativeTeam
-// entirely when the IBDB page's year doesn't match the show's openingYear, so
-// only same-production entries ever reach this function. Callers without an
-// equivalent upstream year gate should not assume this function verifies
-// production identity, only name+role attribution.
-async function verifyCreativeTeamViaSerp(show, proposed, year, sourceTag) {
-  const verified = [];
-  const seen = new Set(); // name+role dedup — a shared gate can't assume every caller pre-dedupes
-  for (const member of proposed) {
-    const name = String(member.name || '').trim();
-    if (!name) {
-      console.log(`    ❌ Blank/missing name for role "${member.role}" — rejecting`);
-      continue;
-    }
-    const role = String(member.role || '').toLowerCase();
-    const dedupeKey = `${role}::${name.toLowerCase()}`;
-    if (seen.has(dedupeKey)) continue;
-    seen.add(dedupeKey);
-
-    const verb = roleVerb(role);
-    if (!verb) {
-      console.log(`    ❌ Unrecognized role "${member.role}" for ${name} — rejecting (cannot SERP-verify)`);
-      continue;
-    }
-    const canonRole = ROLE_CANON[role] || member.role;
-    // "Music & Lyrics" is published inconsistently ("music and lyrics by" vs
-    // "music & lyrics by") — accept either spelling for this one role rather
-    // than widening every role to roleVerbVariants (which would weaken the
-    // single-verb hallucination signal the other roles rely on).
-    const phrases = role === 'music & lyrics' ? [verb, 'music & lyrics by'] : [verb];
-
-    const query = `"${show.title}" ${year} "${verb} ${name}"`;
-    console.log(`    🔍 Verifying: ${name} (${member.role}) via SERP...`);
-    try {
-      await sleep(500);
-      const serpResults = await serpQuery(query);
-      if (serpResults && serpResults.length > 0) {
-        // Require the full phrase "directed by [name]" in a snippet — not just
-        // the name — anchored to a segment naming this show (see
-        // lib/creative-team-verify.js for the snippet-stitching failure mode).
-        const confirmed = serpTextConfirms(serpResults, phrases, name, { title: show.title });
-        if (confirmed) {
-          console.log(`    ✅ SERP confirmed: ${name} (${member.role})`);
-          verified.push({ ...member, name, role: canonRole, _source: sourceTag });
-        } else {
-          console.log(`    ❌ SERP did not confirm: ${member.name} (${member.role}) — rejecting`);
-        }
-      } else {
-        console.log(`    ❌ No SERP results for ${member.name} (${member.role}) — rejecting`);
-      }
-    } catch (e) {
-      console.log(`    ⚠️  SERP verification failed for ${member.name}: ${e.message}`);
-    }
-  }
-
-  return verified;
-}
+// verifyCreativeTeamViaSerp: shared SERP-verification gate for creative-team
+// writes — moved to lib/creative-team-verify.js (BRO-102 follow-up, task
+// #1863) so discover-new-shows.js/enrich-ibdb-dates.js/
+// backfill-playwright-credits.js can import it without pulling in this
+// file's other dependencies. See that file's doc comment for the full
+// history and scope notes.
 
 // Fix creative team - fetch from TodayTix, IBDB (Broadway), or SERP-verified LLM (OB/WE)
 async function fixCreativeTeam(show, todayTixIds) {

--- a/scripts/auto-fix-show-data.test.mjs
+++ b/scripts/auto-fix-show-data.test.mjs
@@ -19,6 +19,13 @@ process.env.SCRAPINGBEE_API_KEY = process.env.SCRAPINGBEE_API_KEY || 'test-key';
 const targetPath = require.resolve('./auto-fix-show-data.js');
 const urlDiscoveryPath = require.resolve('./lib/url-discovery.js');
 const ibdbDatesPath = require.resolve('./lib/ibdb-dates.js');
+// creative-team-verify.js destructures serpQuery from url-discovery.js at
+// require time (`const { serpQuery } = require('./url-discovery')`), so its
+// own cache entry must also be cleared — otherwise a cached copy keeps a
+// closure over the REAL serpQuery even after url-discovery.js's cache entry
+// is swapped for the mock (task #1863, caught when verifyCreativeTeamViaSerp
+// moved out of this file into the shared lib).
+const creativeTeamVerifyPath = require.resolve('./lib/creative-team-verify.js');
 
 // Load auto-fix-show-data.js with serpQuery and lookupIBDBDates swapped out.
 // Restores the real modules afterward so other tests in the same process
@@ -29,6 +36,7 @@ function loadWithMocks({ serpQueryImpl, ibdbCreativeTeam }) {
 
   delete require.cache[urlDiscoveryPath];
   delete require.cache[ibdbDatesPath];
+  delete require.cache[creativeTeamVerifyPath];
   delete require.cache[targetPath];
 
   require.cache[urlDiscoveryPath] = {
@@ -60,6 +68,7 @@ function loadWithMocks({ serpQueryImpl, ibdbCreativeTeam }) {
     // does a plain require('./lib/ibdb-dates') / require('./lib/url-discovery').
     delete require.cache[urlDiscoveryPath];
     delete require.cache[ibdbDatesPath];
+    delete require.cache[creativeTeamVerifyPath];
     delete require.cache[targetPath];
     require.cache[urlDiscoveryPath] = { id: urlDiscoveryPath, filename: urlDiscoveryPath, loaded: true, exports: realUrlDiscovery };
     require.cache[ibdbDatesPath] = { id: ibdbDatesPath, filename: ibdbDatesPath, loaded: true, exports: realIbdbDates };

--- a/scripts/backfill-playwright-credits.js
+++ b/scripts/backfill-playwright-credits.js
@@ -20,6 +20,7 @@ const path = require('path');
 const { lookupIBDBDates } = require('./lib/ibdb-dates');
 const { cleanup } = require('./lib/scraper');
 const { splitCombinedCredits } = require('./lib/credit-splitting');
+const { verifyCreativeTeamViaSerp } = require('./lib/creative-team-verify');
 const showsWriteGuard = require('./lib/shows-write-guard');
 const { pushWithRetry } = require('./lib/push-with-retry.js');
 
@@ -173,6 +174,21 @@ function mergeCreativeTeam(existing, ibdbTeam, targetRole) {
   return { merged, added: newEntries };
 }
 
+// BRO-102 follow-up (task #1863): SERP-verifies IBDB-scraped Playwright
+// credits before merging — the IBDB regex extraction can grab the wrong
+// table cell or carry stale data, same failure class as the other
+// ibdb.creativeTeam consumers. Returns { merged, added: [] } (no-op) when
+// nothing survives verification.
+async function verifyAndMergePlaywright(show, ibdbCreativeTeam, year) {
+  const playwrightEntries = (ibdbCreativeTeam || []).filter(e => e.role === 'Playwright');
+  if (playwrightEntries.length === 0) return { merged: show.creativeTeam || [], added: [] };
+
+  const verified = await verifyCreativeTeamViaSerp(show, playwrightEntries, year, 'serp-verified-ibdb-playwright-backfill');
+  if (verified.length === 0) return { merged: show.creativeTeam || [], added: [] };
+
+  return mergeCreativeTeam(show.creativeTeam || [], verified, 'Playwright');
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -280,10 +296,10 @@ async function main() {
           const showRecord = data.shows.find(s => s.id === show.id);
           if (!showRecord) continue;
 
-          const { merged, added } = mergeCreativeTeam(
-            showRecord.creativeTeam || [],
+          const { merged, added } = await verifyAndMergePlaywright(
+            showRecord,
             ibdb.creativeTeam,
-            'Playwright'
+            openingYear || 'upcoming'
           );
 
           if (added.length > 0) {
@@ -365,11 +381,19 @@ async function main() {
   }
 }
 
-main()
-  .catch(e => {
-    console.error('Backfill failed:', e);
-    process.exit(1);
-  })
-  .finally(() => {
-    cleanup().catch(() => {});
-  });
+if (require.main === module) {
+  main()
+    .catch(e => {
+      console.error('Backfill failed:', e);
+      process.exit(1);
+    })
+    .finally(() => {
+      cleanup().catch(() => {});
+    });
+}
+
+// Exports for unit tests (task #1863) — verifyAndMergePlaywright is the
+// SERP-verification gate for this file's IBDB Playwright-credit writes;
+// tests exercise it directly against a mocked verifyCreativeTeamViaSerp
+// rather than re-implementing its decision logic (CLAUDE.md rule 15).
+module.exports = { verifyAndMergePlaywright, mergeCreativeTeam };

--- a/scripts/backfill-playwright-credits.js
+++ b/scripts/backfill-playwright-credits.js
@@ -178,12 +178,16 @@ function mergeCreativeTeam(existing, ibdbTeam, targetRole) {
 // credits before merging — the IBDB regex extraction can grab the wrong
 // table cell or carry stale data, same failure class as the other
 // ibdb.creativeTeam consumers. Returns { merged, added: [] } (no-op) when
-// nothing survives verification.
+// nothing survives verification. Splits combined names first — a combined
+// "John Doe & Jane Smith" credit would otherwise be SERP-queried as one
+// literal phrase and silently fail to confirm (same reasoning as
+// discover-new-shows.js/enrich-ibdb-dates.js, ship-check 2026-08-20).
 async function verifyAndMergePlaywright(show, ibdbCreativeTeam, year) {
   const playwrightEntries = (ibdbCreativeTeam || []).filter(e => e.role === 'Playwright');
   if (playwrightEntries.length === 0) return { merged: show.creativeTeam || [], added: [] };
 
-  const verified = await verifyCreativeTeamViaSerp(show, playwrightEntries, year, 'serp-verified-ibdb-playwright-backfill');
+  const { result: splitEntries } = splitCombinedCredits(playwrightEntries);
+  const verified = await verifyCreativeTeamViaSerp(show, splitEntries, year, 'serp-verified-ibdb-playwright-backfill');
   if (verified.length === 0) return { merged: show.creativeTeam || [], added: [] };
 
   return mergeCreativeTeam(show.creativeTeam || [], verified, 'Playwright');

--- a/scripts/backfill-playwright-credits.test.mjs
+++ b/scripts/backfill-playwright-credits.test.mjs
@@ -1,0 +1,77 @@
+// task #1863 (BRO-102 follow-up): verifyAndMergePlaywright() routes
+// IBDB-scraped Playwright credits through the same SERP-verification gate
+// as auto-fix-show-data.js before merging into show.creativeTeam.
+// Previously this file merged ibdb.creativeTeam verbatim.
+//
+// Mocks verifyCreativeTeamViaSerp (the network boundary) rather than
+// re-implementing its decision logic — CLAUDE.md rule 15.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const creativeTeamVerifyPath = require.resolve('./lib/creative-team-verify.js');
+const targetPath = require.resolve('./backfill-playwright-credits.js');
+
+function loadWithMockedVerify(verifyImpl) {
+  const real = require(creativeTeamVerifyPath);
+  delete require.cache[creativeTeamVerifyPath];
+  delete require.cache[targetPath];
+  require.cache[creativeTeamVerifyPath] = {
+    id: creativeTeamVerifyPath, filename: creativeTeamVerifyPath, loaded: true,
+    exports: { ...real, verifyCreativeTeamViaSerp: verifyImpl },
+  };
+  try {
+    return require(targetPath);
+  } finally {
+    delete require.cache[creativeTeamVerifyPath];
+    delete require.cache[targetPath];
+    require.cache[creativeTeamVerifyPath] = { id: creativeTeamVerifyPath, filename: creativeTeamVerifyPath, loaded: true, exports: real };
+  }
+}
+
+function fakeShow(overrides = {}) {
+  return { id: 'example-2026', title: 'Example', openingDate: '2026-01-15', creativeTeam: [], ...overrides };
+}
+
+test('verifyAndMergePlaywright: no Playwright entries in IBDB team -> no-op, no SERP call', async () => {
+  let calls = 0;
+  const { verifyAndMergePlaywright } = loadWithMockedVerify(async () => { calls++; return []; });
+  const show = fakeShow();
+  const { merged, added } = await verifyAndMergePlaywright(show, [{ name: 'Some Director', role: 'Director' }], '2026');
+  assert.deepEqual(merged, []);
+  assert.deepEqual(added, []);
+  assert.equal(calls, 0, 'no Playwright entries means no verification call should be made');
+});
+
+test('verifyAndMergePlaywright: unconfirmed Playwright is rejected (wrong-table-cell case)', async () => {
+  const { verifyAndMergePlaywright } = loadWithMockedVerify(async () => []);
+  const show = fakeShow();
+  const { merged, added } = await verifyAndMergePlaywright(show, [{ name: 'Hallucinated Writer', role: 'Playwright' }], '2026');
+  assert.deepEqual(merged, []);
+  assert.deepEqual(added, []);
+});
+
+test('verifyAndMergePlaywright: a confirmed Playwright is merged in', async () => {
+  const { verifyAndMergePlaywright } = loadWithMockedVerify(async (show, proposed, year, sourceTag) =>
+    proposed.map(m => ({ ...m, _source: sourceTag }))
+  );
+  const show = fakeShow({ creativeTeam: [{ name: 'Existing Director', role: 'Director' }] });
+  const { merged, added } = await verifyAndMergePlaywright(show, [{ name: 'Reginald Rose', role: 'Playwright' }], '2026');
+  assert.equal(added.length, 1);
+  assert.equal(added[0].name, 'Reginald Rose');
+  assert.equal(added[0]._source, 'serp-verified-ibdb-playwright-backfill');
+  assert.equal(merged.length, 2);
+  assert.equal(merged[1].name, 'Reginald Rose', 'inserted after Director');
+});
+
+test('verifyAndMergePlaywright: role already present -> mergeCreativeTeam no-ops even if verified', async () => {
+  const { verifyAndMergePlaywright } = loadWithMockedVerify(async (show, proposed, year, sourceTag) =>
+    proposed.map(m => ({ ...m, _source: sourceTag }))
+  );
+  const show = fakeShow({ creativeTeam: [{ name: 'Existing Playwright', role: 'Playwright' }] });
+  const { merged, added } = await verifyAndMergePlaywright(show, [{ name: 'Another Playwright', role: 'Playwright' }], '2026');
+  assert.deepEqual(added, []);
+  assert.equal(merged.length, 1);
+});

--- a/scripts/backfill-playwright-credits.test.mjs
+++ b/scripts/backfill-playwright-credits.test.mjs
@@ -66,6 +66,18 @@ test('verifyAndMergePlaywright: a confirmed Playwright is merged in', async () =
   assert.equal(merged[1].name, 'Reginald Rose', 'inserted after Director');
 });
 
+test('verifyAndMergePlaywright: a combined Playwright credit is split before SERP verification', async () => {
+  let seenProposed;
+  const { verifyAndMergePlaywright } = loadWithMockedVerify(async (show, proposed) => {
+    seenProposed = proposed;
+    return [];
+  });
+  const show = fakeShow();
+  await verifyAndMergePlaywright(show, [{ name: 'John Doe & Jane Smith', role: 'Playwright' }], '2026');
+  assert.equal(seenProposed.length, 2, 'combined name must be split into individual entries before verification');
+  assert.deepEqual(seenProposed.map(m => m.name).sort(), ['Jane Smith', 'John Doe']);
+});
+
 test('verifyAndMergePlaywright: role already present -> mergeCreativeTeam no-ops even if verified', async () => {
   const { verifyAndMergePlaywright } = loadWithMockedVerify(async (show, proposed, year, sourceTag) =>
     proposed.map(m => ({ ...m, _source: sourceTag }))

--- a/scripts/discover-new-shows.js
+++ b/scripts/discover-new-shows.js
@@ -47,6 +47,7 @@ const { ibdbYearMismatch, expectedShowYear } = require('./lib/ibdb-year-guard');
 const { getTheaterAddress } = require('./lib/venue-addresses');
 const { cleanSearchTitle } = require('./lib/title-normalization');
 const { splitCombinedCredits } = require('./lib/credit-splitting');
+const { verifyCreativeTeamViaSerp } = require('./lib/creative-team-verify');
 const { scrapeCurrentRuntimes, matchRuntimesToShows, batchScrapeAgeRecommendations } = require('./lib/broadway-com-runtimes');
 const { classifyGenre, applyGenreCategoryOverride } = require('./lib/genre-classification');
 const { isLondonMarket, isOffWestEndVenue, isWestEndVenue, isKnownOffBroadwayVenue, isBroadwayCategory, sanitizeVenueForWrite } = require('./lib/venue-classification');
@@ -1727,6 +1728,27 @@ function saveShows(data) {
   showsWriteGuard.saveShows(data);
 }
 
+// BRO-102 follow-up (task #1863): this is the first-write path for every
+// newly-discovered Broadway show's creative team — the highest-risk of the
+// IBDB creativeTeam consumers, since a bad write here ships before
+// auto-fix-show-data.js's own IBDB step ever sees the show (that step only
+// fires when the team is empty/1-entry, which won't be true once this
+// write lands). Splits combined credits first so each individual name gets
+// its own SERP query (a combined "John Doe & Jane Smith" name would never
+// match a "directed by John Doe" snippet). Mutates show.creativeTeam only
+// when at least one member survives verification — leaves it unset
+// otherwise so a later enrichment pass can retry.
+async function applyVerifiedIbdbCreativeTeam(show, ibdbCreativeTeam) {
+  const { result } = splitCombinedCredits(ibdbCreativeTeam);
+  const year = show.openingDate?.slice(0, 4) || 'upcoming';
+  const verified = await verifyCreativeTeamViaSerp(show, result, year, 'serp-verified-ibdb-discovery');
+  if (verified.length > 0) {
+    show.creativeTeam = verified;
+  } else {
+    console.log(`    ⚠️  "${show.title}": No IBDB creative-team members passed SERP verification — leaving unset`);
+  }
+}
+
 async function discoverShows() {
   console.log('='.repeat(60));
   console.log(includeWestEnd ? 'BROADWAY + WEST END SHOW DISCOVERY' : 'BROADWAY SHOW DISCOVERY');
@@ -2275,8 +2297,7 @@ async function discoverShows() {
         // pattern.
         if (ibdb.creativeTeam && ibdb.creativeTeam.length > 0
             && (!show.creativeTeam || show.creativeTeam.length === 0)) {
-          const { result } = splitCombinedCredits(ibdb.creativeTeam);
-          show.creativeTeam = result;
+          await applyVerifiedIbdbCreativeTeam(show, ibdb.creativeTeam);
         }
 
         // Use IBDB show type classification if available
@@ -2701,4 +2722,5 @@ module.exports = {
   VENUE_LISTING_PAGES,
   fetchSingleVenuePage,
   shouldExcludeVenueShow,
+  applyVerifiedIbdbCreativeTeam,
 };

--- a/scripts/discover-new-shows.test.mjs
+++ b/scripts/discover-new-shows.test.mjs
@@ -174,3 +174,60 @@ test('every fetch()/https.get() call site in discover-new-shows.js has timeout p
       `https.get()/http.get() at line ${line} must have a .on('timeout', ...) handler that calls .destroy()`);
   }
 });
+
+// task #1863 (BRO-102 follow-up): applyVerifiedIbdbCreativeTeam() is the
+// first-write path for every newly-discovered Broadway show's creative team
+// — the highest-risk of the IBDB creativeTeam consumers, since a bad write
+// here ships before auto-fix-show-data.js's own IBDB step ever runs (that
+// step only fires when the team is empty/1-entry, which won't be true once
+// this write lands). Mocks verifyCreativeTeamViaSerp (the network boundary)
+// rather than re-implementing its decision logic — CLAUDE.md rule 15.
+const creativeTeamVerifyPath = require.resolve('./lib/creative-team-verify.js');
+const discoverNewShowsPath = require.resolve('./discover-new-shows.js');
+
+function loadWithMockedVerify(verifyImpl) {
+  const real = require(creativeTeamVerifyPath);
+  delete require.cache[creativeTeamVerifyPath];
+  delete require.cache[discoverNewShowsPath];
+  require.cache[creativeTeamVerifyPath] = {
+    id: creativeTeamVerifyPath, filename: creativeTeamVerifyPath, loaded: true,
+    exports: { ...real, verifyCreativeTeamViaSerp: verifyImpl },
+  };
+  try {
+    return require(discoverNewShowsPath);
+  } finally {
+    delete require.cache[creativeTeamVerifyPath];
+    delete require.cache[discoverNewShowsPath];
+    require.cache[creativeTeamVerifyPath] = { id: creativeTeamVerifyPath, filename: creativeTeamVerifyPath, loaded: true, exports: real };
+  }
+}
+
+test('applyVerifiedIbdbCreativeTeam: no member confirmed -> show.creativeTeam stays unset (wrong-table-cell case)', async () => {
+  const { applyVerifiedIbdbCreativeTeam } = loadWithMockedVerify(async () => []);
+  const show = { id: 'wrong-cell-2026', title: 'Wrong Cell', openingDate: '2026-01-15' };
+  await applyVerifiedIbdbCreativeTeam(show, [{ name: 'Hallucinated Name', role: 'Director' }]);
+  assert.equal(show.creativeTeam, undefined);
+});
+
+test('applyVerifiedIbdbCreativeTeam: a confirmed member is written to show.creativeTeam', async () => {
+  const { applyVerifiedIbdbCreativeTeam } = loadWithMockedVerify(async (show, proposed) =>
+    proposed.map(m => ({ ...m, _source: 'serp-verified-ibdb-discovery' }))
+  );
+  const show = { id: 'confirmed-2026', title: 'Confirmed', openingDate: '2026-01-15' };
+  await applyVerifiedIbdbCreativeTeam(show, [{ name: 'Mary Zimmerman', role: 'Director' }]);
+  assert.equal(show.creativeTeam.length, 1);
+  assert.equal(show.creativeTeam[0].name, 'Mary Zimmerman');
+  assert.equal(show.creativeTeam[0]._source, 'serp-verified-ibdb-discovery');
+});
+
+test('applyVerifiedIbdbCreativeTeam: combined names are split before SERP verification', async () => {
+  let seenProposed;
+  const { applyVerifiedIbdbCreativeTeam } = loadWithMockedVerify(async (show, proposed) => {
+    seenProposed = proposed;
+    return [];
+  });
+  const show = { id: 'combined-2026', title: 'Combined', openingDate: '2026-01-15' };
+  await applyVerifiedIbdbCreativeTeam(show, [{ name: 'John Doe & Jane Smith', role: 'Director' }]);
+  assert.equal(seenProposed.length, 2, 'combined name must be split into individual entries before verification');
+  assert.deepEqual(seenProposed.map(m => m.name).sort(), ['Jane Smith', 'John Doe']);
+});

--- a/scripts/enrich-ibdb-dates.js
+++ b/scripts/enrich-ibdb-dates.js
@@ -24,6 +24,7 @@ const { execSync } = require('child_process');
 const { lookupIBDBDates, batchLookupIBDBDates } = require('./lib/ibdb-dates');
 const { cleanup } = require('./lib/scraper');
 const { splitCombinedCredits } = require('./lib/credit-splitting');
+const { verifyCreativeTeamViaSerp } = require('./lib/creative-team-verify');
 const { writeClosingDate, canWriteClosingDate } = require('./lib/closing-date-guard');
 const { ibdbYearMismatch, expectedShowYear } = require('./lib/ibdb-year-guard');
 const showsWriteGuard = require('./lib/shows-write-guard');
@@ -93,6 +94,71 @@ function clearPushRefusalSentinel() {
   try {
     if (fs.existsSync(sentinel)) fs.unlinkSync(sentinel);
   } catch (_) { /* non-fatal */ }
+}
+
+const CREATIVE_TEAM_DESIGN_ROLES = new Set([
+  'Scenic Design', 'Costume Design', 'Lighting Design', 'Sound Design',
+  'Projection Design', 'Video Design', 'Orchestrations',
+  'Music Supervision', 'Music Direction', 'Original Score'
+]);
+
+// BRO-102 follow-up (task #1863): routes ibdb.creativeTeam through the same
+// SERP-verification gate as auto-fix-show-data.js before it's staged as a
+// showChanges entry. Splits combined credits BEFORE verifying — a combined
+// "John Doe & Jane Smith" name would never match a "directed by John Doe"
+// SERP snippet, so splitting first lets each individual name get its own
+// query. Returns null when nothing survives verification (mirrors the
+// existing "no change" behavior for an empty newRoles/ibdb.creativeTeam).
+async function buildVerifiedCreativeTeamChange(show, ibdb, { mergeCredits, force }) {
+  if (!ibdb.creativeTeam || ibdb.creativeTeam.length === 0) return null;
+
+  const { result: splitIbdbTeam } = splitCombinedCredits(ibdb.creativeTeam);
+  const hasCreativeTeam = show.creativeTeam && show.creativeTeam.length > 0;
+  const year = ibdb.openingDate?.slice(0, 4) || show.openingDate?.slice(0, 4) || 'upcoming';
+
+  if (mergeCredits && hasCreativeTeam) {
+    // Merge mode: add roles from IBDB that don't already exist
+    const existingRoles = new Set((show.creativeTeam || []).map(e => e.role));
+    const newRoles = splitIbdbTeam.filter(e => !existingRoles.has(e.role));
+    if (newRoles.length === 0) return null;
+
+    const verifiedNewRoles = await verifyCreativeTeamViaSerp(show, newRoles, year, 'serp-verified-ibdb-enrich');
+    if (verifiedNewRoles.length === 0) return null;
+
+    // Build merged array: insert new roles after Director, before design
+    const existing = show.creativeTeam;
+    let insertIdx = existing.length;
+    for (let j = 0; j < existing.length; j++) {
+      if (CREATIVE_TEAM_DESIGN_ROLES.has(existing[j].role)) { insertIdx = j; break; }
+    }
+    const dirIdx = existing.findLastIndex(e => e.role === 'Director');
+    if (dirIdx >= 0 && dirIdx + 1 <= insertIdx) insertIdx = dirIdx + 1;
+
+    const merged = [
+      ...existing.slice(0, insertIdx),
+      ...verifiedNewRoles,
+      ...existing.slice(insertIdx)
+    ];
+    return {
+      field: 'creativeTeam',
+      old: `${existing.length} role(s)`,
+      new: merged,
+      newLabel: `${merged.length} role(s) (+${verifiedNewRoles.length} merged: ${verifiedNewRoles.map(r => r.role).join(', ')})`
+    };
+  }
+
+  if (!hasCreativeTeam || force) {
+    const verified = await verifyCreativeTeamViaSerp(show, splitIbdbTeam, year, 'serp-verified-ibdb-enrich');
+    if (verified.length === 0) return null;
+    return {
+      field: 'creativeTeam',
+      old: hasCreativeTeam ? `${show.creativeTeam.length} role(s)` : 'empty',
+      new: verified,
+      newLabel: `${verified.length} role(s)`
+    };
+  }
+
+  return null;
 }
 
 async function main() {
@@ -273,50 +339,8 @@ async function main() {
     }
 
     // Check creativeTeam
-    if (ibdb.creativeTeam && ibdb.creativeTeam.length > 0) {
-      const hasCreativeTeam = show.creativeTeam && show.creativeTeam.length > 0;
-
-      if (mergeCredits && hasCreativeTeam) {
-        // Merge mode: add roles from IBDB that don't already exist
-        const existingRoles = new Set((show.creativeTeam || []).map(e => e.role));
-        const newRoles = ibdb.creativeTeam.filter(e => !existingRoles.has(e.role));
-
-        if (newRoles.length > 0) {
-          // Build merged array: insert new roles after Director, before design
-          const designRoles = new Set([
-            'Scenic Design', 'Costume Design', 'Lighting Design', 'Sound Design',
-            'Projection Design', 'Video Design', 'Orchestrations',
-            'Music Supervision', 'Music Direction', 'Original Score'
-          ]);
-          const existing = show.creativeTeam;
-          let insertIdx = existing.length;
-          for (let j = 0; j < existing.length; j++) {
-            if (designRoles.has(existing[j].role)) { insertIdx = j; break; }
-          }
-          const dirIdx = existing.findLastIndex(e => e.role === 'Director');
-          if (dirIdx >= 0 && dirIdx + 1 <= insertIdx) insertIdx = dirIdx + 1;
-
-          const merged = [
-            ...existing.slice(0, insertIdx),
-            ...newRoles,
-            ...existing.slice(insertIdx)
-          ];
-          showChanges.push({
-            field: 'creativeTeam',
-            old: `${existing.length} role(s)`,
-            new: merged,
-            newLabel: `${merged.length} role(s) (+${newRoles.length} merged: ${newRoles.map(r => r.role).join(', ')})`
-          });
-        }
-      } else if (!hasCreativeTeam || force) {
-        showChanges.push({
-          field: 'creativeTeam',
-          old: hasCreativeTeam ? `${show.creativeTeam.length} role(s)` : 'empty',
-          new: ibdb.creativeTeam,
-          newLabel: `${ibdb.creativeTeam.length} role(s)`
-        });
-      }
-    }
+    const creativeTeamChange = await buildVerifiedCreativeTeamChange(show, ibdb, { mergeCredits, force });
+    if (creativeTeamChange) showChanges.push(creativeTeamChange);
 
     // Data integrity guards
     const filteredChanges = showChanges.filter(c => {
@@ -399,8 +423,8 @@ async function main() {
 
       for (const ch of c.changes) {
         if (ch.field === 'creativeTeam') {
-          const { result } = splitCombinedCredits(ch.new);
-          showRecord.creativeTeam = result; // ch.new is the array from IBDB, split combined names
+          // ch.new is already split + SERP-verified by buildVerifiedCreativeTeamChange().
+          showRecord.creativeTeam = ch.new;
         } else if (ch.field === 'closingDate') {
           // Route through guard so humanCorrectedClosingDate is honored.
           if (!writeClosingDate(showRecord, ch.new, 'IBDB enrichment')) {
@@ -496,11 +520,19 @@ async function main() {
   }
 }
 
-main()
-  .catch(e => {
-    console.error('IBDB enrichment failed:', e);
-    process.exit(1);
-  })
-  .finally(() => {
-    cleanup().catch(() => {});
-  });
+if (require.main === module) {
+  main()
+    .catch(e => {
+      console.error('IBDB enrichment failed:', e);
+      process.exit(1);
+    })
+    .finally(() => {
+      cleanup().catch(() => {});
+    });
+}
+
+// Exports for unit tests (task #1863) — buildVerifiedCreativeTeamChange is the
+// SERP-verification gate for this file's IBDB creativeTeam writes; tests
+// exercise it directly against a mocked verifyCreativeTeamViaSerp rather than
+// re-implementing its decision logic (CLAUDE.md rule 15).
+module.exports = { buildVerifiedCreativeTeamChange };

--- a/scripts/enrich-ibdb-dates.js
+++ b/scripts/enrich-ibdb-dates.js
@@ -150,6 +150,16 @@ async function buildVerifiedCreativeTeamChange(show, ibdb, { mergeCredits, force
   if (!hasCreativeTeam || force) {
     const verified = await verifyCreativeTeamViaSerp(show, splitIbdbTeam, year, 'serp-verified-ibdb-enrich');
     if (verified.length === 0) return null;
+    // verifyCreativeTeamViaSerp doesn't distinguish "explicitly rejected" from
+    // "SERP call errored" (both just come back missing from `verified`) — a
+    // transient network blip on --force could otherwise silently shrink an
+    // existing complete team down to whatever happened to succeed. --force is
+    // a rare, manually-triggered mode; the safe default is to skip the write
+    // rather than lose credits (ship-check 2026-08-20).
+    if (hasCreativeTeam && force && verified.length < show.creativeTeam.length) {
+      console.log(`  ⚠️  ${show.title}: --force verified only ${verified.length}/${splitIbdbTeam.length} IBDB credit(s), fewer than the existing ${show.creativeTeam.length} — skipping creativeTeam overwrite (possible transient SERP failure, not necessarily a real rejection)`);
+      return null;
+    }
     return {
       field: 'creativeTeam',
       old: hasCreativeTeam ? `${show.creativeTeam.length} role(s)` : 'empty',

--- a/scripts/enrich-ibdb-dates.test.mjs
+++ b/scripts/enrich-ibdb-dates.test.mjs
@@ -1,0 +1,113 @@
+// task #1863 (BRO-102 follow-up): buildVerifiedCreativeTeamChange() routes
+// ibdb.creativeTeam through the same SERP-verification gate as
+// auto-fix-show-data.js before staging a showChanges write. Previously this
+// file wrote ibdb.creativeTeam verbatim — a wrong table cell or stale IBDB
+// entry would ship a hallucinated attribution.
+//
+// Mocks verifyCreativeTeamViaSerp (the network boundary) rather than
+// re-implementing its decision logic — CLAUDE.md rule 15.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const creativeTeamVerifyPath = require.resolve('./lib/creative-team-verify.js');
+const targetPath = require.resolve('./enrich-ibdb-dates.js');
+
+function loadWithMockedVerify(verifyImpl) {
+  const real = require(creativeTeamVerifyPath);
+  delete require.cache[creativeTeamVerifyPath];
+  delete require.cache[targetPath];
+  require.cache[creativeTeamVerifyPath] = {
+    id: creativeTeamVerifyPath, filename: creativeTeamVerifyPath, loaded: true,
+    exports: { ...real, verifyCreativeTeamViaSerp: verifyImpl },
+  };
+  try {
+    return require(targetPath);
+  } finally {
+    delete require.cache[creativeTeamVerifyPath];
+    delete require.cache[targetPath];
+    require.cache[creativeTeamVerifyPath] = { id: creativeTeamVerifyPath, filename: creativeTeamVerifyPath, loaded: true, exports: real };
+  }
+}
+
+function fakeShow(overrides = {}) {
+  return { id: 'example-2026', title: 'Example', openingDate: '2026-01-15', ...overrides };
+}
+
+test('buildVerifiedCreativeTeamChange: no ibdb.creativeTeam -> null', async () => {
+  const { buildVerifiedCreativeTeamChange } = loadWithMockedVerify(async () => []);
+  const result = await buildVerifiedCreativeTeamChange(fakeShow(), { creativeTeam: [] }, { mergeCredits: false, force: false });
+  assert.equal(result, null);
+});
+
+test('buildVerifiedCreativeTeamChange: non-merge mode, unconfirmed member -> null (wrong-table-cell case)', async () => {
+  const { buildVerifiedCreativeTeamChange } = loadWithMockedVerify(async () => []);
+  const show = fakeShow({ creativeTeam: [] });
+  const ibdb = { creativeTeam: [{ name: 'Hallucinated Name', role: 'Playwright' }] };
+  const result = await buildVerifiedCreativeTeamChange(show, ibdb, { mergeCredits: false, force: false });
+  assert.equal(result, null);
+});
+
+test('buildVerifiedCreativeTeamChange: non-merge mode, confirmed member -> creativeTeam showChanges entry', async () => {
+  const { buildVerifiedCreativeTeamChange } = loadWithMockedVerify(async (show, proposed, year, sourceTag) =>
+    proposed.map(m => ({ ...m, _source: sourceTag }))
+  );
+  const show = fakeShow({ creativeTeam: [] });
+  const ibdb = { creativeTeam: [{ name: 'Mary Zimmerman', role: 'Director' }] };
+  const result = await buildVerifiedCreativeTeamChange(show, ibdb, { mergeCredits: false, force: false });
+  assert.ok(result);
+  assert.equal(result.field, 'creativeTeam');
+  assert.equal(result.new.length, 1);
+  assert.equal(result.new[0].name, 'Mary Zimmerman');
+  assert.equal(result.new[0]._source, 'serp-verified-ibdb-enrich');
+});
+
+test('buildVerifiedCreativeTeamChange: existing non-empty team blocks a write without force', async () => {
+  const { buildVerifiedCreativeTeamChange } = loadWithMockedVerify(async (show, proposed) => proposed);
+  const show = fakeShow({ creativeTeam: [{ name: 'Existing Person', role: 'Director' }] });
+  const ibdb = { creativeTeam: [{ name: 'New Person', role: 'Playwright' }] };
+  const result = await buildVerifiedCreativeTeamChange(show, ibdb, { mergeCredits: false, force: false });
+  assert.equal(result, null);
+});
+
+test('buildVerifiedCreativeTeamChange: merge mode adds only new confirmed roles, inserted after Director', async () => {
+  const { buildVerifiedCreativeTeamChange } = loadWithMockedVerify(async (show, proposed, year, sourceTag) =>
+    proposed.map(m => ({ ...m, _source: sourceTag }))
+  );
+  const show = fakeShow({
+    creativeTeam: [
+      { name: 'Existing Director', role: 'Director' },
+      { name: 'Existing Designer', role: 'Scenic Design' },
+    ],
+  });
+  const ibdb = {
+    creativeTeam: [
+      { name: 'Existing Director', role: 'Director' }, // already present — must not duplicate
+      { name: 'New Playwright', role: 'Playwright' },
+    ],
+  };
+  const result = await buildVerifiedCreativeTeamChange(show, ibdb, { mergeCredits: true, force: false });
+  assert.ok(result);
+  assert.equal(result.new.length, 3);
+  assert.equal(result.new[1].name, 'New Playwright', 'new role inserted right after Director, before design roles');
+});
+
+test('buildVerifiedCreativeTeamChange: merge mode rejects an unconfirmed new role -> null', async () => {
+  const { buildVerifiedCreativeTeamChange } = loadWithMockedVerify(async () => []);
+  const show = fakeShow({ creativeTeam: [{ name: 'Existing Director', role: 'Director' }] });
+  const ibdb = { creativeTeam: [{ name: 'Hallucinated Playwright', role: 'Playwright' }] };
+  const result = await buildVerifiedCreativeTeamChange(show, ibdb, { mergeCredits: true, force: false });
+  assert.equal(result, null);
+});
+
+test('buildVerifiedCreativeTeamChange: merge mode with no new roles -> null (no SERP call needed)', async () => {
+  let calls = 0;
+  const { buildVerifiedCreativeTeamChange } = loadWithMockedVerify(async () => { calls++; return []; });
+  const show = fakeShow({ creativeTeam: [{ name: 'Existing Director', role: 'Director' }] });
+  const ibdb = { creativeTeam: [{ name: 'Existing Director', role: 'Director' }] };
+  const result = await buildVerifiedCreativeTeamChange(show, ibdb, { mergeCredits: true, force: false });
+  assert.equal(result, null);
+  assert.equal(calls, 0, 'no new roles means no verification call should be made');
+});

--- a/scripts/enrich-ibdb-dates.test.mjs
+++ b/scripts/enrich-ibdb-dates.test.mjs
@@ -102,6 +102,38 @@ test('buildVerifiedCreativeTeamChange: merge mode rejects an unconfirmed new rol
   assert.equal(result, null);
 });
 
+test('buildVerifiedCreativeTeamChange: force mode with a partial verified result does not shrink an existing complete team', async () => {
+  const { buildVerifiedCreativeTeamChange } = loadWithMockedVerify(async (show, proposed) =>
+    // Simulate one member failing (network error / rejection) — only 1 of 2 survives.
+    proposed.slice(0, 1)
+  );
+  const show = fakeShow({
+    creativeTeam: [
+      { name: 'Existing Director', role: 'Director' },
+      { name: 'Existing Playwright', role: 'Playwright' },
+    ],
+  });
+  const ibdb = {
+    creativeTeam: [
+      { name: 'IBDB Director', role: 'Director' },
+      { name: 'IBDB Playwright', role: 'Playwright' },
+    ],
+  };
+  const result = await buildVerifiedCreativeTeamChange(show, ibdb, { mergeCredits: false, force: true });
+  assert.equal(result, null, 'a partial verified result must not silently shrink an existing complete team on --force');
+});
+
+test('buildVerifiedCreativeTeamChange: force mode with a full verified result still overwrites', async () => {
+  const { buildVerifiedCreativeTeamChange } = loadWithMockedVerify(async (show, proposed, year, sourceTag) =>
+    proposed.map(m => ({ ...m, _source: sourceTag }))
+  );
+  const show = fakeShow({ creativeTeam: [{ name: 'Old Director', role: 'Director' }] });
+  const ibdb = { creativeTeam: [{ name: 'New Director', role: 'Director' }] };
+  const result = await buildVerifiedCreativeTeamChange(show, ibdb, { mergeCredits: false, force: true });
+  assert.ok(result);
+  assert.equal(result.new[0].name, 'New Director');
+});
+
 test('buildVerifiedCreativeTeamChange: merge mode with no new roles -> null (no SERP call needed)', async () => {
   let calls = 0;
   const { buildVerifiedCreativeTeamChange } = loadWithMockedVerify(async () => { calls++; return []; });

--- a/scripts/lib/creative-team-verify.js
+++ b/scripts/lib/creative-team-verify.js
@@ -12,6 +12,11 @@
  */
 
 const { foldDiacritics } = require('./title-match');
+const { serpQuery } = require('./url-discovery');
+
+function sleep(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
 
 // Canonical role label written into show.creativeTeam. src/lib/data-creative.ts
 // ROLE_TO_CATEGORIES is exact-case — writing "playwright" or "Book writer"
@@ -153,4 +158,94 @@ function serpTextConfirms(serpResults, phrases, name, opts = {}) {
   });
 }
 
-module.exports = { ROLE_CANON, roleVerb, roleVerbVariants, serpTextConfirms, titleTokens, normalizeForMatch };
+/**
+ * Shared SERP-verification gate for creative-team writes — network call.
+ *
+ * 2026-05-26: previously non-director roles proposed by the LLM were accepted
+ * without verification. Result: LLM hallucinated "Martyna Majok (Book Writer)"
+ * for Liberation (correct: Bess Wohl, Playwright) and reached production. Now
+ * ALL roles require SERP confirmation; unrecognized roles (design/tech
+ * credits with no reliable "<verb> <name>" attribution phrase — Scenic
+ * Design, Orchestrations, etc.) are rejected rather than trusted verbatim.
+ *
+ * BRO-102 (2026-08-20): the auto-fix-show-data.js IBDB scrape path previously
+ * took ibdb.creativeTeam verbatim — a wrong table cell or stale IBDB entry
+ * would repeat the wrong-attribution pattern for any Broadway show with an
+ * ibdbUrl. It now routes through this same gate before writing. Extracted
+ * here (BRO-102 follow-up, task #1863) so every other ibdb.creativeTeam
+ * writer (discover-new-shows.js, enrich-ibdb-dates.js,
+ * backfill-playwright-credits.js) can import it without pulling in
+ * auto-fix-show-data.js's other dependencies.
+ *
+ * Cost: up to ~7 SERP calls (one per verifiable role) per call. Callers that
+ * run over large batches (e.g. enrich-ibdb-dates.js's weekly cron) should
+ * watch SB SERP credit headroom — see memory/feedback_sb_serp_invisible_burn.md.
+ *
+ * Scope note: this SERP check confirms "<verb> <name>" for the show's TITLE,
+ * not its specific production year — it can't tell a 2026 revival's director
+ * from a same-titled 1990s production's director if both are attributable
+ * online. Callers should pair this with an upstream production-year gate
+ * (e.g. lookupIBDBDates()'s openingYear check in lib/ibdb-dates.js) rather
+ * than assume this function verifies production identity, only name+role
+ * attribution.
+ *
+ * @param {object} show - must have .title; .openingDate not required (pass year separately)
+ * @param {Array<{name: string, role: string}>} proposed - candidate credits to verify
+ * @param {string} year - production year for the SERP query (or 'upcoming')
+ * @param {string} sourceTag - stamped onto each verified member's _source field
+ */
+async function verifyCreativeTeamViaSerp(show, proposed, year, sourceTag) {
+  const verified = [];
+  const seen = new Set(); // name+role dedup — a shared gate can't assume every caller pre-dedupes
+  for (const member of proposed) {
+    const name = String(member.name || '').trim();
+    if (!name) {
+      console.log(`    ❌ Blank/missing name for role "${member.role}" — rejecting`);
+      continue;
+    }
+    const role = String(member.role || '').toLowerCase();
+    const dedupeKey = `${role}::${name.toLowerCase()}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    const verb = roleVerb(role);
+    if (!verb) {
+      console.log(`    ❌ Unrecognized role "${member.role}" for ${name} — rejecting (cannot SERP-verify)`);
+      continue;
+    }
+    const canonRole = ROLE_CANON[role] || member.role;
+    // "Music & Lyrics" is published inconsistently ("music and lyrics by" vs
+    // "music & lyrics by") — accept either spelling for this one role rather
+    // than widening every role to roleVerbVariants (which would weaken the
+    // single-verb hallucination signal the other roles rely on).
+    const phrases = role === 'music & lyrics' ? [verb, 'music & lyrics by'] : [verb];
+
+    const query = `"${show.title}" ${year} "${verb} ${name}"`;
+    console.log(`    🔍 Verifying: ${name} (${member.role}) via SERP...`);
+    try {
+      await sleep(500);
+      const serpResults = await serpQuery(query);
+      if (serpResults && serpResults.length > 0) {
+        // Require the full phrase "directed by [name]" in a snippet — not just
+        // the name — anchored to a segment naming this show (see the
+        // serpTextConfirms doc comment above for the snippet-stitching failure
+        // mode).
+        const confirmed = serpTextConfirms(serpResults, phrases, name, { title: show.title });
+        if (confirmed) {
+          console.log(`    ✅ SERP confirmed: ${name} (${member.role})`);
+          verified.push({ ...member, name, role: canonRole, _source: sourceTag });
+        } else {
+          console.log(`    ❌ SERP did not confirm: ${member.name} (${member.role}) — rejecting`);
+        }
+      } else {
+        console.log(`    ❌ No SERP results for ${member.name} (${member.role}) — rejecting`);
+      }
+    } catch (e) {
+      console.log(`    ⚠️  SERP verification failed for ${member.name}: ${e.message}`);
+    }
+  }
+
+  return verified;
+}
+
+module.exports = { ROLE_CANON, roleVerb, roleVerbVariants, serpTextConfirms, titleTokens, normalizeForMatch, verifyCreativeTeamViaSerp };

--- a/tests/unit-test-manifest.txt
+++ b/tests/unit-test-manifest.txt
@@ -25,6 +25,7 @@ scripts/autonomous-run.test.mjs
 scripts/autonomous-triage.test.mjs
 scripts/backfill-cast.test.mjs
 scripts/backfill-first-seen.test.mjs
+scripts/backfill-playwright-credits.test.mjs
 scripts/backlog-drain.test.mjs
 scripts/bsc-conductor.test.mjs
 scripts/bsc-next-ci-red-claim.test.mjs
@@ -38,6 +39,7 @@ scripts/check-seo-health.test.mjs
 scripts/discover-new-shows.test.mjs
 scripts/enrich-card-acceptance.test.mjs
 scripts/enrich-fallback-ticket-links.test.mjs
+scripts/enrich-ibdb-dates.test.mjs
 scripts/enrich-wikipedia-synopsis.test.mjs
 scripts/export-notion-outcome-history.test.mjs
 scripts/flag-wrong-production-by-date.test.mjs


### PR DESCRIPTION
## Summary
- BRO-102 (PR #632, merged) hardened `auto-fix-show-data.js`'s IBDB creative-team scrape path via a new `verifyCreativeTeamViaSerp()` gate, closing the hallucination-risk class the LLM proposal path was hardened against on 2026-05-26 (wrong regex-extracted table cell / stale IBDB entry → wrong attribution shipped to a show page).
- Independent ship-check review found 3 MORE consumers that still wrote `ibdb.creativeTeam` verbatim, unprotected: `discover-new-shows.js` (first-write path for every newly-discovered Broadway show — highest risk, since a bad write here ships before `auto-fix-show-data.js`'s own IBDB step ever runs), `enrich-ibdb-dates.js`, and `backfill-playwright-credits.js`.
- Moved `verifyCreativeTeamViaSerp()` from `auto-fix-show-data.js` into `scripts/lib/creative-team-verify.js` so it's importable without pulling in that file's other dependencies, and wired all 3 sites through it before any `show.creativeTeam` / `showRecord.creativeTeam` / `showChanges` write.
- Follow-up hardening from an independent Codex adversarial ship-check pass on this diff: `backfill-playwright-credits.js` now splits combined names ("John Doe & Jane Smith") before SERP-querying them individually (matching the other two sites — combined names were silently failing verification); `enrich-ibdb-dates.js`'s `--force` mode now skips a creativeTeam overwrite (with a warning) if the verified result is smaller than the existing team, so a transient SERP error can't silently shrink a complete team.
- Colocated tests per site (`scripts/discover-new-shows.test.mjs`, `scripts/enrich-ibdb-dates.test.mjs` new, `scripts/backfill-playwright-credits.test.mjs` new) prove an unconfirmed member is rejected and a confirmed member is kept, mocking the SERP-verification boundary rather than re-implementing its decision logic.
- Registered the 2 new root-level `*.test.mjs` files in `tests/unit-test-manifest.txt` + `.github/workflows/test.yml` path filter (reviewed via `/second-opinion` first, per rule 18 — plan-review verdict recorded).
- A pre-existing architectural gap found during ship-check (`backfill-playwright-credits.yml` lacks a `shows-json-writer` concurrency group, unlike its siblings) is unrelated to this diff and carded separately (Notion, P2) rather than expanding scope here.

Task: #1863 (BRO-102 follow-up)

## Test plan
- [x] `node --test scripts/discover-new-shows.test.mjs scripts/lib/creative-team-verify.test.mjs scripts/auto-fix-show-data.test.mjs scripts/enrich-ibdb-dates.test.mjs scripts/backfill-playwright-credits.test.mjs` — 42/42 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint` — no new warnings
- [x] `/second-opinion` plan review recorded before the test.yml CI-workflow edit (rule 18)
- [x] `/ship-check` — codebase-aware review (no findings) + Codex adversarial review (2 real findings, both fixed; 1 pre-existing concurrency gap carded separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)