### PR TITLE
fix(ci): guard commit-scraper-spend-ledger steps against job-failing push races (BRO-2243)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2643,14 +2643,18 @@ jobs:
         run: |
           # A "Commit scraper-spend ledger" step races every other concurrent
           # workflow pushing to main — losing that race is routine, expected
-          # contention, not a data problem. BRO-2243: this job (and 5 other
-          # open PRs) went red because that race was mistaken for a real
-          # validation failure. All 30 existing call sites already have both
-          # if: always() and continue-on-error: true (fixed BRO-163,
-          # 2026-08-14) — this is the structural guard so a new call site,
-          # or an edit that drops one of the two flags, can't silently
-          # reopen it. Logic lives in scripts/lint-workflow-guards.sh —
-          # shared with the local pre-push hook.
+          # contention, not a data problem. BRO-2243 investigated a claim
+          # that this race was reddening Data Validation on several open PRs;
+          # it turned out each of those was actually failing on an unrelated
+          # content check (Audit flag-vs-CV contradictions), and all 30
+          # existing commit-scraper-spend-ledger call sites already carry
+          # both if: always() and continue-on-error: true (fixed BRO-163,
+          # 2026-08-14) — so the race itself is already structurally
+          # prevented everywhere. This is the permanent regression guard so
+          # a new call site, or an edit that drops one of the two flags,
+          # can't silently reopen it. Logic lives in
+          # scripts/lint-workflow-guards.sh — shared with the local
+          # pre-push hook.
           bash scripts/lint-workflow-guards.sh ledger-step-guard
 
       - name: Check scripts avoid reset --soft + scoped-add + commit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2639,6 +2639,20 @@ jobs:
           # local pre-push hook.
           bash scripts/lint-workflow-guards.sh ledger-coverage
 
+      - name: Check ledger-commit steps never fail their job (BRO-2243)
+        run: |
+          # A "Commit scraper-spend ledger" step races every other concurrent
+          # workflow pushing to main — losing that race is routine, expected
+          # contention, not a data problem. BRO-2243: this job (and 5 other
+          # open PRs) went red because that race was mistaken for a real
+          # validation failure. All 30 existing call sites already have both
+          # if: always() and continue-on-error: true (fixed BRO-163,
+          # 2026-08-14) — this is the structural guard so a new call site,
+          # or an edit that drops one of the two flags, can't silently
+          # reopen it. Logic lives in scripts/lint-workflow-guards.sh —
+          # shared with the local pre-push hook.
+          bash scripts/lint-workflow-guards.sh ledger-step-guard
+
       - name: Check scripts avoid reset --soft + scoped-add + commit
         run: |
           # Phantom-staged-revert bug class (card #687, generalized from

