### PR TITLE
fix(BRO-2245): normalizeLinearIssue no longer hardcodes category null

### DIFF
--- a/scripts/enrich-card-acceptance.js
+++ b/scripts/enrich-card-acceptance.js
@@ -527,13 +527,37 @@ function selectRefusedLinearIdentifiers(openIssuesWithDesc) {
     .sort((a, b) => linearIssueNumber(a) - linearIssueNumber(b));
 }
 
+// Pure — extracts the category a Linear issue inherited from its Notion
+// import. notion-tasks-sync.js (fmt:2) writes a meta line shaped
+// "[notion:<id>] <priority> · <status> · <category>" — linear-import.js
+// carries that line straight into the issue description verbatim, so it
+// survives the migration unchanged (BRO-2245: the two Marketing cards that
+// slipped through the owner-judgment gate both literally read
+// "P1 Next · Not started · Marketing").
+//
+// Unlike autonomous-eligibility.js's categoryOf() (which anchors to line 1
+// for the Notion task-mirror shape, where the marker is always first),
+// this searches the WHOLE description with the multiline flag: per
+// linear-import-rules.js's extractNotionId comment, the marker is not
+// always line 1 on the Linear side — zombie-sweep re-opens and other
+// prefixes push it down.
+const LINEAR_CATEGORY_LINE_RE = /^\[notion:[^\]]+\]\s*(.+)$/m;
+function categoryOfLinearIssue(description) {
+  const m = LINEAR_CATEGORY_LINE_RE.exec(String(description || ''));
+  if (!m) return null;
+  const parts = m[1].split('·').map(s => s.trim());
+  return parts.length >= 3 ? parts[parts.length - 1] : null;
+}
+
 // Pure — normalizes a full linear.getIssue() result into the {id, name,
 // notes, tags, category} shape enrichOneCard() expects (the same shape
 // audit-card-verifiability.js's evaluateCard() produces for a Notion card).
-// category is always null: Linear has no Notion-category equivalent, which
-// isCardEligible() already treats as fail-closed (applies the human-action
-// title filter without the Notion "no-category" 5-word bound) — the same
-// conservative posture a "no-category" Notion card gets today.
+// category comes from categoryOfLinearIssue() above when the issue was
+// imported from Notion; issues with no such marker (native Linear cards)
+// get null, which isCardEligible() already treats as fail-closed (applies
+// the human-action title filter without the Notion "no-category" 5-word
+// bound) — the same conservative posture a "no-category" Notion card gets
+// today.
 // Pure — true when a freshly-fetched Linear issue has reached a terminal
 // state since the sweep snapshot was taken. See runLinearLeg's call site for
 // why this must be checked before ever writing.
@@ -548,7 +572,7 @@ function normalizeLinearIssue(issue) {
     name: issue.title,
     notes: issue.description || '',
     tags: ((issue.labels && issue.labels.nodes) || []).map(l => l.name),
-    category: null,
+    category: categoryOfLinearIssue(issue.description),
     identifier: issue.identifier,
     url: issue.url || null,
   };
@@ -989,5 +1013,5 @@ module.exports = {
   // a live Linear API call (writeBack/normalizeLinearIssue/selectRefused... are
   // pure; makeLinearWriteCard takes an injectable client).
   writeBack, selectRefusedLinearIdentifiers, normalizeLinearIssue, makeLinearWriteCard,
-  linearIssueNumber, isLinearIssueTerminal,
+  linearIssueNumber, isLinearIssueTerminal, categoryOfLinearIssue,
 };

--- a/scripts/enrich-card-acceptance.test.mjs
+++ b/scripts/enrich-card-acceptance.test.mjs
@@ -8,7 +8,7 @@ const require = createRequire(import.meta.url);
 const {
   enrichOneCard, spliceNotes,
   selectRefusedLinearIdentifiers, normalizeLinearIssue, makeLinearWriteCard, linearIssueNumber,
-  isLinearIssueTerminal,
+  isLinearIssueTerminal, categoryOfLinearIssue,
 } = require('./enrich-card-acceptance.js');
 // Rule 15: assert against the REAL validator the production path uses, never a
 // copy — if isSafeCheckCommand's notion of "safe" drifts, these tests move with
@@ -631,6 +631,8 @@ test('normalizeLinearIssue: maps a full linear.getIssue() result to the enrichOn
   assert.equal(card.name, 'Cron stale 3+ consecutive days: Refresh Show Score');
   assert.equal(card.notes, '## Problem\nCron has not run.');
   assert.deepEqual(card.tags, ['cron', 'auto-enriched']);
+  // No [notion:...] meta line in this description — category is genuinely
+  // unknown (native Linear card, or pre-fmt:2 import), not a hardcode.
   assert.equal(card.category, null);
   assert.equal(card.identifier, 'BRO-450');
 });
