### PR TITLE
fix(BRO-2244): exempt anticipatory_pre_opening_post from flag-vs-CV audit

### DIFF
--- a/data/audit/cv-flag-contradiction-baseline.json
+++ b/data/audit/cv-flag-contradiction-baseline.json
@@ -2,21 +2,6 @@
   "generatedAt": "2026-08-20",
   "hits": [
     {
-      "showId": "aida-off-broadway-2027",
-      "file": "operawire--david-salazar.json",
-      "flag": "wrongProduction"
-    },
-    {
-      "showId": "aida-off-broadway-2027",
-      "file": "washpost--michael-andor-brodeur.json",
-      "flag": "wrongProduction"
-    },
-    {
-      "showId": "aida-off-broadway-2027",
-      "file": "wsj--heidi-waleson.json",
-      "flag": "wrongProduction"
-    },
-    {
       "showId": "as-you-like-it-globe-west-end-2026",
       "file": "standard--nick-curtis.json",
       "flag": "wrongProduction"
@@ -67,33 +52,8 @@
       "flag": "isRoundupArticle"
     },
     {
-      "showId": "macbeth-off-broadway-2026",
-      "file": "standard--nick-curtis.json",
-      "flag": "wrongProduction"
-    },
-    {
-      "showId": "miles-for-mary-off-broadway-2026",
-      "file": "broadwayselect--peter-filichia.json",
-      "flag": "wrongProduction"
-    },
-    {
-      "showId": "miles-for-mary-off-broadway-2026",
-      "file": "culturebot--jennifer-cayer.json",
-      "flag": "wrongProduction"
-    },
-    {
-      "showId": "miles-for-mary-off-broadway-2026",
-      "file": "nyt-theater--jonathan-mandell.json",
-      "flag": "wrongProduction"
-    },
-    {
       "showId": "miles-for-mary-off-broadway-2026",
       "file": "talkinbroadway--marc-miller.json",
-      "flag": "wrongProduction"
-    },
-    {
-      "showId": "miles-for-mary-off-broadway-2026",
-      "file": "timeout--helen-shaw.json",
       "flag": "wrongProduction"
     },
     {

--- a/scripts/lib/flag-contradiction.js
+++ b/scripts/lib/flag-contradiction.js
@@ -54,6 +54,7 @@
 
 const { wrongShowCleared, isStaleCvPromotedWrongShow, computeCvIsStale } = require('./review-guards');
 const { clearWrongProductionFlags } = require('./wrong-production-clear');
+const { DATE_ONLY_AUTO_REASONS } = require('./wrong-production-autoclear');
 
 /**
  * A file whose flag a human has already ruled on — never escalate it. Covers:
@@ -200,6 +201,19 @@ function detectCvFlagContradiction(file) {
     : file.isRoundupArticle === true ? 'isRoundupArticle'
     : null;
   if (!flag) return null;
+
+  // DATE_ONLY_AUTO_REASONS (e.g. the anticipatory ingest gate's
+  // 'anticipatory_pre_opening_post') flags on TEMPORAL/production-context
+  // grounds a content-only CV pass cannot evaluate — CV reading the text as a
+  // valid review of the right show says nothing about whether it reviews the
+  // counted production vs. a preview performance. rebuild-all-reviews.js and
+  // wrong-production-autoclear.js already treat every wrongProductionReason as
+  // protected from CV-based auto-clear (BRO-2244); this audit must not flag
+  // the same reasons as "contradictions" needing human triage — that's not a
+  // gap in the flag, it's the flag working as designed.
+  if (flag === 'wrongProduction' && DATE_ONLY_AUTO_REASONS.has(file.wrongProductionReason)) {
+    return null;
+  }
 
   const reasoning = cv.reasoning
     || (Array.isArray(cv.issues) && cv.issues.length ? cv.issues[0] : '')

--- a/scripts/lib/flag-contradiction.js
+++ b/scripts/lib/flag-contradiction.js
@@ -196,24 +196,28 @@ function detectCvFlagContradiction(file) {
   const wordCount = file.textWordCount ?? file.wordCount ?? 0;
   if (wordCount <= 300) return null;
 
-  const flag = file.wrongProduction === true ? 'wrongProduction'
+  // DATE_ONLY_AUTO_REASONS (e.g. the anticipatory ingest gate's
+  // 'anticipatory_pre_opening_post') flags wrongProduction on TEMPORAL/
+  // production-context grounds a content-only CV pass cannot evaluate — CV
+  // reading the text as a valid review of the right show says nothing about
+  // whether it reviews the counted production vs. a preview performance.
+  // rebuild-all-reviews.js and wrong-production-autoclear.js already treat
+  // every wrongProductionReason as protected from CV-based auto-clear
+  // (BRO-2244); this audit must not flag the same reasons as "contradictions"
+  // needing human triage — that's not a gap in the flag, it's the flag
+  // working as designed. Exempting wrongProduction here must fall through to
+  // check wrongShow/isRoundupArticle rather than aborting outright — a file
+  // can carry more than one exclusion flag, and an exempt wrongProduction
+  // reason says nothing about whether a co-occurring wrongShow flag is also
+  // legitimate (ship-check finding, ~0 corpus instances today but not a
+  // structural guarantee).
+  const wrongProductionExempt = file.wrongProduction === true
+    && DATE_ONLY_AUTO_REASONS.has(file.wrongProductionReason);
+  const flag = (file.wrongProduction === true && !wrongProductionExempt) ? 'wrongProduction'
     : file.wrongShow === true ? 'wrongShow'
     : file.isRoundupArticle === true ? 'isRoundupArticle'
     : null;
   if (!flag) return null;
-
-  // DATE_ONLY_AUTO_REASONS (e.g. the anticipatory ingest gate's
-  // 'anticipatory_pre_opening_post') flags on TEMPORAL/production-context
-  // grounds a content-only CV pass cannot evaluate — CV reading the text as a
-  // valid review of the right show says nothing about whether it reviews the
-  // counted production vs. a preview performance. rebuild-all-reviews.js and
-  // wrong-production-autoclear.js already treat every wrongProductionReason as
-  // protected from CV-based auto-clear (BRO-2244); this audit must not flag
-  // the same reasons as "contradictions" needing human triage — that's not a
-  // gap in the flag, it's the flag working as designed.
-  if (flag === 'wrongProduction' && DATE_ONLY_AUTO_REASONS.has(file.wrongProductionReason)) {
-    return null;
-  }
 
   const reasoning = cv.reasoning
     || (Array.isArray(cv.issues) && cv.issues.length ? cv.issues[0] : '')

--- a/scripts/lib/flag-contradiction.test.mjs
+++ b/scripts/lib/flag-contradiction.test.mjs
@@ -251,6 +251,42 @@ test('null/undefined data → null (never throws)', () => {
   assert.equal(detectCvFlagContradiction(undefined), null);
 });
 
+// BRO-2244: anticipatory ingest gate (wrongProductionReason:
+// 'anticipatory_pre_opening_post') flags on temporal grounds a content-only CV
+// pass cannot evaluate — rebuild-all-reviews.js and wrong-production-autoclear.js
+// already treat it as protected from CV-based auto-clear, so this audit must not
+// surface it as a "new contradiction" either (real prod instance: a-christmas
+// -carol-west-end-2026/broadwayworld--aliya-al-hassan.json).
+test('anticipatory_pre_opening_post wrongProductionReason exempted, even with high-confidence affirming CV', () => {
+  const f = {
+    wrongProduction: true,
+    wrongProductionReason: 'anticipatory_pre_opening_post',
+    textWordCount: 508,
+    contentVerification: { isValid: true, confidence: 'high', wrongProduction: false },
+  };
+  assert.equal(detectCvFlagContradiction(f), null);
+});
+
+test('anticipatory exemption is wrongProduction-only — same reason string on wrongShow still fires', () => {
+  const f = {
+    wrongShow: true,
+    wrongProductionReason: 'anticipatory_pre_opening_post',
+    textWordCount: 900,
+    contentVerification: { isValid: true, confidence: 'high' },
+  };
+  assert.equal(detectCvFlagContradiction(f).flag, 'wrongShow');
+});
+
+test('a different (non-exempt) wrongProductionReason still fires as a contradiction', () => {
+  const f = {
+    wrongProduction: true,
+    wrongProductionReason: 'CV-promoted: some other reason',
+    textWordCount: 900,
+    contentVerification: { isValid: true, confidence: 'high' },
+  };
+  assert.equal(detectCvFlagContradiction(f).flag, 'wrongProduction');
+});
+
 // SELF_CLEAR_PAIRS coverage (tasks #1020/#1022/#1023) — a record asserting an
 // exclusion flag AND its own retraction breadcrumb at once. Regression guard
 // for #1023: an-american-in-paris-2015/broadwayworld--roy-berko.json and

--- a/scripts/lib/flag-contradiction.test.mjs
+++ b/scripts/lib/flag-contradiction.test.mjs
@@ -277,6 +277,22 @@ test('anticipatory exemption is wrongProduction-only — same reason string on w
   assert.equal(detectCvFlagContradiction(f).flag, 'wrongShow');
 });
 
+// Codex ship-check finding: exempting an anticipatory wrongProduction flag must
+// fall through to a co-occurring wrongShow flag on the SAME file, not abort
+// outright — the exempt reason says nothing about whether wrongShow is also a
+// legitimate contradiction worth human triage. 0 corpus instances today, but
+// nothing structurally prevents a file from carrying both.
+test('wrongProduction exempt + wrongShow both true on one file → wrongShow still surfaces', () => {
+  const f = {
+    wrongProduction: true,
+    wrongProductionReason: 'anticipatory_pre_opening_post',
+    wrongShow: true,
+    textWordCount: 900,
+    contentVerification: { isValid: true, confidence: 'high' },
+  };
+  assert.equal(detectCvFlagContradiction(f).flag, 'wrongShow');
+});
+
 test('a different (non-exempt) wrongProductionReason still fires as a contradiction', () => {
   const f = {
     wrongProduction: true,

--- a/scripts/lib/wrong-production-autoclear.js
+++ b/scripts/lib/wrong-production-autoclear.js
@@ -186,6 +186,13 @@ function hasDeclaredPriorRuns(show) {
 // These are written by date-based setters and are valid candidates for priorRuns
 // auto-clear. Anything not in this set (and not in the auto-prefix list below)
 // is treated as a manual reason and protected.
+//
+// ALSO CONSUMED by scripts/lib/flag-contradiction.js's detectCvFlagContradiction
+// (BRO-2244) as the set of wrongProductionReason values a content-only CV pass
+// cannot evaluate (temporal/production-context, not text content) — that
+// consumer exempts these reasons from the flag-vs-CV contradiction audit.
+// Adding a new value here also exempts it from that CI gate; confirm that's
+// intended (or split into a differently-scoped set) before adding one.
 const DATE_ONLY_AUTO_REASONS = new Set([
   'anticipatory_pre_opening_post', // collect-review-texts.js anticipatory gate
 ]);

--- a/scripts/lib/wrong-production-autoclear.js
+++ b/scripts/lib/wrong-production-autoclear.js
@@ -646,6 +646,7 @@ function shouldAutoClearWrongProductionUkDualMarket(data, ctx = {}) {
 }
 
 module.exports = {
+  DATE_ONLY_AUTO_REASONS,
   hasEnsembleConsensus,
   shouldAutoClearWrongProduction,
   shouldAutoClearWrongShow,


### PR DESCRIPTION
## Summary
- `scripts/audit-cv-flag-contradiction.js` was flagging every anticipatory-gate `wrongProduction` review (temporal flag a content-only CV pass can't evaluate) as a "new contradiction," causing Data Validation to go red on all open PRs.
- Fix reuses the canonical `DATE_ONLY_AUTO_REASONS` set (now exported from `scripts/lib/wrong-production-autoclear.js`) to exempt `anticipatory_pre_opening_post` from `detectCvFlagContradiction()`, matching the protection already applied elsewhere (`rebuild-all-reviews.js`).
- Ship-check (Codex adversarial pass) found the initial exemption could mask a co-occurring `wrongShow` flag on the same file — restructured to fall through and still surface that case (0 corpus instances today, but not structurally guaranteed).
- Regenerated `data/audit/cv-flag-contradiction-baseline.json`, dropping 8 stale entries now correctly exempted for the same reason.

## Test plan
- [x] `node --test scripts/lib/flag-contradiction.test.mjs` — 47/47 pass, including new exemption + co-flag-fallthrough coverage
- [x] `node scripts/audit-cv-flag-contradiction.js --window=30 --strict` — exit 0 (was exit 1 with 2 new contradictions before the fix)
- [x] `npx tsc --noEmit`, `npx next lint` — clean
- [x] `node scripts/validate-data.js` — passes (pre-existing warnings only, unrelated to this change)

Fixes BRO-2244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)