--- a/scripts/lib/ledger-step-guard-check.js
+++ b/scripts/lib/ledger-step-guard-check.js
@@ -1,0 +1,78 @@
+/**
+ * Lint check (BRO-2243): every workflow step that calls the
+ * `commit-scraper-spend-ledger` composite action MUST carry both
+ * `if: always()` and `continue-on-error: true` on the CALLING step, so a
+ * push race on the ledger file (many concurrent runs pushing to main) can
+ * never fail the job that's using it for bookkeeping — the composite
+ * action's own header comment documents this as the caller's contract, but
+ * nothing previously enforced it structurally. Investigation for BRO-2243
+ * found all 30 existing call sites already compliant (fixed in BRO-163,
+ * 2026-08-14); this check is the regression guard so a NEW call site (or an
+ * edit that drops one of the two flags) can't silently reopen the race.
+ *
+ * Deliberately text/regex-based over the repo's `      - name: ...` step
+ * convention, matching swallowed-audit-writer-check.js's style. Owns its own
+ * splitSteps() (rather than importing that file's) — every other check.js in
+ * this repo (e.g. ledger-coverage-check.js's splitJobs) implements its own
+ * tiny splitter instead of depending on a sibling, unrelated check module;
+ * following that precedent avoids a needless coupling where an edit to
+ * swallowed-audit-writer-check.js for its own reasons could break this one.
+ */
+
+const STEP_START_RE = /^\s*-\s+name:/;
+const USES_LEDGER_ACTION_RE = /^\s*uses:\s*\.\/\.github\/actions\/commit-scraper-spend-ledger\s*$/;
+// NOTE: matches the literal substring `always()` anywhere on the `if:` line,
+// so it correctly accepts compound conditions (e.g. scrapingdog-account-
+// usage.yml's `if: always() && inputs.mode == 'x'`). Theoretical false-match
+// if a step's `if:` contained `always()` inside a negation/string
+// (`!always()`, a `contains(..., 'always()')` guard) — not present at any of
+// this repo's real call sites today; accepted as out of scope.
+const IF_ALWAYS_RE = /^\s*if:\s*.*\balways\(\)/;
+const CONTINUE_ON_ERROR_RE = /^\s*continue-on-error:\s*true\s*$/;
+const STEP_NAME_RE = /^\s*-\s+name:\s*(.+)\s*$/m;
+
+function splitSteps(workflowYamlText) {
+  const lines = workflowYamlText.split('\n');
+  const starts = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (STEP_START_RE.test(lines[i])) starts.push(i);
+  }
+  return starts.map((s, idx) => {
+    const end = idx + 1 < starts.length ? starts[idx + 1] : lines.length;
+    return lines.slice(s, end);
+  });
+}
+
+/**
+ * findLedgerStepGuardIssues(workflowYamlText) -> string[]
+ * Returns one human-readable violation string per step that uses the ledger
+ * composite action but is missing `if: always()` and/or
+ * `continue-on-error: true`. Empty array = clean (or no matching steps).
+ */
+function findLedgerStepGuardIssues(workflowYamlText) {
+  const violations = [];
+  const steps = splitSteps(workflowYamlText);
+
+  for (const stepLines of steps) {
+    if (!stepLines.some((l) => USES_LEDGER_ACTION_RE.test(l))) continue;
+
+    const hasIfAlways = stepLines.some((l) => IF_ALWAYS_RE.test(l));
+    const hasContinueOnError = stepLines.some((l) => CONTINUE_ON_ERROR_RE.test(l));
+    if (hasIfAlways && hasContinueOnError) continue;
+
+    const stepText = stepLines.join('\n');
+    const nameMatch = stepText.match(STEP_NAME_RE);
+    const stepName = nameMatch ? nameMatch[1].trim() : '(unnamed step)';
+
+    const missing = [];
+    if (!hasIfAlways) missing.push('if: always()');
+    if (!hasContinueOnError) missing.push('continue-on-error: true');
+    violations.push(
+      `step '${stepName}' calls commit-scraper-spend-ledger without ${missing.join(' and ')} — a push race on the ledger file could fail this job (BRO-2243)`
+    );
+  }
+
+  return violations;
+}
+
+module.exports = { findLedgerStepGuardIssues };