@@ -645,6 +647,83 @@ test('normalizeLinearIssue: tolerates a missing description, no labels, and no u
 test('normalizeLinearIssue: carries the issue url through for the audit log', () => {
   const card = normalizeLinearIssue({ id: 'uuid-1', identifier: 'BRO-1', title: 'x', url: 'https://linear.app/broadway-scorecard/issue/BRO-1' });
   assert.equal(card.url, 'https://linear.app/broadway-scorecard/issue/BRO-1');
+});
+
+// BRO-2245: normalizeLinearIssue hardcoded category:null, so the
+// owner-judgment branch could never fire on the Linear leg. notion-tasks-sync
+// writes "[notion:<id>] <priority> · <status> · <category>" as the imported
+// description's meta line — linear-import.js carries it through verbatim, so
+// it is recoverable on every already-imported card.
+test('normalizeLinearIssue: recovers category from the imported [notion:...] meta line', () => {
+  const issue = {
+    id: 'uuid-mkt-1',
+    identifier: 'BRO-9001',
+    title: 'Reddit post: Les Mis Arena Concert (r/Broadway)',
+    description: '[notion:3b2637c5-abcd-1234-9999-000000000000] P1 Next · Not started · Marketing\nDraft a Reddit post.',
+  };
+  const card = normalizeLinearIssue(issue);
+  assert.equal(card.category, 'Marketing');
+});
+
+test('categoryOfLinearIssue: parses the trailing segment of the [notion:...] meta line', () => {
+  assert.equal(
+    categoryOfLinearIssue('[notion:abc-123] P0 Now · In progress · Marketing'),
+    'Marketing'
+  );
+  assert.equal(
+    categoryOfLinearIssue('[notion:abc-123] P2 Later · Backlog · Product'),
+    'Product'
+  );
+});
+
+test('categoryOfLinearIssue: returns null when there is no [notion:...] meta line at all', () => {
+  assert.equal(categoryOfLinearIssue('## Problem\nNative Linear card, no Notion import.'), null);
+  assert.equal(categoryOfLinearIssue(''), null);
+  assert.equal(categoryOfLinearIssue(undefined), null);
+});
+
+// linear-import-rules.js's extractNotionId scans the whole description, not
+// just line 1, because zombie-sweep re-opens and other prefixes push the
+// marker down — categoryOfLinearIssue must do the same or a re-opened
+// Marketing card silently loses its category again.
+test('categoryOfLinearIssue: finds the meta line even when it is not line 1', () => {
+  const description = [
+    '[zombie-sweep re-opened 2026-08-10]',
+    'Follow-up needed.',
+    '[notion:abc-123] P1 Now · Not started · Marketing',
+    'Original body text.',
+  ].join('\n');
+  assert.equal(categoryOfLinearIssue(description), 'Marketing');
+});
+
+// End-to-end reproduction of the live incident: a Marketing card imported
+// from Notion into Linear, run through normalizeLinearIssue then
+// enrichOneCard, must land on owner-judgment and must NEVER be armed with a
+// runnable acceptance command.
+test('BRO-2245: a Linear issue whose imported description marks it Marketing is owner-judgment, never armed', async () => {
+  let llmCalled = false;
+  const writeCalls = [];
+  const issue = {
+    id: 'uuid-mkt-2',
+    identifier: 'BRO-9002',
+    title: 'Forbes feature pitch: Marc Hershberg (Commercial Scorecard)',
+    description: '[notion:3b2637c5-abcd-1234-9999-000000000001] P1 Next · Not started · Marketing\nDraft a pitch email.',
+  };
+  const card = normalizeLinearIssue(issue);
+  assert.equal(card.category, 'Marketing');
+
+  const r = await enrichOneCard(card, {
+    callLLM: async () => { llmCalled = true; return '{}'; },
+    writeCard: async (c, newNotes) => { writeCalls.push({ id: c.id, newNotes }); },
+    logPath: SCRATCH_LOG_PATH,
+  });
+
+  assert.equal(r.action, 'owner-judgment');
+  assert.equal(llmCalled, false, 'the LLM must never be called for an owner-judgment card');
+  assert.equal(writeCalls.length, 1);
+  assert.match(writeCalls[0].newNotes, /VERIFY: owner-judgment/);
+  // The whole point: no runnable safe-form command anywhere in the write.
+  assert.doesNotMatch(writeCalls[0].newNotes, /## Acceptance criteria/);
 });
 
 test('makeLinearWriteCard: updates the description then ensures the auto-enriched label via findOrCreateLabel + addLabelToIssue', async () => {


### PR DESCRIPTION
## Summary
- `normalizeLinearIssue()` in `scripts/enrich-card-acceptance.js` hardcoded `category: null`, so the owner-judgment gate (`isCardEligible`) could never fire on the Linear leg — every Linear issue reached the classifier blind.
- Two Marketing cards ("Reddit post: Les Mis Arena Concert" and "Forbes pitch to Marc Hershberg") were consequently armed with runnable acceptance commands and dispatched to autonomous coding workers before being caught and killed manually.
- Fix: recover `category` from the `[notion:<id>] <priority> · <status> · <category>` meta line `notion-tasks-sync.js` writes into the Notion card description, which `linear-import.js` carries verbatim into the imported Linear issue description. Native (non-imported) Linear issues still get `category: null` — same fail-closed posture a "no-category" Notion card already gets.
- No title-keyword matching added (per issue instructions) — this reuses the existing upstream category data.

## Test plan
- [x] `node --test scripts/enrich-card-acceptance.test.mjs` — 54/54 pass, including new coverage: `categoryOfLinearIssue` unit tests, `normalizeLinearIssue` category-recovery test, and an end-to-end reproduction of the incident (Marketing-tagged Linear issue → `enrichOneCard` → `owner-judgment`, never armed with a command).
- [x] `npx tsc --noEmit` clean
- [x] `npx next lint` — no new warnings
- [x] Manual edge-case check: marker mid-description (zombie-sweep style), no marker, no whitespace after `]` — all resolve correctly.

Linear: https://linear.app/broadway-scorecard/issue/BRO-2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)