--- a/scripts/lib/ledger-step-guard-check.test.mjs
+++ b/scripts/lib/ledger-step-guard-check.test.mjs
@@ -1,0 +1,146 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const { findLedgerStepGuardIssues } = require('./ledger-step-guard-check.js');
+
+// The real, compliant pattern — every one of the repo's 30 existing call
+// sites looks like this (verified BRO-2243). Must report clean.
+const COMPLIANT_FIXTURE = `name: Example
+on:
+  push:
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Commit scraper-spend ledger
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/commit-scraper-spend-ledger
+        with:
+          workflow-name: test-data-validation
+`;
+
+// A conditional if: that still includes always() (scrapingdog-account-usage.yml's
+// real shape) must also count as compliant — always() combined with another
+// predicate is still unconditional-on-failure.
+const COMPOUND_IF_FIXTURE = `name: Example
+on:
+  workflow_dispatch:
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Commit scraper-spend ledger
+        if: always() && inputs.mode == 'confirm-empty-authoritative'
+        continue-on-error: true
+        uses: ./.github/actions/commit-scraper-spend-ledger
+        with:
+          workflow-name: scrapingdog-account-usage
+`;
+
+// The exact bug BRO-2243 investigated: this is the shape that would let a
+// ledger push race fail the job. Both flags missing.
+const MISSING_BOTH_FIXTURE = `name: Example
+on:
+  push:
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Commit scraper-spend ledger
+        uses: ./.github/actions/commit-scraper-spend-ledger
+        with:
+          workflow-name: some-workflow
+`;
+
+// Only continue-on-error missing — the step would be skipped after an
+// earlier failed step (no if: always()) but if it DID run and lost the
+// push race, the job would still fail.
+const MISSING_CONTINUE_ON_ERROR_FIXTURE = `name: Example
+on:
+  push:
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Commit scraper-spend ledger
+        if: always()
+        uses: ./.github/actions/commit-scraper-spend-ledger
+        with:
+          workflow-name: some-workflow
+`;
+
+// Only if: always() missing — on a job with no earlier failed step this is
+// usually fine, but a push race would still fail the job since nothing
+// catches it.
+const MISSING_IF_ALWAYS_FIXTURE = `name: Example
+on:
+  push:
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Commit scraper-spend ledger
+        continue-on-error: true
+        uses: ./.github/actions/commit-scraper-spend-ledger
+        with:
+          workflow-name: some-workflow
+`;
+
+// A step that doesn't use the ledger action at all must never be flagged,
+// regardless of its own if:/continue-on-error: config.
+const UNRELATED_STEP_FIXTURE = `name: Example
+on:
+  push:
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Some other step
+        run: echo hi
+`;
+
+test('compliant ledger step (if: always() + continue-on-error: true) is clean', () => {
+  assert.deepEqual(findLedgerStepGuardIssues(COMPLIANT_FIXTURE), []);
+});
+
+test('compound if: expression that includes always() is clean', () => {
+  assert.deepEqual(findLedgerStepGuardIssues(COMPOUND_IF_FIXTURE), []);
+});
+
+test('step missing both flags is flagged, naming both', () => {
+  const issues = findLedgerStepGuardIssues(MISSING_BOTH_FIXTURE);
+  assert.equal(issues.length, 1);
+  assert.match(issues[0], /Commit scraper-spend ledger/);
+  assert.match(issues[0], /if: always\(\)/);
+  assert.match(issues[0], /continue-on-error: true/);
+});
+
+test('step missing only continue-on-error is flagged', () => {
+  const issues = findLedgerStepGuardIssues(MISSING_CONTINUE_ON_ERROR_FIXTURE);
+  assert.equal(issues.length, 1);
+  assert.match(issues[0], /continue-on-error: true/);
+  assert.doesNotMatch(issues[0], /if: always\(\) and/);
+});
+
+test('step missing only if: always() is flagged', () => {
+  const issues = findLedgerStepGuardIssues(MISSING_IF_ALWAYS_FIXTURE);
+  assert.equal(issues.length, 1);
+  assert.match(issues[0], /if: always\(\)/);
+});
+
+test('steps not using the ledger action are never flagged', () => {
+  assert.deepEqual(findLedgerStepGuardIssues(UNRELATED_STEP_FIXTURE), []);
+});
+
+test('real test.yml data-validation call site is clean', () => {
+  const fs = require('fs');
+  const workflowPath = path.join(__dirname, '..', '..', '.github', 'workflows', 'test.yml');
+  const text = fs.readFileSync(workflowPath, 'utf8');
+  assert.deepEqual(findLedgerStepGuardIssues(text), []);
+});

--- a/scripts/lint-workflow-guards.sh
+++ b/scripts/lint-workflow-guards.sh
@@ -13,8 +13,8 @@
 # Usage: lint-workflow-guards.sh <check>[,<check>...]
 #   Checks: prebuild | core-data-pairing | private-git-add | merge-drivers
 #         | scraping-fallback | scrapingdog-pairing | theatr-token | demo-flags
-#         | snapshot-overwrite | alert-ledger-commit | ledger-coverage | reset-soft-partial-commit
-#         | dry-run-flag-setter | swallowed-audit-writers
+#         | snapshot-overwrite | alert-ledger-commit | ledger-coverage | ledger-step-guard
+#         | reset-soft-partial-commit | dry-run-flag-setter | swallowed-audit-writers
 #   Groups: workflows (all .github/workflows-scoped checks) | all
 
 set -uo pipefail
@@ -430,6 +430,45 @@ check_ledger_coverage() {
   fi
 }
 
+check_ledger_step_guard() {
+  # BRO-2243: a job that commits data/audit/scraper-spend-ledger.jsonl is
+  # racing every other concurrent workflow pushing to main — a losing race
+  # is expected, routine contention, not a data problem. The composite
+  # action's own header comment documents the contract every caller must
+  # follow (if: always() + continue-on-error: true on the CALLING step) so
+  # that race can never fail the job using it for bookkeeping. Investigation
+  # found all 30 existing call sites already compliant (fixed BRO-163,
+  # 2026-08-14) — this is the structural guard so a new call site, or an
+  # edit that drops one of the two flags, can't silently reopen the race.
+  # Logic lives in scripts/lib/ledger-step-guard-check.js (colocated test:
+  # scripts/lib/ledger-step-guard-check.test.mjs) — shared with the local
+  # pre-push hook.
+  local OUT
+  OUT=$(node -e "
+    const fs = require('fs');
+    const path = require('path');
+    const { findLedgerStepGuardIssues } = require('./scripts/lib/ledger-step-guard-check.js');
+    const dir = '.github/workflows';
+    let any = false;
+    for (const name of fs.readdirSync(dir).filter((f) => f.endsWith('.yml'))) {
+      const text = fs.readFileSync(path.join(dir, name), 'utf8');
+      for (const v of findLedgerStepGuardIssues(text)) {
+        any = true;
+        console.log(name + ': ' + v);
+      }
+    }
+    if (!any) console.log('__CLEAN__');
+  " 2>&1)
+  if echo "$OUT" | grep -qF '__CLEAN__' && ! echo "$OUT" | grep -qvF '__CLEAN__'; then
+    echo "Every commit-scraper-spend-ledger call site has if: always() + continue-on-error: true — a ledger push race can never fail the calling job"
+  else
+    echo "::error::Workflow step(s) call commit-scraper-spend-ledger without both if: always() and continue-on-error: true — a routine push race on the ledger file would fail the job (BRO-2243):"
+    echo "$OUT" | grep -vF '__CLEAN__'
+    echo "Fix: add both 'if: always()' and 'continue-on-error: true' to the calling step (see test.yml's Data Validation job for the pattern)."
+    FAILED=1
+  fi
+}
+
 check_dry_run_flag_setter() {
   # Task #653 ship-check finding: scripts/flag-wrong-production-by-date.js is
   # DRY_RUN unless --apply (flag-wrong-production-by-date.js:43). rebuild-fast.yml
@@ -562,6 +601,7 @@ run_check() {
     snapshot-overwrite) check_snapshot_overwrite ;;
     alert-ledger-commit) check_alert_ledger_commit ;;
     ledger-coverage)    check_ledger_coverage ;;
+    ledger-step-guard)  check_ledger_step_guard ;;
     reset-soft-partial-commit) check_reset_soft_partial_commit ;;
     dry-run-flag-setter) check_dry_run_flag_setter ;;
     swallowed-audit-writers) check_swallowed_audit_writers ;;
@@ -573,13 +613,14 @@ run_check() {
       # (`swallowed-audit-writers`) or via `all`.
       check_prebuild; check_core_data_pairing; check_private_git_add
       check_merge_drivers; check_scraping_fallback; check_scrapingdog_pairing; check_theatr_token
-      check_snapshot_overwrite; check_alert_ledger_commit; check_ledger_coverage; check_dry_run_flag_setter ;;
+      check_snapshot_overwrite; check_alert_ledger_commit; check_ledger_coverage; check_ledger_step_guard
+      check_dry_run_flag_setter ;;
     all)
       check_prebuild; check_core_data_pairing; check_private_git_add
       check_merge_drivers; check_scraping_fallback; check_scrapingdog_pairing; check_theatr_token
       check_demo_flags; check_snapshot_overwrite; check_alert_ledger_commit; check_ledger_coverage
-      check_reset_soft_partial_commit; check_dry_run_flag_setter; check_swallowed_audit_writers ;;
-    *) echo "usage: $0 <prebuild|core-data-pairing|private-git-add|merge-drivers|scraping-fallback|scrapingdog-pairing|theatr-token|demo-flags|snapshot-overwrite|alert-ledger-commit|ledger-coverage|reset-soft-partial-commit|dry-run-flag-setter|swallowed-audit-writers|workflows|all>[,...]" >&2; exit 2 ;;
+      check_ledger_step_guard; check_reset_soft_partial_commit; check_dry_run_flag_setter; check_swallowed_audit_writers ;;
+    *) echo "usage: $0 <prebuild|core-data-pairing|private-git-add|merge-drivers|scraping-fallback|scrapingdog-pairing|theatr-token|demo-flags|snapshot-overwrite|alert-ledger-commit|ledger-coverage|ledger-step-guard|reset-soft-partial-commit|dry-run-flag-setter|swallowed-audit-writers|workflows|all>[,...]" >&2; exit 2 ;;
   esac
 }
 


### PR DESCRIPTION
## Summary

BRO-2243 claimed Data Validation was going red on 6+ open PRs because the "Commit scraper-spend ledger" step loses a push race against concurrent workflows.

Investigated and found the literal mechanism doesn't currently reproduce:
- Checked all 8 currently-failing PR runs (608/614/621/631/633/634/635/637) via the GitHub API — in every case the actual failing step is **"Audit flag-vs-CV contradictions"** (a real content-validation check), not the ledger step, which shows `conclusion: success` in all of them.
- Grepped all 30 workflow call sites of `commit-scraper-spend-ledger` and confirmed every one already has both `if: always()` and `continue-on-error: true` on the calling step — this was fixed repo-wide in BRO-163 (`5fcfb4a763b`, 2026-08-14), six days before this ticket was filed.
- Checked the shallow-checkout "widening" warning mentioned in the ticket — it's a `::warning::`, part of an already-implemented self-healing refetch path (task #466), and only escalates to a real error if the widen also fails.

So the race is already structurally prevented. This PR adds a permanent regression guard so it can't silently reopen:

- `scripts/lib/ledger-step-guard-check.js` (+ colocated test) — flags any workflow step using the ledger composite action that's missing `if: always()` or `continue-on-error: true`.
- Wired into `scripts/lint-workflow-guards.sh` as a new `ledger-step-guard` check (in the `workflows`/`all` groups, shared with the local pre-push hook).
- New CI step in `test.yml`'s Lint Workflows job. Currently a pure no-op — verified 100% clean against all 30 real call sites.

The real, currently-blocking cause of the red PRs (Audit flag-vs-CV contradictions) is a separate, unrelated issue — reported separately.

## Test plan
- [x] `node --test scripts/lib/ledger-step-guard-check.test.mjs` — 7/7 pass
- [x] `bash scripts/lint-workflow-guards.sh ledger-step-guard` — clean across all 30 real call sites
- [x] `bash scripts/lint-workflow-guards.sh workflows` — full group, exit 0
- [x] `npx tsc --noEmit` — clean
- [x] `actionlint .github/workflows/test.yml` — no new findings (2 pre-existing unrelated shellcheck infos)
- [x] Reviewed via `/second-opinion` before editing `test.yml` (task #1079 gate) — verdict: ready to implement

🤖 Generated with [Claude Code](https://claude.com/claude-code)